### PR TITLE
use monero instead of bitcoin in Take/Place offer to Buy/Sell monero

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -467,7 +467,7 @@ createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
 createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
-createOffer.placeOfferButton=Review: Place offer to {0} bitcoin
+createOffer.placeOfferButton=Review: Place offer to {0} monero
 createOffer.createOfferFundWalletInfo.headline=Fund your offer
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Trade amount: {0} \n
@@ -533,7 +533,7 @@ takeOffer.success.info=You can see the status of your trade at \"Portfolio/Open 
 takeOffer.error.message=An error occurred when taking the offer.\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Review: Take offer to {0} bitcoin
+takeOffer.takeOfferButton=Review: Take offer to {0} monero
 takeOffer.noPriceFeedAvailable=You cannot take that offer as it uses a percentage price based on the market price but there is no price feed available.
 takeOffer.takeOfferFundWalletInfo.headline=Fund your trade
 # suppress inspection "TrailingSpacesInProperty"
@@ -2674,8 +2674,8 @@ offerDetailsWindow.countryBank=Maker's country of bank
 offerDetailsWindow.commitment=Commitment
 offerDetailsWindow.agree=I agree
 offerDetailsWindow.tac=Terms and conditions
-offerDetailsWindow.confirm.maker=Confirm: Place offer to {0} bitcoin
-offerDetailsWindow.confirm.taker=Confirm: Take offer to {0} bitcoin
+offerDetailsWindow.confirm.maker=Confirm: Place offer to {0} monero
+offerDetailsWindow.confirm.taker=Confirm: Take offer to {0} monero
 offerDetailsWindow.creationDate=Creation date
 offerDetailsWindow.makersOnion=Maker's onion address
 

--- a/core/src/main/resources/i18n/displayStrings_cs.properties
+++ b/core/src/main/resources/i18n/displayStrings_cs.properties
@@ -454,7 +454,7 @@ createOffer.triggerPrice.invalid.tooLow=Hodnota musí být vyšší než {0}
 createOffer.triggerPrice.invalid.tooHigh=Hodnota musí být nižší než {0}
 
 # new entries
-createOffer.placeOfferButton=Přehled: Umístěte nabídku {0} bitcoin
+createOffer.placeOfferButton=Přehled: Umístěte nabídku {0} monero
 createOffer.createOfferFundWalletInfo.headline=Financujte svou nabídku
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Výše obchodu: {0}\n
@@ -509,7 +509,7 @@ takeOffer.success.info=Stav vašeho obchodu můžete vidět v \"Portfolio/Otevř
 takeOffer.error.message=Při převzetí nabídky došlo k chybě.\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Přehled: Využijte nabídku {0} bitcoin
+takeOffer.takeOfferButton=Přehled: Využijte nabídku {0} monero
 takeOffer.noPriceFeedAvailable=Tuto nabídku nemůžete vzít, protože používá procentuální cenu založenou na tržní ceně, ale není k dispozici žádný zdroj cen.
 takeOffer.takeOfferFundWalletInfo.headline=Financujte svůj obchod
 # suppress inspection "TrailingSpacesInProperty"
@@ -2168,8 +2168,8 @@ offerDetailsWindow.countryBank=Země původu banky tvůrce
 offerDetailsWindow.commitment=Závazek
 offerDetailsWindow.agree=Souhlasím
 offerDetailsWindow.tac=Pravidla a podmínky
-offerDetailsWindow.confirm.maker=Potvrďte: Umístit nabídku {0} bitcoin
-offerDetailsWindow.confirm.taker=Potvrďte: Využít nabídku {0} bitcoin
+offerDetailsWindow.confirm.maker=Potvrďte: Umístit nabídku {0} monero
+offerDetailsWindow.confirm.taker=Potvrďte: Využít nabídku {0} monero
 offerDetailsWindow.creationDate=Datum vzniku
 offerDetailsWindow.makersOnion=Onion adresa tvůrce
 

