### PR TITLE
increase trade limits

### DIFF
--- a/core/src/main/java/bisq/core/offer/OfferRestrictions.java
+++ b/core/src/main/java/bisq/core/offer/OfferRestrictions.java
@@ -36,7 +36,7 @@ public class OfferRestrictions {
         return new Date().after(REQUIRE_UPDATE_DATE);
     }
 
-    public static Coin TOLERATED_SMALL_TRADE_AMOUNT = Coin.parseCoin("0.01");
+    public static Coin TOLERATED_SMALL_TRADE_AMOUNT = Coin.parseCoin("0.1");
 
     static boolean hasOfferMandatoryCapability(Offer offer, Capability mandatoryCapability) {
         Map<String, String> extraDataMap = offer.getOfferPayload().getExtraDataMap();

--- a/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/bisq/core/payment/payload/PaymentMethod.java
@@ -60,10 +60,10 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     // risk factor so the relation between the risk categories stays the same as with the default values.
     // We must not change those values as it could lead to invalid offers if amount becomes lower then new trade limit.
     // Increasing might be ok, but needs more thought as well...
-    private static final Coin DEFAULT_TRADE_LIMIT_VERY_LOW_RISK = Coin.parseCoin("1");
-    private static final Coin DEFAULT_TRADE_LIMIT_LOW_RISK = Coin.parseCoin("0.5");
-    private static final Coin DEFAULT_TRADE_LIMIT_MID_RISK = Coin.parseCoin("0.25");
-    private static final Coin DEFAULT_TRADE_LIMIT_HIGH_RISK = Coin.parseCoin("0.125");
+    private static final Coin DEFAULT_TRADE_LIMIT_VERY_LOW_RISK = Coin.parseCoin("10");
+    private static final Coin DEFAULT_TRADE_LIMIT_LOW_RISK = Coin.parseCoin("5");
+    private static final Coin DEFAULT_TRADE_LIMIT_MID_RISK = Coin.parseCoin("2.5");
+    private static final Coin DEFAULT_TRADE_LIMIT_HIGH_RISK = Coin.parseCoin("1.25");
 
     public static final String UPHOLD_ID = "UPHOLD";
     public static final String MONEY_BEAM_ID = "MONEY_BEAM";


### PR DESCRIPTION
This increases the trade limits 10x. We can change it to any other number or change it again later.

TOLERATED_SMALL_TRADE_AMOUNT is the limit before account signing.
DEFAULT_TRADE_LIMIT_*_RISK are used for different payment methods. First 30 and 60 days after signing they are lower (divided by a coefficient) 

Closes #62