### PR TITLE
add config option to specify wallet rpc bind port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ alice-desktop:
 		--nodePort=5555 \
 		--appName=haveno-XMR_STAGENET_Alice \
 		--apiPassword=apitest \
-		--apiPort=9999
+		--apiPort=9999 \
+		--walletRpcBindPort=38091
 
 alice-daemon:
 	./haveno-daemon \
@@ -72,7 +73,8 @@ alice-daemon:
 		--nodePort=5555 \
 		--appName=haveno-XMR_STAGENET_Alice \
 		--apiPassword=apitest \
-		--apiPort=9999
+		--apiPort=9999 \
+		--walletRpcBindPort=38091
 
 bob-desktop:
 	./haveno-desktop \
@@ -82,7 +84,8 @@ bob-desktop:
 		--nodePort=6666 \
 		--appName=haveno-XMR_STAGENET_Bob \
 		--apiPassword=apitest \
-		--apiPort=10000
+		--apiPort=10000 \
+		--walletRpcBindPort=38092
 
 bob-daemon:
 	./haveno-daemon \
@@ -92,7 +95,8 @@ bob-daemon:
 		--nodePort=6666 \
 		--appName=haveno-XMR_STAGENET_Bob \
 		--apiPassword=apitest \
-		--apiPort=10000
+		--apiPort=10000 \
+		--walletRpcBindPort=38092
 
 monero-shared:
 	./.localnet/monerod \