--- a/core/src/main/resources/i18n/displayStrings_de.properties
+++ b/core/src/main/resources/i18n/displayStrings_de.properties
@@ -454,7 +454,7 @@ createOffer.triggerPrice.invalid.tooLow=Wert muss höher sein als {0}
 createOffer.triggerPrice.invalid.tooHigh=Wert muss niedriger sein als {0}
 
 # new entries
-createOffer.placeOfferButton=Überprüfung: Anbieten Bitcoins zu {0}
+createOffer.placeOfferButton=Überprüfung: Anbieten moneros zu {0}
 createOffer.createOfferFundWalletInfo.headline=Ihr Angebot finanzieren
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Handelsbetrag: {0} \n
@@ -509,7 +509,7 @@ takeOffer.success.info=Sie können den Status Ihres Trades unter \"Portfolio/Off
 takeOffer.error.message=Bei der Angebotsannahme trat ein Fehler auf.\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Überprüfung: Angebot annehmen Bitcoins zu {0}
+takeOffer.takeOfferButton=Überprüfung: Angebot annehmen moneros zu {0}
 takeOffer.noPriceFeedAvailable=Sie können dieses Angebot nicht annehmen, da es auf einem Prozentsatz vom Marktpreis basiert, jedoch keiner verfügbar ist.
 takeOffer.takeOfferFundWalletInfo.headline=Ihren Handel finanzieren
 # suppress inspection "TrailingSpacesInProperty"
@@ -2168,8 +2168,8 @@ offerDetailsWindow.countryBank=Land der Bank des Erstellers
 offerDetailsWindow.commitment=Verpflichtung
 offerDetailsWindow.agree=Ich stimme zu
 offerDetailsWindow.tac=Geschäftsbedingungen
-offerDetailsWindow.confirm.maker=Bestätigen: Anbieten Bitcoin zu {0}
-offerDetailsWindow.confirm.taker=Bestätigen: Angebot annehmen Bitcoin zu {0}
+offerDetailsWindow.confirm.maker=Bestätigen: Anbieten monero zu {0}
+offerDetailsWindow.confirm.taker=Bestätigen: Angebot annehmen monero zu {0}
 offerDetailsWindow.creationDate=Erstellungsdatum
 offerDetailsWindow.makersOnion=Onion-Adresse des Erstellers
 

--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -454,7 +454,7 @@ createOffer.triggerPrice.invalid.tooLow=El valor debe ser superior a {0}
 createOffer.triggerPrice.invalid.tooHigh=El valor debe ser inferior a {0}
 
 # new entries
-createOffer.placeOfferButton=Revisar: Poner oferta para {0} bitcoin
+createOffer.placeOfferButton=Revisar: Poner oferta para {0} monero
 createOffer.createOfferFundWalletInfo.headline=Dote de fondos su trato.
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Cantidad a intercambiar: {0}\n
@@ -509,7 +509,7 @@ takeOffer.success.info=Puede ver el estado de su intercambio en \"Portafolio/Int
 takeOffer.error.message=Un error ocurrió al tomar la oferta.\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Revisión: Tomar oferta a {0} bitcoin
+takeOffer.takeOfferButton=Revisión: Tomar oferta a {0} monero
 takeOffer.noPriceFeedAvailable=No puede tomar esta oferta porque utiliza un precio porcentual basado en el precio de mercado y no hay fuentes de precio disponibles.
 takeOffer.takeOfferFundWalletInfo.headline=Dotar de fondos su intercambio
 # suppress inspection "TrailingSpacesInProperty"
@@ -2168,8 +2168,8 @@ offerDetailsWindow.countryBank=País del banco del creador
 offerDetailsWindow.commitment=Compromiso
 offerDetailsWindow.agree=Estoy de acuerdo
 offerDetailsWindow.tac=Términos y condiciones:
-offerDetailsWindow.confirm.maker=Confirmar: Poner oferta para {0} bitcoin
-offerDetailsWindow.confirm.taker=Confirmar: Tomar oferta {0} bitcoin
+offerDetailsWindow.confirm.maker=Confirmar: Poner oferta para {0} monero
+offerDetailsWindow.confirm.taker=Confirmar: Tomar oferta {0} monero
 offerDetailsWindow.creationDate=Fecha de creación
 offerDetailsWindow.makersOnion=Dirección onion del creador
 

