### PR TITLE
workflows: don't try to send coverage reports on windows bot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,3 @@ jobs:
         run: git lfs pull
       - name: Build with Gradle
         run: ./gradlew build --stacktrace --scan
-      - name: Send coverage report to Codacy
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        if: success()
-        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r assets/build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
Windows doesn't recognize the command `bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r assets/build/reports/jacoco/test/jacocoTestReport.xml` (added with #220) and [throws an error](https://github.com/haveno-dex/haveno/runs/4885514312?check_suite_focus=true#step:6:11).

After unsuccessfully trying several workarounds to make `<` work, i figured that it's probably better to just remove it. Sending the report from Windows is not really needed and codacy's reporter seem to be set to work only on one operative system (Ubuntu), so probably better remove it regardless.