### PR TITLE
Updated checksum of jtorctl

### DIFF
--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -21,7 +21,7 @@ dependencyVerification {
         'com.fasterxml.jackson.core:jackson-annotations:203cefdfa6c81e6aa84e11f292f29ca97344a3c3bc0293abea065cd837592873',
         'com.fasterxml.jackson.core:jackson-core:cc899cb6eae0c80b87d590eea86528797369cc4feb7b79463207d6bb18f0c257',
         'com.fasterxml.jackson.core:jackson-databind:f2ca3c28ebded59c98447d51afe945323df961540af66a063c015597af936aa0',
-        'com.github.JesusMcCloud:jtorctl:389d61b1b5a85eb2f23c582c3913ede49f80c9f2b553e4762382c836270e57e5',
+        'com.github.JesusMcCloud:jtorctl:6465e0b22b921344a065a6e82a5390ab2f9dac5ab293c38bd8a76baddead6492',
         'com.github.bisq-network.netlayer:tor.external:e1d6b8fe73891207701c6b14317be789fd4acd25f7b499425d2471598d9a22ac',
         'com.github.bisq-network.netlayer:tor.native:aa3edf9c27071fdc2b7d55b00dbc7c6cd5dc9aa9f87aafa4be0805f818a466be',
         'com.github.bisq-network.netlayer:tor:37198bc56e8fe112f8c80441544a2b9731929dae586bda841a4a926fdc04f457',


### PR DESCRIPTION
`make` command fails when following https://github.com/haveno-dex/haveno/blob/master/docs/installing.md on osx:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':desktop'.
> Checksum failed for com.github.JesusMcCloud:jtorctl:389d61b1b5a85eb2f23c582c3913ede49f80c9f2b553e4762382c836270e57e5
```

Apparently the checksum of `jtorctl` is outdated, when updating this, the`make` command runs as expected.