--- a/core/src/main/resources/i18n/displayStrings_fr.properties
+++ b/core/src/main/resources/i18n/displayStrings_fr.properties
@@ -454,7 +454,7 @@ createOffer.triggerPrice.invalid.tooLow=La valeur doit être supérieure à {0}
 createOffer.triggerPrice.invalid.tooHigh=La valuer doit être inférieure à {0]
 
 # new entries
-createOffer.placeOfferButton=Review: Placer un ordre de {0} Bitcoin
+createOffer.placeOfferButton=Review: Placer un ordre de {0} monero
 createOffer.createOfferFundWalletInfo.headline=Financer votre ordre
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=Montant du trade: {0}\n\n
@@ -509,7 +509,7 @@ takeOffer.success.info=Vous pouvez voir vos transactions dans \"Portfolio/Échan
 takeOffer.error.message=Une erreur s''est produite pendant l’'acceptation de l''ordre.\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Vérifier: Accepter l''ordre de {0} Bitcoin
+takeOffer.takeOfferButton=Vérifier: Accepter l''ordre de {0} Monero
 takeOffer.noPriceFeedAvailable=Vous ne pouvez pas accepter cet ordre, car celui-ci utilise un prix en pourcentage basé sur le prix du marché, mais il n'y a pas de prix de référence de disponible.
 takeOffer.takeOfferFundWalletInfo.headline=Provisionner votre trade
 # suppress inspection "TrailingSpacesInProperty"
@@ -2168,8 +2168,8 @@ offerDetailsWindow.countryBank=Pays de la banque du Maker
 offerDetailsWindow.commitment=Engagement
 offerDetailsWindow.agree=J'accepte
 offerDetailsWindow.tac=Conditions d'utilisation
-offerDetailsWindow.confirm.maker=Confirmer: Placer un ordre de {0} Bitcoin
-offerDetailsWindow.confirm.taker=Confirmer: Acceptez l''ordre de {0} Bitcoin
+offerDetailsWindow.confirm.maker=Confirmer: Placer un ordre de {0} monero
+offerDetailsWindow.confirm.taker=Confirmer: Acceptez l''ordre de {0} monero
 offerDetailsWindow.creationDate=Date de création
 offerDetailsWindow.makersOnion=Adresse onion du maker
 

--- a/core/src/main/resources/i18n/displayStrings_it.properties
+++ b/core/src/main/resources/i18n/displayStrings_it.properties
@@ -454,7 +454,7 @@ createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
 createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
-createOffer.placeOfferButton=Revisione: piazza l'offerta a {0} bitcoin
+createOffer.placeOfferButton=Revisione: piazza l'offerta a {0} monero
 createOffer.createOfferFundWalletInfo.headline=Finanzia la tua offerta
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Importo di scambio: {0} \n
@@ -509,7 +509,7 @@ takeOffer.success.info=Puoi vedere lo stato del tuo scambio su \"Portafoglio/Sca
 takeOffer.error.message=Si è verificato un errore durante l'accettazione dell'offerta.\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Rivedi: Accetta l'offerta per {0} bitcoin
+takeOffer.takeOfferButton=Rivedi: Accetta l'offerta per {0} monero
 takeOffer.noPriceFeedAvailable=Non puoi accettare questa offerta poiché utilizza un prezzo in percentuale basato sul prezzo di mercato ma non è disponibile alcun feed di prezzi.
 takeOffer.takeOfferFundWalletInfo.headline=Finanzia il tuo scambio
 # suppress inspection "TrailingSpacesInProperty"
@@ -2168,8 +2168,8 @@ offerDetailsWindow.countryBank=Paese della banca del maker
 offerDetailsWindow.commitment=Impegno
 offerDetailsWindow.agree=Accetto
 offerDetailsWindow.tac=Termini e condizioni
