### PR TITLE
improve error handling in protocol pipelines

### DIFF
--- a/cli/src/main/java/bisq/cli/GrpcClient.java
+++ b/cli/src/main/java/bisq/cli/GrpcClient.java
@@ -39,6 +39,7 @@ import bisq.proto.grpc.GetPaymentAccountFormRequest;
 import bisq.proto.grpc.GetPaymentAccountsRequest;
 import bisq.proto.grpc.GetPaymentMethodsRequest;
 import bisq.proto.grpc.GetTradeRequest;
+import bisq.proto.grpc.GetTradesRequest;
 import bisq.proto.grpc.GetTransactionRequest;
 import bisq.proto.grpc.GetTxFeeRateRequest;
 import bisq.proto.grpc.GetVersionRequest;
@@ -347,6 +348,11 @@ public final class GrpcClient {
                 .setTradeId(tradeId)
                 .build();
         return grpcStubs.tradesService.getTrade(request).getTrade();
+    }
+
+    public List<TradeInfo> getTrades() {
+        var request = GetTradesRequest.newBuilder().build();
+        return grpcStubs.tradesService.getTrades(request).getTradesList();
     }
 
     public void confirmPaymentStarted(String tradeId) {

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -244,11 +244,15 @@ public class CoreApi {
                           String paymentAccountId,
                           Consumer<Trade> resultHandler,
                           ErrorMessageHandler errorMessageHandler) {
-        Offer offer = coreOffersService.getOffer(offerId);
-        coreTradesService.takeOffer(offer,
-                paymentAccountId,
-                resultHandler,
-                errorMessageHandler);
+        try {
+            Offer offer = coreOffersService.getOffer(offerId);
+            coreTradesService.takeOffer(offer,
+                    paymentAccountId,
+                    resultHandler,
+                    errorMessageHandler);
+        } catch (Exception e) {
+            errorMessageHandler.handleErrorMessage(e.getMessage());
+        }
     }
 
     public void confirmPaymentStarted(String tradeId) {
@@ -269,6 +273,10 @@ public class CoreApi {
 
     public Trade getTrade(String tradeId) {
         return coreTradesService.getTrade(tradeId);
+    }
+
+    public List<Trade> getTrades() {
+        return coreTradesService.getTrades();
     }
 
     public String getTradeRole(String tradeId) {

--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -142,20 +143,31 @@ class CoreOffersService {
     }
 
     List<Offer> getMyOffers(String direction, String currencyCode) {
+
+        // get my offers posted to books
         List<Offer> offers = offerBookService.getOffers().stream()
                 .filter(o -> o.isMyOffer(keyRing))
                 .filter(o -> offerMatchesDirectionAndCurrency(o, direction, currencyCode))
                 .sorted(priceComparator(direction))
                 .collect(Collectors.toList());
+
+        // remove unreserved offers
         Set<Offer> unreservedOffers = getUnreservedOffers(offers);
         offers.removeAll(unreservedOffers);
-        
+
         // remove my unreserved offers from offer manager
         List<OpenOffer> unreservedOpenOffers = new ArrayList<OpenOffer>();
         for (Offer unreservedOffer : unreservedOffers) {
           unreservedOpenOffers.add(openOfferManager.getOpenOfferById(unreservedOffer.getId()).get());
         }
         openOfferManager.removeOpenOffers(unreservedOpenOffers, null);
+
+        // set offer state
+        for (Offer offer : offers) {
+            Optional<OpenOffer> openOffer = openOfferManager.getOpenOfferById(offer.getId());
+            if (openOffer.isPresent()) offer.setState(openOffer.get().getState() == OpenOffer.State.AVAILABLE ? Offer.State.AVAILABLE : Offer.State.NOT_AVAILABLE);
+        }
+
         return offers;
     }
     

--- a/core/src/main/java/bisq/core/api/CoreTradesService.java
+++ b/core/src/main/java/bisq/core/api/CoreTradesService.java
@@ -38,7 +38,8 @@ import org.bitcoinj.core.Coin;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -89,31 +90,35 @@ class CoreTradesService {
                    String paymentAccountId,
                    Consumer<Trade> resultHandler,
                    ErrorMessageHandler errorMessageHandler) {
-        coreWalletsService.verifyWalletsAreAvailable();
-        coreWalletsService.verifyEncryptedWalletIsUnlocked();
+        try {
+            coreWalletsService.verifyWalletsAreAvailable();
+            coreWalletsService.verifyEncryptedWalletIsUnlocked();
 
-        var paymentAccount = user.getPaymentAccount(paymentAccountId);
-        if (paymentAccount == null)
-            throw new IllegalArgumentException(format("payment account with id '%s' not found", paymentAccountId));
+            var paymentAccount = user.getPaymentAccount(paymentAccountId);
+            if (paymentAccount == null)
+                throw new IllegalArgumentException(format("payment account with id '%s' not found", paymentAccountId));
 
-        var useSavingsWallet = true;
-        //noinspection ConstantConditions
-        takeOfferModel.initModel(offer, paymentAccount, useSavingsWallet);
-        log.info("Initiating take {} offer, {}",
-                offer.isBuyOffer() ? "buy" : "sell",
-                takeOfferModel);
-        //noinspection ConstantConditions
-        tradeManager.onTakeOffer(offer.getAmount(),
-                takeOfferModel.getTxFeeFromFeeService(),
-                takeOfferModel.getTakerFee(),
-                takeOfferModel.getFundsNeededForTrade(),
-                offer,
-                paymentAccountId,
-                useSavingsWallet,
-                coreContext.isApiUser(),
-                resultHandler::accept,
-                errorMessageHandler
-        );
+            var useSavingsWallet = true;
+            //noinspection ConstantConditions
+            takeOfferModel.initModel(offer, paymentAccount, useSavingsWallet);
+            log.info("Initiating take {} offer, {}",
+                    offer.isBuyOffer() ? "buy" : "sell",
+                    takeOfferModel);
+            //noinspection ConstantConditions
+            tradeManager.onTakeOffer(offer.getAmount(),
+                    takeOfferModel.getTxFeeFromFeeService(),
+                    takeOfferModel.getTakerFee(),
+                    takeOfferModel.getFundsNeededForTrade(),
+                    offer,
+                    paymentAccountId,
+                    useSavingsWallet,
+                    coreContext.isApiUser(),
+                    resultHandler::accept,
+                    errorMessageHandler
+            );
+        } catch (Exception e) {
+            errorMessageHandler.handleErrorMessage(e.getMessage());
+        }
     }
 
     void confirmPaymentStarted(String tradeId) {
@@ -222,6 +227,14 @@ class CoreTradesService {
     private Optional<Trade> getClosedTrade(String tradeId) {
         Optional<Tradable> tradable = closedTradableManager.getTradableById(tradeId);
         return tradable.filter((t) -> t instanceof Trade).map(value -> (Trade) value);
+    }
+
+    List<Trade> getTrades() {
+        coreWalletsService.verifyWalletsAreAvailable();
+        coreWalletsService.verifyEncryptedWalletIsUnlocked();
+        List<Trade> trades = new ArrayList<Trade>(tradeManager.getTrades());
+        trades.addAll(closedTradableManager.getClosedTrades());
+        return trades;
     }
 
     private boolean isFollowingBuyerProtocol(Trade trade) {

--- a/core/src/main/java/bisq/core/btc/setup/MoneroWalletRpcManager.java
+++ b/core/src/main/java/bisq/core/btc/setup/MoneroWalletRpcManager.java
@@ -90,12 +90,14 @@ public class MoneroWalletRpcManager {
    * Stop an instance of monero-wallet-rpc.
    *
    * @param walletRpc the client connected to the monero-wallet-rpc instance to stop
+   * @param save specifies if the wallet should be saved before closing
    */
-  public void stopInstance(MoneroWalletRpc walletRpc) {
+  public void stopInstance(MoneroWalletRpc walletRpc, boolean save) {
     boolean found = false;
     for (Map.Entry<Integer, MoneroWalletRpc> entry : registeredPorts.entrySet()) {
       if (walletRpc == entry.getValue()) {
-        walletRpc.stop();
+        walletRpc.close(save);
+        walletRpc.stopProcess();
         found = true;
         try { unregisterPort(entry.getKey()); }
         catch (Exception e) { throw new MoneroError(e); }

--- a/core/src/main/java/bisq/core/btc/wallet/XmrWalletService.java
+++ b/core/src/main/java/bisq/core/btc/wallet/XmrWalletService.java
@@ -86,7 +86,7 @@ public class XmrWalletService {
   // TODO (woodser): wallet has single password which is passed here?
   // TODO (woodser): test retaking failed trade.  create new multisig wallet or replace?  cannot reuse
   
-  public MoneroWallet createMultisigWallet(String tradeId) {
+  public synchronized MoneroWallet createMultisigWallet(String tradeId) {
       if (multisigWallets.containsKey(tradeId)) return multisigWallets.get(tradeId);
       String path = "xmr_multisig_trade_" + tradeId;
       MoneroWallet multisigWallet = null;
@@ -99,7 +99,7 @@ public class XmrWalletService {
       return multisigWallet;
   }
   
-  public MoneroWallet getMultisigWallet(String tradeId) {
+  public synchronized MoneroWallet getMultisigWallet(String tradeId) {
       if (multisigWallets.containsKey(tradeId)) return multisigWallets.get(tradeId);
       String path = "xmr_multisig_trade_" + tradeId;
       MoneroWallet multisigWallet = null;
@@ -110,6 +110,19 @@ public class XmrWalletService {
       multisigWallets.put(tradeId, multisigWallet);
       multisigWallet.startSyncing(5000l); // TODO (woodser): use sync period from config. apps stall if too many multisig wallets and too short sync period
       return multisigWallet;
+  }
+  
+  public synchronized boolean deleteMultisigWallet(String tradeId) {
+      String walletName = "xmr_multisig_trade_" + tradeId;
+      if (!walletsSetup.getWalletConfig().walletExists(walletName)) return false;
+      try {
+          walletsSetup.getWalletConfig().closeWallet(getMultisigWallet(tradeId), false);
+      } catch (Exception err) {
+          // multisig wallet may not be open
+      }
+      walletsSetup.getWalletConfig().deleteWallet(walletName);
+      multisigWallets.remove(tradeId);
+      return true;
   }
 
   public XmrAddressEntry recoverAddressEntry(String offerId, String address, XmrAddressEntry.Context context) {
@@ -291,7 +304,7 @@ public class XmrWalletService {
       threads.add(new Thread(new Runnable() {
         @Override
         public void run() {
-          try { walletsSetup.getWalletConfig().closeWallet(openWallet); }
+          try { walletsSetup.getWalletConfig().closeWallet(openWallet, true); }
           catch (Exception e) {
             log.warn("Error closing monero-wallet-rpc subprocess. Was Haveno stopped manually with ctrl+c?");
           }

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -391,11 +391,6 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 offer.getAmount(),
                 buyerSecurityDeposit,
                 createOfferService.getSellerSecurityDepositAsDouble(buyerSecurityDeposit));
-        
-        if (placeOfferProtocols.containsKey(offer.getId())) {
-            log.warn("We already have a place offer protocol for offer " + offer.getId() + ", ignoring");
-            throw new RuntimeException("We already have a place offer protocol for offer " + offer.getId() + ", ignoring");
-        }
 
         PlaceOfferModel model = new PlaceOfferModel(offer,
                 reservedFundsForOffer,
@@ -596,6 +591,10 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         requestPersistence();
     }
 
+    public void unreserveOpenOffer(OpenOffer openOffer) {
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+        requestPersistence();
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Getters

--- a/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/SellerAsMakerProtocol.java
@@ -64,37 +64,153 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
         super(trade);
     }
 
-
     ///////////////////////////////////////////////////////////////////////////////////////////
-    // Incoming messages Take offer process
+    // MakerProtocol
     ///////////////////////////////////////////////////////////////////////////////////////////
+    
+    // TODO (woodser): these methods are duplicated with BuyerAsMakerProtocol due to single inheritance
 
-    protected void handle(DepositTxMessage message, NodeAddress peer) {
-        expect(phase(Trade.Phase.TAKER_FEE_PUBLISHED)
+    @Override
+    public void handleInitTradeRequest(InitTradeRequest message,
+                                       NodeAddress peer,
+                                       ErrorMessageHandler errorMessageHandler) {
+        this.errorMessageHandler = errorMessageHandler;
+        expect(phase(Trade.Phase.INIT)
                 .with(message)
                 .from(peer))
                 .setup(tasks(
-                        MakerRemovesOpenOffer.class,
-                        SellerAsMakerProcessDepositTxMessage.class,
-                        SellerAsMakerFinalizesDepositTx.class,
-                        SellerCreatesDelayedPayoutTx.class,
-                        SellerSignsDelayedPayoutTx.class,
-                        SellerSendDelayedPayoutTxSignatureRequest.class)
-                        .withTimeout(60))
+                        ProcessInitTradeRequest.class,
+                        //ApplyFilter.class, // TODO (woodser): these checks apply when maker signs availability request, but not here
+                        //VerifyPeersAccountAgeWitness.class, // TODO (woodser): these checks apply after in multisig, means if rejected need to reimburse other's fee
+                        MakerSendsInitTradeRequestIfUnreserved.class)
+                .using(new TradeTaskRunner(trade,
+                        () -> {
+                            handleTaskRunnerSuccess(peer, message);
+                        },
+                        errorMessage -> {
+                            errorMessageHandler.handleErrorMessage(errorMessage);
+                            handleTaskRunnerFault(peer, message, errorMessage);
+                        }))
+                .withTimeout(30))
                 .executeTasks();
     }
 
-
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // Incoming message when buyer has clicked payment started button
-    ///////////////////////////////////////////////////////////////////////////////////////////
-
-    // We keep the handler here in as well to make it more transparent which messages we expect
     @Override
-    protected void handle(CounterCurrencyTransferStartedMessage message, NodeAddress peer) {
-        super.handle(message, peer);
+    public void handleInitMultisigRequest(InitMultisigRequest request, NodeAddress sender) {
+      System.out.println("BuyerAsMakerProtocol.handleInitMultisigRequest()");
+      Validator.checkTradeId(processModel.getOfferId(), request);
+      processModel.setTradeMessage(request); // TODO (woodser): synchronize access since concurrent requests processed
+      expect(anyPhase(Trade.Phase.INIT)
+              .with(request)
+              .from(sender))
+              .setup(tasks(
+                      ProcessInitMultisigRequest.class,
+                      SendSignContractRequestAfterMultisig.class)
+              .using(new TradeTaskRunner(trade,
+                  () -> {
+                      handleTaskRunnerSuccess(sender, request);
+                  },
+                  errorMessage -> {
+                      errorMessageHandler.handleErrorMessage(errorMessage);
+                      handleTaskRunnerFault(sender, request, errorMessage);
+                  }))
+              .withTimeout(30))
+              .executeTasks();
     }
 
+    @Override
+    public void handleSignContractRequest(SignContractRequest message, NodeAddress sender) {
+        System.out.println("BuyerAsMakerProtocol.handleSignContractRequest()");
+        Validator.checkTradeId(processModel.getOfferId(), message);
+        processModel.setTradeMessage(message);
+        expect(anyPhase(Trade.Phase.INIT)
+                .with(message)
+                .from(sender))
+                .setup(tasks(
+                        // TODO (woodser): validate request
+                        ProcessSignContractRequest.class)
+                .using(new TradeTaskRunner(trade,
+                    () -> {
+                        handleTaskRunnerSuccess(sender, message);
+                    },
+                    errorMessage -> {
+                        errorMessageHandler.handleErrorMessage(errorMessage);
+                        handleTaskRunnerFault(sender, message, errorMessage);
+                    }))
+                .withTimeout(30))
+                .executeTasks();
+    }
+
+    @Override
+    public void handleSignContractResponse(SignContractResponse message, NodeAddress sender) {
+        System.out.println("BuyerAsMakerProtocol.handleSignContractResponse()");
+        Validator.checkTradeId(processModel.getOfferId(), message);
+        processModel.setTradeMessage(message); // TODO (woodser): synchronize access since concurrent requests processed
+        expect(anyPhase(Trade.Phase.INIT)
+                .with(message)
+                .from(sender))
+                .setup(tasks(
+                        // TODO (woodser): validate request
+                        ProcessSignContractResponse.class)
+                .using(new TradeTaskRunner(trade,
+                    () -> {
+                        handleTaskRunnerSuccess(sender, message);
+                    },
+                    errorMessage -> {
+                        errorMessageHandler.handleErrorMessage(errorMessage);
+                        handleTaskRunnerFault(sender, message, errorMessage);
+                    }))
+                .withTimeout(30))
+                .executeTasks();
+    }
+    
+    @Override
+    public void handleDepositResponse(DepositResponse response, NodeAddress sender) {
+        System.out.println("BuyerAsMakerProtocol.handleDepositResponse()");
+        Validator.checkTradeId(processModel.getOfferId(), response);
+        processModel.setTradeMessage(response);
+        expect(anyPhase(Trade.Phase.INIT, Trade.Phase.DEPOSIT_PUBLISHED)
+                .with(response)
+                .from(sender)) // TODO (woodser): ensure this asserts sender == response.getSenderNodeAddress()
+                .setup(tasks(
+                        // TODO (woodser): validate request
+                        ProcessDepositResponse.class)
+                .using(new TradeTaskRunner(trade,
+                    () -> {
+                        handleTaskRunnerSuccess(sender, response);
+                    },
+                    errorMessage -> {
+                        errorMessageHandler.handleErrorMessage(errorMessage);
+                        handleTaskRunnerFault(sender, response, errorMessage);
+                    }))
+                .withTimeout(30))
+                .executeTasks();
+    }
+    
+    @Override
+    public void handlePaymentAccountPayloadRequest(PaymentAccountPayloadRequest request, NodeAddress sender) {
+        System.out.println("BuyerAsMakerProtocol.handlePaymentAccountPayloadRequest()");
+        Validator.checkTradeId(processModel.getOfferId(), request);
+        processModel.setTradeMessage(request);
+        expect(anyPhase(Trade.Phase.INIT, Trade.Phase.DEPOSIT_PUBLISHED)
+                .with(request)
+                .from(sender)) // TODO (woodser): ensure this asserts sender == response.getSenderNodeAddress()
+                .setup(tasks(
+                        // TODO (woodser): validate request
+                        ProcessPaymentAccountPayloadRequest.class,
+                        MakerRemovesOpenOffer.class)
+                .using(new TradeTaskRunner(trade,
+                    () -> {
+                        stopTimeout();
+                        handleTaskRunnerSuccess(sender, request);
+                    },
+                    errorMessage -> {
+                        errorMessageHandler.handleErrorMessage(errorMessage);
+                        handleTaskRunnerFault(sender, request, errorMessage);
+                    }))
+                .withTimeout(30))
+                .executeTasks();
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // User interaction
@@ -105,7 +221,6 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
     public void onPaymentReceived(ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
         super.onPaymentReceived(resultHandler, errorMessageHandler);
     }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Massage dispatcher
@@ -128,145 +243,35 @@ public class SellerAsMakerProtocol extends SellerProtocol implements MakerProtoc
         return MakerVerifyTakerFeePayment.class;
     }
 
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    // MakerProtocol
-    ///////////////////////////////////////////////////////////////////////////////////////////
-    
-    // TODO (woodser): these methods are duplicated with BuyerAsMakerProtocol due to single inheritance
+    // TODO (woodser): remove unused
 
-    @Override
-    public void handleInitTradeRequest(InitTradeRequest message,
-                                       NodeAddress peer,
-                                       ErrorMessageHandler errorMessageHandler) {
-        expect(phase(Trade.Phase.INIT)
-            .with(message)
-            .from(peer))
-            .setup(tasks(
-                    ProcessInitTradeRequest.class,
-                    //ApplyFilter.class, // TODO (woodser): these checks apply when maker signs availability request, but not here
-                    //VerifyPeersAccountAgeWitness.class, // TODO (woodser): these checks apply after in multisig, means if rejected need to reimburse other's fee
-                    MakerSendsInitTradeRequestIfUnreserved.class,
-                    MakerRemovesOpenOffer.class).
-                    using(new TradeTaskRunner(trade,
-                            () -> {
-                              handleTaskRunnerSuccess(peer, message);
-                            },
-                            errorMessage -> {
-                                errorMessageHandler.handleErrorMessage(errorMessage);
-                                handleTaskRunnerFault(peer, message, errorMessage);
-                            }))
-                    .withTimeout(30))
-            .executeTasks();
-    }
-    
-    @Override
-    public void handleInitMultisigRequest(InitMultisigRequest request, NodeAddress sender, ErrorMessageHandler errorMessageHandler) {
-      System.out.println("BuyerAsMakerProtocol.handleInitMultisigRequest()");
-      Validator.checkTradeId(processModel.getOfferId(), request);
-      processModel.setTradeMessage(request); // TODO (woodser): synchronize access since concurrent requests processed
-      expect(anyPhase(Trade.Phase.INIT)
-          .with(request)
-          .from(sender))
-          .setup(tasks(
-                  ProcessInitMultisigRequest.class,
-                  SendSignContractRequestAfterMultisig.class)
-              .using(new TradeTaskRunner(trade,
-                  () -> {
-                    handleTaskRunnerSuccess(sender, request);
-                  },
-                  errorMessage -> {
-                      errorMessageHandler.handleErrorMessage(errorMessage);
-                      handleTaskRunnerFault(sender, request, errorMessage);
-                  })))
-          .executeTasks();
-    }
-    
-    @Override
-    public void handleSignContractRequest(SignContractRequest message, NodeAddress sender, ErrorMessageHandler errorMessageHandler) {
-        System.out.println("BuyerAsMakerProtocol.handleSignContractRequest()");
-        Validator.checkTradeId(processModel.getOfferId(), message);
-        processModel.setTradeMessage(message);
-        expect(anyPhase(Trade.Phase.INIT)
-            .with(message)
-            .from(sender))
-            .setup(tasks(
-                    // TODO (woodser): validate request
-                    ProcessSignContractRequest.class)
-                .using(new TradeTaskRunner(trade,
-                    () -> {
-                      handleTaskRunnerSuccess(sender, message);
-                    },
-                    errorMessage -> {
-                        errorMessageHandler.handleErrorMessage(errorMessage);
-                        handleTaskRunnerFault(sender, message, errorMessage);
-                    })))
-            .executeTasks();
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Incoming messages Take offer process
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    protected void handle(DepositTxMessage message, NodeAddress peer) {
+        expect(phase(Trade.Phase.TAKER_FEE_PUBLISHED)
+                .with(message)
+                .from(peer))
+                .setup(tasks(
+                        MakerRemovesOpenOffer.class,
+                        SellerAsMakerProcessDepositTxMessage.class,
+                        SellerAsMakerFinalizesDepositTx.class,
+                        SellerCreatesDelayedPayoutTx.class,
+                        SellerSignsDelayedPayoutTx.class,
+                        SellerSendDelayedPayoutTxSignatureRequest.class)
+                .withTimeout(60))
+                .executeTasks();
     }
 
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Incoming message when buyer has clicked payment started button
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    // We keep the handler here in as well to make it more transparent which messages we expect
     @Override
-    public void handleSignContractResponse(SignContractResponse message, NodeAddress sender, ErrorMessageHandler errorMessageHandler) {
-        System.out.println("BuyerAsMakerProtocol.handleSignContractResponse()");
-        Validator.checkTradeId(processModel.getOfferId(), message);
-        processModel.setTradeMessage(message); // TODO (woodser): synchronize access since concurrent requests processed
-        expect(anyPhase(Trade.Phase.INIT)
-            .with(message)
-            .from(sender))
-            .setup(tasks(
-                    // TODO (woodser): validate request
-                    ProcessSignContractResponse.class)
-                .using(new TradeTaskRunner(trade,
-                    () -> {
-                      handleTaskRunnerSuccess(sender, message);
-                    },
-                    errorMessage -> {
-                        errorMessageHandler.handleErrorMessage(errorMessage);
-                        handleTaskRunnerFault(sender, message, errorMessage);
-                    })))
-            .executeTasks();
-    }
-    
-    @Override
-    public void handleDepositResponse(DepositResponse response, NodeAddress sender, ErrorMessageHandler errorMessageHandler) {
-        System.out.println("BuyerAsMakerProtocol.handleDepositResponse()");
-        Validator.checkTradeId(processModel.getOfferId(), response);
-        processModel.setTradeMessage(response);
-        expect(anyPhase(Trade.Phase.INIT, Trade.Phase.DEPOSIT_PUBLISHED)
-            .with(response)
-            .from(sender)) // TODO (woodser): ensure this asserts sender == response.getSenderNodeAddress()
-            .setup(tasks(
-                    // TODO (woodser): validate request
-                    ProcessDepositResponse.class)
-                .using(new TradeTaskRunner(trade,
-                    () -> {
-                      handleTaskRunnerSuccess(sender, response);
-                    },
-                    errorMessage -> {
-                        errorMessageHandler.handleErrorMessage(errorMessage);
-                        handleTaskRunnerFault(sender, response, errorMessage);
-                    })))
-            .executeTasks();
-    }
-    
-    @Override
-    public void handlePaymentAccountPayloadRequest(PaymentAccountPayloadRequest request, NodeAddress sender, ErrorMessageHandler errorMessageHandler) {
-        System.out.println("BuyerAsMakerProtocol.handlePaymentAccountPayloadRequest()");
-        Validator.checkTradeId(processModel.getOfferId(), request);
-        processModel.setTradeMessage(request);
-        expect(anyPhase(Trade.Phase.INIT, Trade.Phase.DEPOSIT_PUBLISHED)
-            .with(request)
-            .from(sender)) // TODO (woodser): ensure this asserts sender == response.getSenderNodeAddress()
-            .setup(tasks(
-                    // TODO (woodser): validate request
-                    ProcessPaymentAccountPayloadRequest.class)
-                .using(new TradeTaskRunner(trade,
-                    () -> {
-                        stopTimeout();
-                        handleTaskRunnerSuccess(sender, request);
-                    },
-                    errorMessage -> {
-                        errorMessageHandler.handleErrorMessage(errorMessage);
-                        handleTaskRunnerFault(sender, request, errorMessage);
-                    })))
-            .executeTasks();
+    protected void handle(CounterCurrencyTransferStartedMessage message, NodeAddress peer) {
+        super.handle(message, peer);
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/TraderProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TraderProtocol.java
@@ -23,10 +23,8 @@ import bisq.core.trade.messages.PaymentAccountPayloadRequest;
 import bisq.core.trade.messages.SignContractResponse;
 import bisq.network.p2p.NodeAddress;
 
-import bisq.common.handlers.ErrorMessageHandler;
-
 public interface TraderProtocol {
-    public void handleSignContractResponse(SignContractResponse message, NodeAddress peer, ErrorMessageHandler errorMessageHandler);
-    public void handleDepositResponse(DepositResponse response, NodeAddress peer, ErrorMessageHandler errorMessageHandler);
-    public void handlePaymentAccountPayloadRequest(PaymentAccountPayloadRequest request, NodeAddress peer, ErrorMessageHandler errorMessageHandler);
+    public void handleSignContractResponse(SignContractResponse message, NodeAddress peer);
+    public void handleDepositResponse(DepositResponse response, NodeAddress peer);
+    public void handlePaymentAccountPayloadRequest(PaymentAccountPayloadRequest request, NodeAddress peer);
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/ProcessInitMultisigRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/ProcessInitMultisigRequest.java
@@ -22,8 +22,9 @@ import bisq.core.trade.MakerTrade;
 import bisq.core.trade.TakerTrade;
 import bisq.core.trade.Trade;
 import bisq.core.trade.messages.InitMultisigRequest;
+import bisq.core.trade.protocol.TradeListener;
 import bisq.core.trade.protocol.TradingPeer;
-
+import bisq.network.p2p.AckMessage;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.SendDirectMessageListener;
 
@@ -50,6 +51,7 @@ public class ProcessInitMultisigRequest extends TradeTask {
 
     private boolean ack1 = false;
     private boolean ack2 = false;
+    private boolean failed = false;
     private static Object lock = new Object();
     MoneroWallet multisigWallet;
 
@@ -149,37 +151,31 @@ public class ProcessInitMultisigRequest extends TradeTask {
               if (peer2Address == null) throw new RuntimeException("Peer2 address is null");
               if (peer2PubKeyRing == null) throw new RuntimeException("Peer2 pub key ring null");
 
-              // send to peer 1
-              sendInitMultisigRequest(peer1Address, peer1PubKeyRing, new SendDirectMessageListener() {
-                @Override
-                public void onArrived() {
-                    log.info("{} arrived: peer={}; offerId={}; uid={}", request.getClass().getSimpleName(), peer1Address, request.getTradeId(), request.getUid());
-                    ack1 = true;
-                    if (ack1 && ack2) completeAux();
-                }
-                @Override
-                public void onFault(String errorMessage) {
-                    log.error("Sending {} failed: uid={}; peer={}; error={}", request.getClass().getSimpleName(), request.getUid(), peer1Address, errorMessage);
-                    appendToErrorMessage("Sending message failed: message=" + request + "\nerrorMessage=" + errorMessage);
-                    failed();
-                }
-              });
+              // complete on successful ack messages
+              TradeListener ackListener = new TradeListener() {
+                  @Override
+                  public void onAckMessage(AckMessage ackMessage, NodeAddress sender) {
+                      if (!ackMessage.getSourceMsgClassName().equals(InitMultisigRequest.class.getSimpleName())) return;
+                      if (ackMessage.isSuccess()) {
+                         if (sender.equals(peer1Address)) ack1 = true;
+                         if (sender.equals(peer2Address)) ack2 = true;
+                         if (ack1 && ack2) {
+                             trade.removeListener(this);
+                             completeAux();
+                         }
+                      } else {
+                          if (!failed) {
+                              failed = true;
+                              failed(ackMessage.getErrorMessage()); // TODO: (woodser): only fail once? build into task?
+                          }
+                      }
+                  }
+              };
+              trade.addListener(ackListener);
 
-              // send to peer 2
-              sendInitMultisigRequest(peer2Address, peer2PubKeyRing, new SendDirectMessageListener() {
-                @Override
-                public void onArrived() {
-                    log.info("{} arrived: peer={}; offerId={}; uid={}", request.getClass().getSimpleName(), peer2Address, request.getTradeId(), request.getUid());
-                    ack2 = true;
-                    if (ack1 && ack2) completeAux();
-                }
-                @Override
-                public void onFault(String errorMessage) {
-                    log.error("Sending {} failed: uid={}; peer={}; error={}", request.getClass().getSimpleName(), request.getUid(), peer2Address, errorMessage);
-                    appendToErrorMessage("Sending message failed: message=" + request + "\nerrorMessage=" + errorMessage);
-                    failed();
-                }
-              });
+              // send to peers
+              sendInitMultisigRequest(peer1Address, peer1PubKeyRing);
+              sendInitMultisigRequest(peer2Address, peer2PubKeyRing);
             } else {
               completeAux();
             }
@@ -204,21 +200,32 @@ public class ProcessInitMultisigRequest extends TradeTask {
       return peers;
     }
 
-    private void sendInitMultisigRequest(NodeAddress recipient, PubKeyRing pubKeyRing, SendDirectMessageListener listener) {
+    private void sendInitMultisigRequest(NodeAddress recipient, PubKeyRing pubKeyRing) {
 
-      // create multisig message with current multisig hex
-      InitMultisigRequest request = new InitMultisigRequest(
-              processModel.getOffer().getId(),
-              processModel.getMyNodeAddress(),
-              processModel.getPubKeyRing(),
-              UUID.randomUUID().toString(),
-              Version.getP2PMessageVersion(),
-              new Date().getTime(),
-              processModel.getPreparedMultisigHex(),
-              processModel.getMadeMultisigHex());
-
-      log.info("Send {} with offerId {} and uid {} to peer {}", request.getClass().getSimpleName(), request.getTradeId(), request.getUid(), recipient);
-      processModel.getP2PService().sendEncryptedDirectMessage(recipient, pubKeyRing, request, listener);
+        // create request with current multisig hex
+        InitMultisigRequest request = new InitMultisigRequest(
+                processModel.getOffer().getId(),
+                processModel.getMyNodeAddress(),
+                processModel.getPubKeyRing(),
+                UUID.randomUUID().toString(),
+                Version.getP2PMessageVersion(),
+                new Date().getTime(),
+                processModel.getPreparedMultisigHex(),
+                processModel.getMadeMultisigHex());
+    
+        log.info("Send {} with offerId {} and uid {} to peer {}", request.getClass().getSimpleName(), request.getTradeId(), request.getUid(), recipient);
+        processModel.getP2PService().sendEncryptedDirectMessage(recipient, pubKeyRing, request, new SendDirectMessageListener() {
+            @Override
+            public void onArrived() {
+                log.info("{} arrived: peer={}; offerId={}; uid={}", request.getClass().getSimpleName(), recipient, request.getTradeId(), request.getUid());
+            }
+            @Override
+            public void onFault(String errorMessage) {
+                log.error("Sending {} failed: uid={}; peer={}; error={}", request.getClass().getSimpleName(), request.getUid(), recipient, errorMessage);
+                appendToErrorMessage("Sending message failed: message=" + request + "\nerrorMessage=" + errorMessage);
+                failed();
+            }
+        });
     }
 
     private void completeAux() {

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/ProcessSignContractRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/ProcessSignContractRequest.java
@@ -29,7 +29,9 @@ import bisq.core.trade.Trade;
 import bisq.core.trade.TradeUtils;
 import bisq.core.trade.messages.SignContractRequest;
 import bisq.core.trade.messages.SignContractResponse;
+import bisq.core.trade.protocol.TradeListener;
 import bisq.core.trade.protocol.TradingPeer;
+import bisq.network.p2p.AckMessage;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.SendDirectMessageListener;
 import java.util.Date;
@@ -41,6 +43,7 @@ public class ProcessSignContractRequest extends TradeTask {
     
     private boolean ack1 = false;
     private boolean ack2 = false;
+    private boolean failed = false;
 
     @SuppressWarnings({"unused"})
     public ProcessSignContractRequest(TaskRunner taskHandler, Trade trade) {
@@ -61,73 +64,84 @@ public class ProcessSignContractRequest extends TradeTask {
           trader.setPaymentAccountPayloadHash(request.getPaymentAccountPayloadHash());
           trader.setPayoutAddressString(request.getPayoutAddress());
           
-          // return contract signature when ready
+          // sign contract only when both deposit txs hashes known
           // TODO (woodser): synchronize contract creation; both requests received at the same time
           // TODO (woodser): remove makerDepositTxId and takerDepositTxId from Trade
-          if (processModel.getMaker().getDepositTxHash() != null && processModel.getTaker().getDepositTxHash() != null) { // TODO (woodser): synchronize on process model before setting hash so response only sent once
-              
-              // create and sign contract
-              Contract contract = TradeUtils.createContract(trade);
-              String contractAsJson = Utilities.objectToJson(contract);
-              String signature = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(), contractAsJson);
-              
-              // save contract and signature
-              trade.setContract(contract);
-              trade.setContractAsJson(contractAsJson);
-              trade.getSelf().setContractSignature(signature);
-              
-              // create response with contract signature
-              SignContractResponse response = new SignContractResponse(
-                      trade.getOffer().getId(),
-                      processModel.getMyNodeAddress(),
-                      processModel.getPubKeyRing(),
-                      UUID.randomUUID().toString(),
-                      Version.getP2PMessageVersion(),
-                      new Date().getTime(),
-                      signature);
-              
-              // get response recipients. only arbitrator sends response to both peers
-              NodeAddress recipient1 = trade instanceof ArbitratorTrade ? trade.getMakerNodeAddress() : trade.getTradingPeerNodeAddress();
-              PubKeyRing recipient1PubKey = trade instanceof ArbitratorTrade ? trade.getMakerPubKeyRing() : trade.getTradingPeerPubKeyRing();
-              NodeAddress recipient2 = trade instanceof ArbitratorTrade ? trade.getTakerNodeAddress() : null;
-              PubKeyRing recipient2PubKey = trade instanceof ArbitratorTrade ? trade.getTakerPubKeyRing() : null;
-              
-              // send response to recipient 1
-              processModel.getP2PService().sendEncryptedDirectMessage(recipient1, recipient1PubKey, response, new SendDirectMessageListener() {
-                  @Override
-                  public void onArrived() {
-                      log.info("{} arrived: trading peer={}; offerId={}; uid={}", response.getClass().getSimpleName(), recipient1, trade.getId());
-                      ack1 = true;
-                      if (ack1 && (recipient2 == null || ack2)) complete();
-                  }
-                  @Override
-                  public void onFault(String errorMessage) {
-                      log.error("Sending {} failed: uid={}; peer={}; error={}", response.getClass().getSimpleName(), recipient1, trade.getId(), errorMessage);
-                      appendToErrorMessage("Sending message failed: message=" + response + "\nerrorMessage=" + errorMessage);
-                      failed();
-                  }
-              });
-              
-              // send response to recipient 2 if applicable
-              if (recipient2 != null) {
-                  processModel.getP2PService().sendEncryptedDirectMessage(recipient2, recipient2PubKey, response, new SendDirectMessageListener() {
-                      @Override
-                      public void onArrived() {
-                          log.info("{} arrived: trading peer={}; offerId={}; uid={}", response.getClass().getSimpleName(), recipient2, trade.getId());
-                          ack2 = true;
-                          if (ack1 && ack2) complete();
-                      }
-                      @Override
-                      public void onFault(String errorMessage) {
-                          log.error("Sending {} failed: uid={}; peer={}; error={}", response.getClass().getSimpleName(), recipient2, trade.getId(), errorMessage);
-                          appendToErrorMessage("Sending message failed: message=" + response + "\nerrorMessage=" + errorMessage);
-                          failed();
-                      }
-                  });
-              }
+          if (processModel.getMaker().getDepositTxHash() == null || processModel.getTaker().getDepositTxHash() == null) {
+              complete();
+              return;
           }
+          
+          // create and sign contract
+          Contract contract = TradeUtils.createContract(trade);
+          String contractAsJson = Utilities.objectToJson(contract);
+          String signature = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(), contractAsJson);
+          
+          // save contract and signature
+          trade.setContract(contract);
+          trade.setContractAsJson(contractAsJson);
+          trade.getSelf().setContractSignature(signature);
+          
+          // get response recipients. only arbitrator sends response to both peers
+          NodeAddress recipient1 = trade instanceof ArbitratorTrade ? trade.getMakerNodeAddress() : trade.getTradingPeerNodeAddress();
+          PubKeyRing recipient1PubKey = trade instanceof ArbitratorTrade ? trade.getMakerPubKeyRing() : trade.getTradingPeerPubKeyRing();
+          NodeAddress recipient2 = trade instanceof ArbitratorTrade ? trade.getTakerNodeAddress() : null;
+          PubKeyRing recipient2PubKey = trade instanceof ArbitratorTrade ? trade.getTakerPubKeyRing() : null;
+          
+          // complete on successful ack messages
+          TradeListener ackListener = new TradeListener() {
+              @Override
+              public void onAckMessage(AckMessage ackMessage, NodeAddress sender) {
+                  if (!ackMessage.getSourceMsgClassName().equals(SignContractResponse.class.getSimpleName())) return;
+                  if (ackMessage.isSuccess()) {
+                     if (sender.equals(trade.getTradingPeerNodeAddress())) ack1 = true;
+                     if (sender.equals(trade.getArbitratorNodeAddress())) ack2 = true;
+                     if (trade instanceof ArbitratorTrade ? ack1 && ack2 : ack1) { // only arbitrator sends response to both peers
+                         trade.removeListener(this);
+                         complete();
+                     }
+                  } else {
+                      if (!failed) {
+                          failed = true;
+                          failed(ackMessage.getErrorMessage()); // TODO: (woodser): only fail once? build into task?
+                      }
+                  }
+              }
+          };
+          trade.addListener(ackListener);
+          
+          // send contract signature response(s)
+          if (recipient1 != null) sendSignContractResponse(recipient1, recipient1PubKey, signature);
+          if (recipient2 != null) sendSignContractResponse(recipient2, recipient2PubKey, signature);
         } catch (Throwable t) {
           failed(t);
         }
+    }
+    
+    private void sendSignContractResponse(NodeAddress nodeAddress, PubKeyRing pubKeyRing, String contractSignature) {
+        
+        // create response with contract signature
+        SignContractResponse response = new SignContractResponse(
+                trade.getOffer().getId(),
+                processModel.getMyNodeAddress(),
+                processModel.getPubKeyRing(),
+                UUID.randomUUID().toString(),
+                Version.getP2PMessageVersion(),
+                new Date().getTime(),
+                contractSignature);
+        
+        // send request
+        processModel.getP2PService().sendEncryptedDirectMessage(nodeAddress, pubKeyRing, response, new SendDirectMessageListener() {
+            @Override
+            public void onArrived() {
+                log.info("{} arrived: trading peer={}; offerId={}; uid={}", response.getClass().getSimpleName(), nodeAddress, trade.getId());
+            }
+            @Override
+            public void onFault(String errorMessage) {
+                log.error("Sending {} failed: uid={}; peer={}; error={}", response.getClass().getSimpleName(), nodeAddress, trade.getId(), errorMessage);
+                appendToErrorMessage("Sending message failed: message=" + response + "\nerrorMessage=" + errorMessage);
+                failed();
+            }
+        });
     }
 }

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcTradesService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcTradesService.java
@@ -27,6 +27,8 @@ import bisq.proto.grpc.ConfirmPaymentStartedReply;
 import bisq.proto.grpc.ConfirmPaymentStartedRequest;
 import bisq.proto.grpc.GetTradeReply;
 import bisq.proto.grpc.GetTradeRequest;
+import bisq.proto.grpc.GetTradesReply;
+import bisq.proto.grpc.GetTradesRequest;
 import bisq.proto.grpc.KeepFundsReply;
 import bisq.proto.grpc.KeepFundsRequest;
 import bisq.proto.grpc.TakeOfferReply;
@@ -40,8 +42,9 @@ import io.grpc.stub.StreamObserver;
 import javax.inject.Inject;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
-
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 import static bisq.core.api.model.TradeInfo.toTradeInfo;
@@ -82,6 +85,25 @@ class GrpcTradesService extends TradesImplBase {
             // Offer makers may call 'gettrade' many times before a trade exists.
             // Log a 'trade not found' warning instead of a full stack trace.
             exceptionHandler.handleExceptionAsWarning(log, "getTrade", cause, responseObserver);
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
+    public void getTrades(GetTradesRequest req,
+                         StreamObserver<GetTradesReply> responseObserver) {
+        try {
+            List<TradeInfo> trades = coreApi.getTrades()
+                    .stream().map(TradeInfo::toTradeInfo)
+                    .collect(Collectors.toList());
+            var reply = GetTradesReply.newBuilder()
+                    .addAllTrades(trades.stream()
+                            .map(TradeInfo::toProtoMessage)
+                            .collect(Collectors.toList()))
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
         } catch (Throwable cause) {
             exceptionHandler.handleException(log, cause, responseObserver);
         }
@@ -173,8 +195,9 @@ class GrpcTradesService extends TradesImplBase {
         return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
                 .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
                         new HashMap<>() {{
-                            put(getGetTradeMethod().getFullMethodName(), new GrpcCallRateMeter(3, SECONDS));
-                            put(getTakeOfferMethod().getFullMethodName(), new GrpcCallRateMeter(1, SECONDS));
+                            put(getGetTradeMethod().getFullMethodName(), new GrpcCallRateMeter(10, SECONDS));
+                            put(getGetTradesMethod().getFullMethodName(), new GrpcCallRateMeter(10, SECONDS));
+                            put(getTakeOfferMethod().getFullMethodName(), new GrpcCallRateMeter(10, SECONDS));
                             put(getConfirmPaymentStartedMethod().getFullMethodName(), new GrpcCallRateMeter(1, SECONDS));
                             put(getConfirmPaymentReceivedMethod().getFullMethodName(), new GrpcCallRateMeter(1, SECONDS));
                             put(getKeepFundsMethod().getFullMethodName(), new GrpcCallRateMeter(1, MINUTES));

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -300,6 +300,8 @@ message StopReply {
 service Trades {
     rpc GetTrade (GetTradeRequest) returns (GetTradeReply) {
     }
+    rpc GetTrades (GetTradesRequest) returns (GetTradesReply) {
+    }
     rpc TakeOffer (TakeOfferRequest) returns (TakeOfferReply) {
     }
     rpc ConfirmPaymentStarted (ConfirmPaymentStartedRequest) returns (ConfirmPaymentStartedReply) {
@@ -342,6 +344,13 @@ message GetTradeRequest {
 
 message GetTradeReply {
     TradeInfo trade = 1;
+}
+
+message GetTradesRequest {
+}
+
+message GetTradesReply {
+    repeated TradeInfo trades = 1;
 }
 
 message KeepFundsRequest {


### PR DESCRIPTION
support getTrades() from grpc api
consistently use timeouts in protocol pipelines
remove trade and repost offer on protocol errors
delete multisig wallet when trade removed
protocol advances on ack messages instead of network onArrived()
re-order protocol class methods to correct order