### PR TITLE
FormattingUtilsTest locale fix

### DIFF
--- a/core/src/test/java/bisq/core/util/FormattingUtilsTest.java
+++ b/core/src/test/java/bisq/core/util/FormattingUtilsTest.java
@@ -1,5 +1,6 @@
 package bisq.core.util;
 
+import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.Res;
 import bisq.core.monetary.Altcoin;
 import bisq.core.monetary.Price;
@@ -31,6 +32,7 @@ public class FormattingUtilsTest {
     @Before
     public void setUp() {
         Locale.setDefault(new Locale("en", "US"));
+        GlobalSettings.setLocale(new Locale("en", "US"));
         Res.setBaseCurrencyCode("XMR");
         Res.setBaseCurrencyName("Monero");
     }


### PR DESCRIPTION
This test was failing sometimes (not consistently) on a system with non-en locale. GlobalSettings.setLocale is used in other tests like this