-offerDetailsWindow.confirm.maker=Conferma: Piazza l'offerta a {0} bitcoin
-offerDetailsWindow.confirm.taker=Conferma: Accetta l'offerta a {0} bitcoin
+offerDetailsWindow.confirm.maker=Conferma: Piazza l'offerta a {0} monero
+offerDetailsWindow.confirm.taker=Conferma: Accetta l'offerta a {0} monero
 offerDetailsWindow.creationDate=Data di creazione
 offerDetailsWindow.makersOnion=Indirizzo .onion del maker
 

--- a/core/src/main/resources/i18n/displayStrings_pt-br.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt-br.properties
@@ -454,7 +454,7 @@ createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
 createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
-createOffer.placeOfferButton=Revisar: Criar oferta para {0} bitcoin
+createOffer.placeOfferButton=Revisar: Criar oferta para {0} monero
 createOffer.createOfferFundWalletInfo.headline=Financiar sua oferta
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Quantia da negociação: {0} \n
@@ -509,7 +509,7 @@ takeOffer.success.info=Você pode ver o status de sua negociação em \"Portfoli
 takeOffer.error.message=Ocorreu um erro ao aceitar a oferta.\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Revisar: Aceitar oferta para {0} bitcoin
+takeOffer.takeOfferButton=Revisar: Aceitar oferta para {0} monero
 takeOffer.noPriceFeedAvailable=Você não pode aceitar essa oferta pois ela usa uma porcentagem do preço baseada no preço de mercado, mas o canal de preços está indisponível no momento.
 takeOffer.takeOfferFundWalletInfo.headline=Financiar sua negociação
 # suppress inspection "TrailingSpacesInProperty"
@@ -2168,8 +2168,8 @@ offerDetailsWindow.countryBank=País do banco do ofertante
 offerDetailsWindow.commitment=Compromisso
 offerDetailsWindow.agree=Eu concordo
 offerDetailsWindow.tac=Termos e condições
-offerDetailsWindow.confirm.maker=Criar oferta para {0} bitcoin
-offerDetailsWindow.confirm.taker=Confirmar: Aceitar oferta de {0} bitcoin
+offerDetailsWindow.confirm.maker=Criar oferta para {0} monero
+offerDetailsWindow.confirm.taker=Confirmar: Aceitar oferta de {0} monero
 offerDetailsWindow.creationDate=Criada em
 offerDetailsWindow.makersOnion=Endereço onion do ofertante
 

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -454,7 +454,7 @@ createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
 createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
-createOffer.placeOfferButton=Rever: Colocar oferta para {0} bitcoin
+createOffer.placeOfferButton=Rever: Colocar oferta para {0} monero
 createOffer.createOfferFundWalletInfo.headline=Financiar sua oferta
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Quantia de negócio: {0} \n
@@ -509,7 +509,7 @@ takeOffer.success.info=Você pode ver o estado de seu negócio em \"Portefólio/
 takeOffer.error.message=Ocorreu um erro ao aceitar a oferta .\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Rever: Colocar oferta para {0} bitcoin
+takeOffer.takeOfferButton=Rever: Colocar oferta para {0} monero
 takeOffer.noPriceFeedAvailable=Você não pode aceitar aquela oferta pois ela utiliza uma percentagem do preço baseada no preço de mercado, mas o feed de preços está indisponível no momento.
 takeOffer.takeOfferFundWalletInfo.headline=Financiar seu negócio
 # suppress inspection "TrailingSpacesInProperty"
@@ -2168,8 +2168,8 @@ offerDetailsWindow.countryBank=País do banco do ofertante
 offerDetailsWindow.commitment=Compromisso
 offerDetailsWindow.agree=Eu concordo
 offerDetailsWindow.tac=Termos e condições
