### PR TITLE
CI: cache dependencies in makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,43 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: gradle
+      - name: Pull lfs
+        run: git lfs pull
+      - name: Build with make
+        run: make
+      - name: cache nodes dependencies
+        uses: actions/upload-artifact@v2
+        with:
+          name: cached-localnet
+          path: .localnet
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: gradlew-report
+          path: 'desktop/build/reports/tests/test/index.html'
+          retention-days: 30
+
+  build-windows:
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -27,9 +61,3 @@ jobs:
         run: git lfs pull
       - name: Build with Gradle
         run: ./gradlew build --stacktrace --scan
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: gradlew-report
-          path: 'desktop/build/reports/tests/test/index.html'
-          retention-days: 30


### PR DESCRIPTION
closes #124

cache both gradle and haveno-specific dependencies when running CI.
windows binaries are built using ./gradlew build directly, since
windows users have to download binaries manually regardless.

Note that the btc arhive is still being downloaded when it's supposed to be cached in .localnet. Github says correctly that there are 6 files cached, but when running make, CI still downloads the btc binaries. This doesn't happen locally and shouldn't happen in CI as well, but i haven't found a reason why the archive is downloaded regardless. Any ideas?