### PR TITLE
add monerod to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ deploy
 .localnet
 /apitest/src/main/resources/dao-setup*
 /monero-wallet-rpc
+/monerod


### PR DESCRIPTION
current install instructions are to unpack the prebuilt monerod in root of the project