-offerDetailsWindow.confirm.maker=Confirmar: Criar oferta para {0} bitcoin
-offerDetailsWindow.confirm.taker=Confirmar: Aceitar oferta de {0} bitcoin
+offerDetailsWindow.confirm.maker=Confirmar: Criar oferta para {0} monero
+offerDetailsWindow.confirm.taker=Confirmar: Aceitar oferta de {0} monero
 offerDetailsWindow.creationDate=Data de criação
 offerDetailsWindow.makersOnion=Endereço onion do ofertante
 

--- a/core/src/main/resources/i18n/displayStrings_th.properties
+++ b/core/src/main/resources/i18n/displayStrings_th.properties
@@ -509,7 +509,7 @@ takeOffer.success.info=คุณสามารถดูสถานะการ
 takeOffer.error.message=เกิดข้อผิดพลาดขณะรับข้อเสนอ\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=รีวิว: รับข้อเสนอจาก {0} bitcoin
+takeOffer.takeOfferButton=รีวิว: รับข้อเสนอจาก {0} monero
 takeOffer.noPriceFeedAvailable=คุณไม่สามารถรับข้อเสนอดังกล่าวเนื่องจากใช้ราคาร้อยละตามราคาตลาด แต่ไม่มีฟีดราคาที่พร้อมใช้งาน
 takeOffer.takeOfferFundWalletInfo.headline=ทุนการซื้อขายของคุณ
 # suppress inspection "TrailingSpacesInProperty"

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -454,7 +454,7 @@ createOffer.triggerPrice.invalid.tooLow=Value must be higher than {0}
 createOffer.triggerPrice.invalid.tooHigh=Value must be lower than {0}
 
 # new entries
-createOffer.placeOfferButton=Kiểm tra:: Đặt báo giá cho {0} bitcoin
+createOffer.placeOfferButton=Kiểm tra:: Đặt báo giá cho {0} monero
 createOffer.createOfferFundWalletInfo.headline=Nộp tiền cho báo giá của bạn
 # suppress inspection "TrailingSpacesInProperty"
 createOffer.createOfferFundWalletInfo.tradeAmount=- Khoản tiền giao dịch: {0} \n
@@ -509,7 +509,7 @@ takeOffer.success.info=Bạn có thể xem trạng thái giao dịch của bạn
 takeOffer.error.message=Có lỗi xảy ra khi nhận báo giá.\n\n{0}
 
 # new entries
-takeOffer.takeOfferButton=Rà soát: Nhận báo giá cho {0} bitcoin
+takeOffer.takeOfferButton=Rà soát: Nhận báo giá cho {0} monero
 takeOffer.noPriceFeedAvailable=Bạn không thể nhận báo giá này do sử dụng giá phần trăm dựa trên giá thị trường nhưng không có giá cung cấp.
 takeOffer.takeOfferFundWalletInfo.headline=Nộp tiền cho giao dịch của bạn
 # suppress inspection "TrailingSpacesInProperty"
@@ -2168,8 +2168,8 @@ offerDetailsWindow.countryBank=Quốc gia ngân hàng của người tạo
 offerDetailsWindow.commitment=Cam kết
 offerDetailsWindow.agree=Tôi đồng ý
 offerDetailsWindow.tac=Điều khoản và điều kiện
-offerDetailsWindow.confirm.maker=Xác nhận: Đặt chào giá cho {0} bitcoin
-offerDetailsWindow.confirm.taker=Xác nhận: Nhận chào giáo cho {0} bitcoin
+offerDetailsWindow.confirm.maker=Xác nhận: Đặt chào giá cho {0} monero
+offerDetailsWindow.confirm.taker=Xác nhận: Nhận chào giáo cho {0} monero
 offerDetailsWindow.creationDate=Ngày tạo
 offerDetailsWindow.makersOnion=Địa chỉ onion của người tạo
 


### PR DESCRIPTION
This changes the text for the "Take/Place offer to Buy/Sell monero" when creating / taking an offer.
![](https://docs.bisq.network/images/confirm-deal.png)

I replaced the text in the languages that are using latin, in the others I don't know how to.
Not sure how to proceed with translations in future when it's not this easy. Edit english only and mark the translations that it needs to be updated? how?

