### PR TITLE
substitute jtorctl transitive dependency to resolve checksum issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,6 +268,11 @@ configure(project(':common')) {
         compileOnly "org.projectlombok:lombok:$lombokVersion"
         annotationProcessor "org.projectlombok:lombok:$lombokVersion"
         testCompile "org.hamcrest:hamcrest-all:$hamcrestVersion"
+
+        // override transitive dependency version from 1.5 to the same version just identified by commit number. 
+        // Remove this if transitive dependency is changed to something else than 1.5
+        compile( group: 'com.github.JesusMcCloud', name: 'jtorctl') { version { strictly "[9b5ba2036b]" } }
+
     }
 }
 

--- a/gradle/witness/gradle-witness.gradle
+++ b/gradle/witness/gradle-witness.gradle
@@ -21,7 +21,7 @@ dependencyVerification {
         'com.fasterxml.jackson.core:jackson-annotations:203cefdfa6c81e6aa84e11f292f29ca97344a3c3bc0293abea065cd837592873',
         'com.fasterxml.jackson.core:jackson-core:cc899cb6eae0c80b87d590eea86528797369cc4feb7b79463207d6bb18f0c257',
         'com.fasterxml.jackson.core:jackson-databind:f2ca3c28ebded59c98447d51afe945323df961540af66a063c015597af936aa0',
-        'com.github.JesusMcCloud:jtorctl:6465e0b22b921344a065a6e82a5390ab2f9dac5ab293c38bd8a76baddead6492',
+        'com.github.JesusMcCloud:jtorctl:b2bdfe9758e4c82ff1b10e7c3098981bf55ea3e5f161ee7990ac125003a6cdbe',
         'com.github.bisq-network.netlayer:tor.external:e1d6b8fe73891207701c6b14317be789fd4acd25f7b499425d2471598d9a22ac',
         'com.github.bisq-network.netlayer:tor.native:aa3edf9c27071fdc2b7d55b00dbc7c6cd5dc9aa9f87aafa4be0805f818a466be',
         'com.github.bisq-network.netlayer:tor:37198bc56e8fe112f8c80441544a2b9731929dae586bda841a4a926fdc04f457',


### PR DESCRIPTION
on jitpack versions can be built from git tags or commits. Tag 1.5 and commit 9b5ba2036b points to exactly the same code. Lets see if this change resolves the issues when 2 different versions 1.5 were cached somewhere with different checksums

I did run the build job on my fork 2 times and it passed on all of them so far 