### PR TITLE
allow getMarketPrice for crypto currencies

### DIFF
--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -19,6 +19,7 @@ package bisq.core.api;
 
 import bisq.core.api.model.AddressBalanceInfo;
 import bisq.core.api.model.BalancesInfo;
+import bisq.core.api.model.MarketPrice;
 import bisq.core.api.model.TxFeeRateInfo;
 import bisq.core.monetary.Price;
 import bisq.core.offer.Offer;
@@ -46,6 +47,8 @@ import com.google.common.util.concurrent.FutureCallback;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import lombok.Getter;
@@ -225,8 +228,12 @@ public class CoreApi {
     // Prices
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public void getMarketPrice(String currencyCode, Consumer<Double> resultHandler) {
-        corePriceService.getMarketPrice(currencyCode, resultHandler);
+    public double getMarketPrice(String currencyCode) throws ExecutionException, InterruptedException, TimeoutException {
+        return corePriceService.getMarketPrice(currencyCode);
+    }
+
+    public List<MarketPrice> getMarketPrices() throws ExecutionException, InterruptedException, TimeoutException {
+        return corePriceService.getMarketPrices();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -275,7 +282,7 @@ public class CoreApi {
     public BalancesInfo getBalances(String currencyCode) {
         return walletsService.getBalances(currencyCode);
     }
-    
+
     public String getNewDepositSubaddress() {
         return walletsService.getNewDepositSubaddress();
     }

--- a/core/src/main/java/bisq/core/api/model/MarketPrice.java
+++ b/core/src/main/java/bisq/core/api/model/MarketPrice.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.api.model;
+
+import bisq.common.Payload;
+
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+public class MarketPrice implements Payload {
+
+    private final String currencyCode;
+    private final double price;
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.MarketPrice toProtoMessage() {
+        return bisq.proto.grpc.MarketPrice.newBuilder()
+                .setPrice(price)
+                .setCurrencyCode(currencyCode)
+                .build();
+    }
+
+    public static MarketPrice fromProto(bisq.proto.grpc.MarketPrice proto) {
+        return new MarketPrice(proto.getCurrencyCode(),
+                proto.getPrice());
+    }
+}

--- a/core/src/main/java/bisq/core/provider/price/PriceFeedService.java
+++ b/core/src/main/java/bisq/core/provider/price/PriceFeedService.java
@@ -56,6 +56,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import lombok.extern.slf4j.Slf4j;
@@ -322,6 +326,19 @@ public class PriceFeedService {
                     setBisqMarketPrice(tradeStatistics.getCurrency(), tradeStatistics.getTradePrice());
                 });
     }
+
+    /**
+     * Returns prices for all available currencies.
+     * For crypto currencies the value is XMR price for 1 unit of given crypto currency (e.g. 1 DOGE = X XMR).
+     * For fiat currencies the value is price in the given fiiat currency per 1 XMR (e.g.  1 XMR = X USD).
+     * Does not update PriceFeedService internal state (cache, epochInMillisAtLastRequest)
+     */
+    public Map<String, MarketPrice> requestAllPrices() throws ExecutionException, InterruptedException, TimeoutException, CancellationException {
+        return new PriceRequest().requestAllPrices(priceProvider)
+                .get(20, TimeUnit.SECONDS)
+                .second;
+    }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -238,6 +238,8 @@ message GetCryptoCurrencyPaymentMethodsReply {
 service Price {
     rpc GetMarketPrice (MarketPriceRequest) returns (MarketPriceReply) {
     }
+    rpc GetMarketPrices (MarketPricesRequest) returns (MarketPricesReply) {
+    }
 }
 
 message MarketPriceRequest {
@@ -246,6 +248,18 @@ message MarketPriceRequest {
 
 message MarketPriceReply {
     double price = 1;
+}
+
+message MarketPricesRequest {
+}
+
+message MarketPricesReply {
+    repeated MarketPrice market_price = 1;
+}
+
+message MarketPrice {
+    string currency_code = 1;
+    double price = 2;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -371,7 +385,7 @@ message TradeInfo {
     bool is_withdrawn = 23;
     string contract_as_json = 24;
     ContractInfo contract = 25;
-    
+
     string maker_deposit_tx_id = 100;
     string taker_deposit_tx_id = 101;
 }
@@ -389,7 +403,7 @@ message ContractInfo {
     string maker_payout_address_string = 10;
     string taker_payout_address_string = 11;
     uint64 lock_time = 12;
-    
+
     string arbitrator_node_address = 100;
 }
 


### PR DESCRIPTION
this makes the 'Can get market prices' API test pass

The api works for crypto currencies too but the price is inverted, e.g. for BTC it returns 250 (1 BTC = 250 XMR), for USD it returns 242 (1 XMR = 242 USD), maybe we should fix that?