### PR TITLE
Add and document bounty system

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,19 @@
+# This file is maintained in https://github.com/WeblateOrg/meta/
+name: Comment to label
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  issueLabeled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bounty explanation
+        uses: peter-evans/create-or-update-comment@v1
+        if: github.event.label.name == '💰bounty'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            There is a bounty on this issue, the amount is in the title. The bounty will be awarded to the first person(s) who resolves this issue. Read the full conditions in the ['bounties.md' file](https://github.com/erciccione/haveno/blob/master/docs/bounties.md). If you are starting to work on this issue, please write a comment here, so that we can assign the issue to you and avoid duplicated work.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ These are the main priorities for the near future:
 - The User Interface is basically still Bisq. Needs to be completely reworked and adapted for Monero as base currency. The new design is discussed and developed in [haveno-design](https://github.com/haveno-dex/haveno-design)
 - Cleanup the repository from Bisq-specific content (https://github.com/haveno-dex/haveno/projects/1)
 
+### Bounties
+
+To incentivize development we adopt a simple bounty system. Contributors may be awarded bounties after completing a task (resolving an issue). [More details in the docs](https://github.com/erciccione/haveno/blob/master/docs/bounties.md).
+
 ## Keep in touch and help out!
 
 Haveno is a community-driven project. For it to be succesful it's fundamental to have the support and help of the Monero community. We have our own Matrix server. Registrations are not open at the moment, but the rooms are public and can be joined from any matrix client (like Element). We look forward to hearing from you!

--- a/docs/bounties.md
+++ b/docs/bounties.md
@@ -1,0 +1,14 @@
+## Bounties
+
+We use bounties to incentivize development. To receive a bounty, you agree to these conditions:
+
+- Bounties will be set and awarded at discretion of the Haveno core team.
+- The issues eligible for a bounty are labelled '💰bounty' and have the amount of the bounty specified in the title in this form: `[$200]` if in dollars or `[ɱ20]` if in Monero.
+- The first person who resolves an issue in its entirety will receive the entire amount of the bounty.
+- If the issue is resolved collaboratively by more than one person, the reward will be distributed among the contributors at discretion of the Haveno core team.
+- Let the Maintainers know if you intend to work on a bounty, so that the issue can be assigned to you. Being assigned to an issue doesn't make that issue resolvable only by the assignee. It's meant to avoid duplication of efforts and not to discourage collective works.
+- After the issue is resolved, contact the maintainers and claim your bounty (remember to provide them with a Monero address).
+- If a big number of bounties is claimed at the same time, the maintainers might opt for sending all the rewards on a specific day of the month instead of right after resolution.
+- If the bounty is in dollars, the contributor will receive the amount in Monero according to the value of XMR at the moment the issue was practically resolved, so in the moment the maintainers accept the last patch resolving the issue.
+
+We want to keep the system simple and flexible, but we will add new rules or edit existing ones if necessary.


### PR DESCRIPTION
- Add mention in the README
- add new workflow label.yml, which uses github actions to post the
rules of the bounty as a comment in an issue labelled 'bounty'
- add docs/bounties.md where the bounty system is documented

Resolves https://github.com/haveno-dex/haveno-meta/issues/5