--- a/common/src/main/java/bisq/common/config/Config.java
+++ b/common/src/main/java/bisq/common/config/Config.java
@@ -73,6 +73,7 @@ public class Config {
     public static final String STORAGE_DIR = "storageDir";
     public static final String KEY_STORAGE_DIR = "keyStorageDir";
     public static final String WALLET_DIR = "walletDir";
+    public static final String WALLET_RPC_BIND_PORT = "walletRpcBindPort";
     public static final String USE_DEV_PRIVILEGE_KEYS = "useDevPrivilegeKeys";
     public static final String DUMP_STATISTICS = "dumpStatistics";
     public static final String IGNORE_DEV_MSG = "ignoreDevMsg";
@@ -140,6 +141,7 @@ public class Config {
     public final String appName;
     public final File userDataDir;
     public final File appDataDir;
+    public final int walletRpcBindPort;
     public final int nodePort;
     public final int maxMemory;
     public final String logLevel;
@@ -271,6 +273,12 @@ public class Config {
                         .withRequiredArg()
                         .ofType(Integer.class)
                         .defaultsTo(9999);
+
+        ArgumentAcceptingOptionSpec<Integer> walletRpcBindPortOpt =
+                parser.accepts(WALLET_RPC_BIND_PORT, "Port to bind the wallet RPC on")
+                        .withRequiredArg()
+                        .ofType(int.class)
+                        .defaultsTo(UNSPECIFIED_PORT);
 
         ArgumentAcceptingOptionSpec<Integer> maxMemoryOpt =
                 parser.accepts(MAX_MEMORY, "Max. permitted memory (used only by headless versions)")
@@ -628,6 +636,7 @@ public class Config {
             this.helpRequested = options.has(helpOpt);
             this.configFile = configFile;
             this.nodePort = options.valueOf(nodePortOpt);
+            this.walletRpcBindPort = options.valueOf(walletRpcBindPortOpt);
             this.maxMemory = options.valueOf(maxMemoryOpt);
             this.logLevel = options.valueOf(logLevelOpt);
             this.bannedBtcNodes = options.valuesOf(bannedBtcNodesOpt);

--- a/core/src/main/java/bisq/core/btc/BitcoinModule.java
+++ b/core/src/main/java/bisq/core/btc/BitcoinModule.java
@@ -44,6 +44,7 @@ import java.util.List;
 
 import static bisq.common.config.Config.PROVIDERS;
 import static bisq.common.config.Config.WALLET_DIR;
+import static bisq.common.config.Config.WALLET_RPC_BIND_PORT;
 import static com.google.inject.name.Names.named;
 
 public class BitcoinModule extends AppModule {
@@ -71,6 +72,7 @@ public class BitcoinModule extends AppModule {
         }
 
         bind(File.class).annotatedWith(named(WALLET_DIR)).toInstance(config.walletDir);
+        bind(int.class).annotatedWith(named(WALLET_RPC_BIND_PORT)).toInstance(config.walletRpcBindPort);
 
         bindConstant().annotatedWith(named(Config.BTC_NODES)).to(config.btcNodes);
         bindConstant().annotatedWith(named(Config.USER_AGENT)).to(config.userAgent);

--- a/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletsSetup.java
@@ -50,9 +50,6 @@ import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.core.RejectMessage;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
-import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.params.RegTestParams;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.DeterministicSeed;
 import org.bitcoinj.wallet.Wallet;
@@ -135,6 +132,7 @@ public class WalletsSetup {
     private final String userAgent;
     private final NetworkParameters params;
     private final File walletDir;
+    private final int walletRpcBindPort;
     private final int socks5DiscoverMode;
     private final IntegerProperty numPeers = new SimpleIntegerProperty(0);
     private final IntegerProperty chainHeight = new SimpleIntegerProperty(0);
@@ -161,6 +159,7 @@ public class WalletsSetup {
                         BtcNodes btcNodes,
                         @Named(Config.USER_AGENT) String userAgent,
                         @Named(Config.WALLET_DIR) File walletDir,
+                        @Named(Config.WALLET_RPC_BIND_PORT) int walletRpcBindPort,
                         @Named(Config.USE_ALL_PROVIDED_NODES) boolean useAllProvidedNodes,
                         @Named(Config.NUM_CONNECTIONS_FOR_BTC) int numConnectionsForBtc,
                         @Named(Config.SOCKS5_DISCOVER_MODE) String socks5DiscoverModeString) {
@@ -177,6 +176,7 @@ public class WalletsSetup {
         this.userAgent = userAgent;
         this.socks5DiscoverMode = evaluateMode(socks5DiscoverModeString);
         this.walletDir = walletDir;
+        this.walletRpcBindPort = walletRpcBindPort;
 
         xmrWalletFileName = "haveno_" + config.baseCurrencyNetwork.getCurrencyCode();
         params = Config.baseCurrencyNetworkParameters();
@@ -207,9 +207,7 @@ public class WalletsSetup {
         final Socks5Proxy socks5Proxy = preferences.getUseTorForBitcoinJ() ? socks5ProxyProvider.getSocks5Proxy() : null;
         log.info("Socks5Proxy for bitcoinj: socks5Proxy=" + socks5Proxy);
 
-        walletConfig = new WalletConfig(params,
-                walletDir,
-                "haveno") {
+        walletConfig = new WalletConfig(params, walletDir, walletRpcBindPort, "haveno") {
             @Override
             protected void onSetupCompleted() {
                 //We are here in the btcj thread Thread[ STARTING,5,main]

--- a/core/src/main/java/bisq/core/btc/wallet/XmrWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/XmrWalletService.java
@@ -92,7 +92,8 @@ public class XmrWalletService {
       MoneroWallet multisigWallet = null;
       multisigWallet = walletsSetup.getWalletConfig().createWallet(new MoneroWalletConfig()
               .setPath(path)
-              .setPassword("abctesting123"));
+              .setPassword("abctesting123"),
+              null); // auto-assign port
       multisigWallets.put(tradeId, multisigWallet);
       multisigWallet.startSyncing(5000l);
       return multisigWallet;
@@ -104,7 +105,8 @@ public class XmrWalletService {
       MoneroWallet multisigWallet = null;
       multisigWallet = walletsSetup.getWalletConfig().openWallet(new MoneroWalletConfig()
               .setPath(path)
-              .setPassword("abctesting123"));
+              .setPassword("abctesting123"),
+              null);
       multisigWallets.put(tradeId, multisigWallet);
       multisigWallet.startSyncing(5000l); // TODO (woodser): use sync period from config. apps stall if too many multisig wallets and too short sync period
       return multisigWallet;


### PR DESCRIPTION
This adds a new optional `--walletRpcBindPort` option to specify on which port to bind the RPC wallet.
When the option is not used, the behavior is the same as before (random port used)

Some fixed ports added to Makefile for alice and bob to be used in haveno-ui-poc tests

The goal is to simplify running the ui tests 