### PR TITLE
backup monero wallet

### DIFF
--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -348,7 +348,7 @@ public class WalletConfig extends AbstractIdleService {
 
             // XMR wallet
             String xmrPrefix = "_XMR";
-            vXmrWalletFile = new File(directory, filePrefix + xmrPrefix); // TODO: *.wallet?
+            vXmrWalletFile = new File(directory, filePrefix + xmrPrefix);
             if (MoneroUtils.walletExists(vXmrWalletFile.getPath())) {
               vXmrWallet = openWallet(new MoneroWalletConfig().setPath(filePrefix + xmrPrefix).setPassword("abctesting123"));
             } else {

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -131,7 +131,7 @@ public class WalletsSetup {
     private final Config config;
     private final LocalBitcoinNode localBitcoinNode;
     private final BtcNodes btcNodes;
-    private final String btcWalletFileName;
+    private final String xmrWalletFileName;
     private final int numConnectionsForBtc;
     private final String userAgent;
     private final NetworkParameters params;
@@ -179,7 +179,7 @@ public class WalletsSetup {
         this.socks5DiscoverMode = evaluateMode(socks5DiscoverModeString);
         this.walletDir = walletDir;
 
-        btcWalletFileName = "bisq_" + config.baseCurrencyNetwork.getCurrencyCode() + ".wallet";
+        xmrWalletFileName = "bisq_" + config.baseCurrencyNetwork.getCurrencyCode();
         params = Config.baseCurrencyNetworkParameters();
         PeerGroup.setIgnoreHttpSeeds(true);
     }
@@ -424,7 +424,9 @@ public class WalletsSetup {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void backupWallets() {
-        FileUtil.rollingBackup(walletDir, btcWalletFileName, 20);
+        FileUtil.rollingBackup(walletDir, xmrWalletFileName, 20);
+        FileUtil.rollingBackup(walletDir, xmrWalletFileName + ".keys", 20);
+        FileUtil.rollingBackup(walletDir, xmrWalletFileName + ".address.txt", 20);
         FileUtil.rollingBackup(walletDir, BSQ_WALLET_FILE_NAME, 20);
     }
 


### PR DESCRIPTION
Fixes #68

This will create backup files in:
- /home/premek/.local/share/haveno-XMR_STAGENET_Alice/xmr_stagenet/wallet/backup/backups_bisq_XMR/1622414693446_bisq_XMR
- /home/premek/.local/share/haveno-XMR_STAGENET_Alice/xmr_stagenet/wallet/backup/backups_bisq_XMR_address_txt/1622414693460_bisq_XMR.address.txt
- /home/premek/.local/share/haveno-XMR_STAGENET_Alice/xmr_stagenet/wallet/backup/backups_bisq_XMR_keys/1622414693459_bisq_XMR.keys

Are all three files supposed to be backed up?