### PR TITLE
workflows: add coverage reports to their own action and remove from build.yml

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -1,19 +1,11 @@
-name: CI
+name: codacy-coverage-reporter
 
-on:
-  push:
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**/README.md'
+on: ["push"]
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
+  codacy-coverage-reporter:
+    runs-on: ubuntu-latest
+    name: codacy-coverage-reporter
     steps:
       - uses: actions/checkout@v2
         with:
@@ -39,25 +31,8 @@ jobs:
         run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock
           rm -f ~/.gradle/caches/modules-2/gc.properties
-      - uses: actions/upload-artifact@v2
-        if: failure()
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
         with:
-          name: gradlew-report
-          path: 'desktop/build/reports/tests/test/index.html'
-          retention-days: 30
-
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          lfs: true
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: Pull lfs
-        run: git lfs pull
-      - name: Build with Gradle
-        run: ./gradlew build --stacktrace --scan
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: assets/build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
[codacy's github action](https://github.com/codacy/codacy-coverage-reporter-action) will allow us to run checks also on pull requests (tested on my fork)