### PR TITLE
send coverage results to codacy after every successful ci build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,11 @@ jobs:
         run: git lfs pull
       - name: Build with make
         run: make
+      - name: Send coverage report to Codacy
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        if: success()
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r assets/build/reports/jacoco/test/jacocoTestReport.xml
       - name: cache nodes dependencies
         uses: actions/upload-artifact@v2
         with:
@@ -61,3 +66,8 @@ jobs:
         run: git lfs pull
       - name: Build with Gradle
         run: ./gradlew build --stacktrace --scan
+      - name: Send coverage report to Codacy
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        if: success()
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r assets/build/reports/jacoco/test/jacocoTestReport.xml

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ configure(rootProject) {
 configure(subprojects) {
     apply plugin: 'java'
     apply plugin: 'com.google.osdetector'
+    // Apply the jacoco plugin to add support for test coverage
+    apply plugin: 'jacoco'
 
     sourceCompatibility = 1.10
 
@@ -91,6 +93,15 @@ configure(subprojects) {
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
     }
+
+    jacocoTestReport {
+        reports {
+            xml.enabled true
+            html.enabled false
+        }
+    }
+    // Codacy report generated with every build at assets/build/reports/jacoco/test/jacocoTestReport.xml
+    test.finalizedBy jacocoTestReport
 }
 
 


### PR DESCRIPTION
Result:

![coverage](https://user-images.githubusercontent.com/28106476/150104008-ce873fc9-23ba-4bd8-aa9f-7fd9743e51d3.png)

The detailed coverage stats will be on https://app.codacy.com/gh/haveno-dex/haveno/dashboard. I will add a badge on the readme after this PR is merged (it's not available until the first report is sent)