### PR TITLE
Change network version

### DIFF
--- a/common/src/main/java/bisq/common/app/Version.java
+++ b/common/src/main/java/bisq/common/app/Version.java
@@ -85,7 +85,7 @@ public class Version {
     // If objects are used for both network and database the network version is applied.
     // VERSION = 0.5.0 -> P2P_NETWORK_VERSION = 1
     // With version 1.2.2 we change to version 2 (new trade protocol)
-    public static final int P2P_NETWORK_VERSION = 1;
+    public static final String P2P_NETWORK_VERSION = "A";
 
     // The version no. of the serialized data stored to disc. A change will break the serialization of old objects.
     // VERSION = 0.5.0 -> LOCAL_DB_VERSION = 1
@@ -100,9 +100,9 @@ public class Version {
     // Version 1.2.2 -> TRADE_PROTOCOL_VERSION = 2
     // Version 1.5.0 -> TRADE_PROTOCOL_VERSION = 3
     public static final int TRADE_PROTOCOL_VERSION = 3;
-    private static int p2pMessageVersion;
+    private static String p2pMessageVersion;
 
-    public static int getP2PMessageVersion() {
+    public static String getP2PMessageVersion() {
         return p2pMessageVersion;
     }
 
@@ -114,7 +114,12 @@ public class Version {
 
         // CRYPTO_NETWORK_ID is ordinal of enum. We use for changes at NETWORK_PROTOCOL_VERSION a multiplication with 10
         // to not mix up networks:
-        p2pMessageVersion = BASE_CURRENCY_NETWORK + 10 * P2P_NETWORK_VERSION;
+        if (BASE_CURRENCY_NETWORK == 0)
+            p2pMessageVersion =  "0" + P2P_NETWORK_VERSION;
+        if (BASE_CURRENCY_NETWORK == 1)
+            p2pMessageVersion =  "1" + P2P_NETWORK_VERSION;
+        if (BASE_CURRENCY_NETWORK == 2)
+            p2pMessageVersion =  "2" + P2P_NETWORK_VERSION;
     }
 
     public static int getBaseCurrencyNetwork() {

--- a/common/src/main/java/bisq/common/proto/network/NetworkEnvelope.java
+++ b/common/src/main/java/bisq/common/proto/network/NetworkEnvelope.java
@@ -28,14 +28,14 @@ import static com.google.common.base.Preconditions.checkArgument;
 @EqualsAndHashCode
 public abstract class NetworkEnvelope implements Envelope {
 
-    protected final int messageVersion;
+    protected final String messageVersion;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    protected NetworkEnvelope(int messageVersion) {
+    protected NetworkEnvelope(String messageVersion) {
         this.messageVersion = messageVersion;
     }
 
@@ -57,10 +57,10 @@ public abstract class NetworkEnvelope implements Envelope {
     // API
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public int getMessageVersion() {
+    public String getMessageVersion() {
         // -1 is used for the case that we use an envelope message as payload (mailbox)
         // so we check only against 0 which is the default value if not set
-        checkArgument(messageVersion != 0, "messageVersion is not set (0).");
+        checkArgument(messageVersion.equals("0"), "messageVersion is not set (0).");
         return messageVersion;
     }
 

--- a/core/src/main/java/bisq/core/alert/PrivateNotificationMessage.java
+++ b/core/src/main/java/bisq/core/alert/PrivateNotificationMessage.java
@@ -51,7 +51,7 @@ public class PrivateNotificationMessage extends NetworkEnvelope implements Mailb
     private PrivateNotificationMessage(PrivateNotificationPayload privateNotificationPayload,
                                        NodeAddress senderNodeAddress,
                                        String uid,
-                                       int messageVersion) {
+                                       String messageVersion) {
         super(messageVersion);
         this.privateNotificationPayload = privateNotificationPayload;
         this.senderNodeAddress = senderNodeAddress;
@@ -68,7 +68,7 @@ public class PrivateNotificationMessage extends NetworkEnvelope implements Mailb
                 .build();
     }
 
-    public static PrivateNotificationMessage fromProto(protobuf.PrivateNotificationMessage proto, int messageVersion) {
+    public static PrivateNotificationMessage fromProto(protobuf.PrivateNotificationMessage proto, String messageVersion) {
         return new PrivateNotificationMessage(PrivateNotificationPayload.fromProto(proto.getPrivateNotificationPayload()),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),

--- a/core/src/main/java/bisq/core/filter/FilterManager.java
+++ b/core/src/main/java/bisq/core/filter/FilterManager.java
@@ -222,6 +222,13 @@ public class FilterManager {
         });
     }
 
+    public void banNode(String nodeAddress){
+        List<String> bannedNodes = providersRepository.getBannedNodes();
+        bannedNodes.add(nodeAddress);
+        providersRepository.applyBannedNodes(bannedNodes);
+        saveBannedNodes(BANNED_SEED_NODES, bannedNodes);
+    }
+
     public void setFilterWarningHandler(Consumer<String> filterWarningHandler) {
         this.filterWarningHandler = filterWarningHandler;
 

--- a/core/src/main/java/bisq/core/network/CoreNetworkFilter.java
+++ b/core/src/main/java/bisq/core/network/CoreNetworkFilter.java
@@ -51,6 +51,12 @@ public class CoreNetworkFilter implements NetworkFilter {
     }
 
     @Override
+    public void banNode(NodeAddress nodeAddress) {
+        bannedPeersFromOptions.add(nodeAddress);
+
+    }
+
+    @Override
     public boolean isPeerBanned(NodeAddress nodeAddress) {
         return bannedPeersFromOptions.contains(nodeAddress) ||
                 bannedNodeFunction != null && bannedNodeFunction.apply(nodeAddress);

--- a/core/src/main/java/bisq/core/network/p2p/inventory/messages/GetInventoryRequest.java
+++ b/core/src/main/java/bisq/core/network/p2p/inventory/messages/GetInventoryRequest.java
@@ -39,7 +39,7 @@ public class GetInventoryRequest extends NetworkEnvelope {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private GetInventoryRequest(String version, int messageVersion) {
+    private GetInventoryRequest(String version, String messageVersion) {
         super(messageVersion);
 
         this.version = version;
@@ -53,7 +53,7 @@ public class GetInventoryRequest extends NetworkEnvelope {
                 .build();
     }
 
-    public static GetInventoryRequest fromProto(protobuf.GetInventoryRequest proto, int messageVersion) {
+    public static GetInventoryRequest fromProto(protobuf.GetInventoryRequest proto, String messageVersion) {
         return new GetInventoryRequest(proto.getVersion(), messageVersion);
     }
 }

--- a/core/src/main/java/bisq/core/network/p2p/inventory/messages/GetInventoryResponse.java
+++ b/core/src/main/java/bisq/core/network/p2p/inventory/messages/GetInventoryResponse.java
@@ -46,7 +46,7 @@ public class GetInventoryResponse extends NetworkEnvelope {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private GetInventoryResponse(Map<InventoryItem, String> inventory, int messageVersion) {
+    private GetInventoryResponse(Map<InventoryItem, String> inventory, String messageVersion) {
         super(messageVersion);
 
         this.inventory = inventory;
@@ -63,7 +63,7 @@ public class GetInventoryResponse extends NetworkEnvelope {
                 .build();
     }
 
-    public static GetInventoryResponse fromProto(protobuf.GetInventoryResponse proto, int messageVersion) {
+    public static GetInventoryResponse fromProto(protobuf.GetInventoryResponse proto, String messageVersion) {
         // For protobuf we use a map with a string key
         Map<String, String> map = proto.getInventoryMap();
         Map<InventoryItem, String> inventory = new HashMap<>();

--- a/core/src/main/java/bisq/core/offer/messages/OfferAvailabilityRequest.java
+++ b/core/src/main/java/bisq/core/offer/messages/OfferAvailabilityRequest.java
@@ -71,7 +71,7 @@ public final class OfferAvailabilityRequest extends OfferMessage implements Supp
                                      long takersTradePrice,
                                      boolean isTakerApiUser,
                                      @Nullable Capabilities supportedCapabilities,
-                                     int messageVersion,
+                                     String messageVersion,
                                      @Nullable String uid,
                                      InitTradeRequest tradeRequest) {
         super(messageVersion, offerId, uid);
@@ -81,7 +81,7 @@ public final class OfferAvailabilityRequest extends OfferMessage implements Supp
         this.supportedCapabilities = supportedCapabilities;
         this.tradeRequest = tradeRequest;
     }
-    
+
 //    @Override
 //    public protobuf.Offer toProtoMessage() {
 //        return protobuf.Offer.newBuilder().setOfferPayload(offerPayload.toProtoMessage().getOfferPayload()).build();
@@ -108,7 +108,7 @@ public final class OfferAvailabilityRequest extends OfferMessage implements Supp
                 .build();
     }
 
-    public static OfferAvailabilityRequest fromProto(protobuf.OfferAvailabilityRequest proto, CoreProtoResolver coreProtoResolver, int messageVersion) {
+    public static OfferAvailabilityRequest fromProto(protobuf.OfferAvailabilityRequest proto, CoreProtoResolver coreProtoResolver, String messageVersion) {
         return new OfferAvailabilityRequest(proto.getOfferId(),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),
                 proto.getTakersTradePrice(),

--- a/core/src/main/java/bisq/core/offer/messages/OfferAvailabilityResponse.java
+++ b/core/src/main/java/bisq/core/offer/messages/OfferAvailabilityResponse.java
@@ -69,7 +69,7 @@ public final class OfferAvailabilityResponse extends OfferMessage implements Sup
     private OfferAvailabilityResponse(String offerId,
                                       AvailabilityResult availabilityResult,
                                       @Nullable Capabilities supportedCapabilities,
-                                      int messageVersion,
+                                      String messageVersion,
                                       @Nullable String uid,
                                       String makerSignature,
                                       NodeAddress arbitratorNodeAddress) {
@@ -96,7 +96,7 @@ public final class OfferAvailabilityResponse extends OfferMessage implements Sup
                 .build();
     }
 
-    public static OfferAvailabilityResponse fromProto(protobuf.OfferAvailabilityResponse proto, int messageVersion) {
+    public static OfferAvailabilityResponse fromProto(protobuf.OfferAvailabilityResponse proto, String messageVersion) {
         return new OfferAvailabilityResponse(proto.getOfferId(),
                 ProtoUtil.enumFromProto(AvailabilityResult.class, proto.getAvailabilityResult().name()),
                 Capabilities.fromIntList(proto.getSupportedCapabilitiesList()),

--- a/core/src/main/java/bisq/core/offer/messages/OfferMessage.java
+++ b/core/src/main/java/bisq/core/offer/messages/OfferMessage.java
@@ -38,7 +38,7 @@ public abstract class OfferMessage extends NetworkEnvelope implements DirectMess
     @Nullable
     protected final String uid;
 
-    protected OfferMessage(int messageVersion, String offerId, @Nullable String uid) {
+    protected OfferMessage(String messageVersion, String offerId, @Nullable String uid) {
         super(messageVersion);
         this.offerId = offerId;
         this.uid = uid;

--- a/core/src/main/java/bisq/core/offer/messages/SignOfferRequest.java
+++ b/core/src/main/java/bisq/core/offer/messages/SignOfferRequest.java
@@ -46,7 +46,7 @@ public final class SignOfferRequest extends OfferMessage implements DirectMessag
                                      String senderAccountId,
                                      OfferPayload offerPayload,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate,
                                      String reserveTxHash,
                                      String reserveTxHex,
@@ -91,7 +91,7 @@ public final class SignOfferRequest extends OfferMessage implements DirectMessag
     }
 
     public static SignOfferRequest fromProto(protobuf.SignOfferRequest proto,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new SignOfferRequest(proto.getOfferId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/offer/messages/SignOfferResponse.java
+++ b/core/src/main/java/bisq/core/offer/messages/SignOfferResponse.java
@@ -29,7 +29,7 @@ public final class SignOfferResponse extends OfferMessage implements DirectMessa
 
     public SignOfferResponse(String offerId,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      OfferPayload signedOfferPayload) {
         super(messageVersion, offerId, uid);
         this.signedOfferPayload = signedOfferPayload;
@@ -51,7 +51,7 @@ public final class SignOfferResponse extends OfferMessage implements DirectMessa
     }
 
     public static SignOfferResponse fromProto(protobuf.SignOfferResponse proto,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new SignOfferResponse(proto.getOfferId(),
                 proto.getUid(),
                 messageVersion,

--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -106,7 +106,7 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
     @Override
     public NetworkEnvelope fromProto(protobuf.NetworkEnvelope proto) throws ProtobufferException {
         if (proto != null) {
-            final int messageVersion = proto.getMessageVersion();
+            final String messageVersion = proto.getMessageVersion();
             switch (proto.getMessageCase()) {
                 case PRELIMINARY_GET_DATA_REQUEST:
                     return PreliminaryGetDataRequest.fromProto(proto.getPreliminaryGetDataRequest(), messageVersion);

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/messages/ArbitrationMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/messages/ArbitrationMessage.java
@@ -21,7 +21,7 @@ import bisq.core.support.SupportType;
 import bisq.core.support.dispute.messages.DisputeMessage;
 
 abstract class ArbitrationMessage extends DisputeMessage {
-    ArbitrationMessage(int messageVersion, String uid, SupportType supportType) {
+    ArbitrationMessage(String messageVersion, String uid, SupportType supportType) {
         super(messageVersion, uid, supportType);
     }
 }

--- a/core/src/main/java/bisq/core/support/dispute/arbitration/messages/PeerPublishedDisputePayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/arbitration/messages/PeerPublishedDisputePayoutTxMessage.java
@@ -59,7 +59,7 @@ public final class PeerPublishedDisputePayoutTxMessage extends ArbitrationMessag
                                                 String tradeId,
                                                 NodeAddress senderNodeAddress,
                                                 String uid,
-                                                int messageVersion,
+                                                String messageVersion,
                                                 SupportType supportType) {
         super(messageVersion, uid, supportType);
         this.updatedMultisigHex = updatedMultisigHex;
@@ -82,7 +82,7 @@ public final class PeerPublishedDisputePayoutTxMessage extends ArbitrationMessag
     }
 
     public static PeerPublishedDisputePayoutTxMessage fromProto(protobuf.PeerPublishedDisputePayoutTxMessage proto,
-                                                                int messageVersion) {
+                                                                String messageVersion) {
         return new PeerPublishedDisputePayoutTxMessage(proto.getUpdatedMultisigHex(),
         		proto.getPayoutTxHex(),
                 proto.getTradeId(),

--- a/core/src/main/java/bisq/core/support/dispute/messages/ArbitratorPayoutTxRequest.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/ArbitratorPayoutTxRequest.java
@@ -56,7 +56,7 @@ public final class ArbitratorPayoutTxRequest extends DisputeMessage {
     private ArbitratorPayoutTxRequest(Dispute dispute,
                                   NodeAddress senderNodeAddress,
                                   String uid,
-                                  int messageVersion,
+                                  String messageVersion,
                                   SupportType supportType,
                                   String updatedMultisigHex) {
         super(messageVersion, uid, supportType);
@@ -79,7 +79,7 @@ public final class ArbitratorPayoutTxRequest extends DisputeMessage {
 
     public static ArbitratorPayoutTxRequest fromProto(protobuf.ArbitratorPayoutTxRequest proto,
                                                   CoreProtoResolver coreProtoResolver,
-                                                  int messageVersion) {
+                                                  String messageVersion) {
         return new ArbitratorPayoutTxRequest(Dispute.fromProto(proto.getDispute(), coreProtoResolver),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),

--- a/core/src/main/java/bisq/core/support/dispute/messages/ArbitratorPayoutTxResponse.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/ArbitratorPayoutTxResponse.java
@@ -55,7 +55,7 @@ public final class ArbitratorPayoutTxResponse extends DisputeMessage {
     private ArbitratorPayoutTxResponse(String tradeId,
                                   NodeAddress senderNodeAddress,
                                   String uid,
-                                  int messageVersion,
+                                  String messageVersion,
                                   SupportType supportType,
                                   String arbitratorSignedPayoutTxHex) {
         super(messageVersion, uid, supportType);
@@ -78,7 +78,7 @@ public final class ArbitratorPayoutTxResponse extends DisputeMessage {
 
     public static ArbitratorPayoutTxResponse fromProto(protobuf.ArbitratorPayoutTxResponse proto,
                                                   CoreProtoResolver coreProtoResolver,
-                                                  int messageVersion) {
+                                                  String messageVersion) {
         return new ArbitratorPayoutTxResponse(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),

--- a/core/src/main/java/bisq/core/support/dispute/messages/DisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/DisputeMessage.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class DisputeMessage extends SupportMessage {
     public static final long TTL = TimeUnit.DAYS.toMillis(15);
 
-    public DisputeMessage(int messageVersion, String uid, SupportType supportType) {
+    public DisputeMessage(String messageVersion, String uid, SupportType supportType) {
         super(messageVersion, uid, supportType);
     }
 

--- a/core/src/main/java/bisq/core/support/dispute/messages/DisputeResultMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/DisputeResultMessage.java
@@ -54,7 +54,7 @@ public final class DisputeResultMessage extends DisputeMessage {
     private DisputeResultMessage(DisputeResult disputeResult,
                                  NodeAddress senderNodeAddress,
                                  String uid,
-                                 int messageVersion,
+                                 String messageVersion,
                                  SupportType supportType) {
         super(messageVersion, uid, supportType);
         this.disputeResult = disputeResult;
@@ -72,7 +72,7 @@ public final class DisputeResultMessage extends DisputeMessage {
                 .build();
     }
 
-    public static DisputeResultMessage fromProto(protobuf.DisputeResultMessage proto, int messageVersion) {
+    public static DisputeResultMessage fromProto(protobuf.DisputeResultMessage proto, String messageVersion) {
         checkArgument(proto.hasDisputeResult(), "DisputeResult must be set");
         return new DisputeResultMessage(DisputeResult.fromProto(proto.getDisputeResult()),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),

--- a/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/OpenNewDisputeMessage.java
@@ -56,7 +56,7 @@ public final class OpenNewDisputeMessage extends DisputeMessage {
     private OpenNewDisputeMessage(Dispute dispute,
                                   NodeAddress senderNodeAddress,
                                   String uid,
-                                  int messageVersion,
+                                  String messageVersion,
                                   SupportType supportType,
                                   String updatedMultisigHex) {
         super(messageVersion, uid, supportType);
@@ -79,7 +79,7 @@ public final class OpenNewDisputeMessage extends DisputeMessage {
 
     public static OpenNewDisputeMessage fromProto(protobuf.OpenNewDisputeMessage proto,
                                                   CoreProtoResolver coreProtoResolver,
-                                                  int messageVersion) {
+                                                  String messageVersion) {
         return new OpenNewDisputeMessage(Dispute.fromProto(proto.getDispute(), coreProtoResolver),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),

--- a/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
+++ b/core/src/main/java/bisq/core/support/dispute/messages/PeerOpenedDisputeMessage.java
@@ -53,7 +53,7 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage {
     private PeerOpenedDisputeMessage(Dispute dispute,
                                      NodeAddress senderNodeAddress,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      SupportType supportType) {
         super(messageVersion, uid, supportType);
         this.dispute = dispute;
@@ -71,7 +71,7 @@ public final class PeerOpenedDisputeMessage extends DisputeMessage {
                 .build();
     }
 
-    public static PeerOpenedDisputeMessage fromProto(protobuf.PeerOpenedDisputeMessage proto, CoreProtoResolver coreProtoResolver, int messageVersion) {
+    public static PeerOpenedDisputeMessage fromProto(protobuf.PeerOpenedDisputeMessage proto, CoreProtoResolver coreProtoResolver, String messageVersion) {
         return new PeerOpenedDisputeMessage(Dispute.fromProto(proto.getDispute(), coreProtoResolver),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getUid(),

--- a/core/src/main/java/bisq/core/support/messages/ChatMessage.java
+++ b/core/src/main/java/bisq/core/support/messages/ChatMessage.java
@@ -183,7 +183,7 @@ public final class ChatMessage extends SupportMessage {
                         boolean arrived,
                         boolean storedInMailbox,
                         String uid,
-                        int messageVersion,
+                        String messageVersion,
                         boolean acknowledged,
                         @Nullable String sendMessageError,
                         @Nullable String ackError,
@@ -232,7 +232,7 @@ public final class ChatMessage extends SupportMessage {
 
     // The protobuf definition ChatMessage cannot be changed as it would break backward compatibility.
     public static ChatMessage fromProto(protobuf.ChatMessage proto,
-                                        int messageVersion) {
+                                        String messageVersion) {
         // If we get a msg from an old client type will be ordinal 0 which is the dispute entry and as we only added
         // the trade case it is the desired behaviour.
         final ChatMessage chatMessage = new ChatMessage(
@@ -261,7 +261,7 @@ public final class ChatMessage extends SupportMessage {
         // We don't check the message version here as it was checked in the carrier envelope already (in connection class)
         // Payloads don't have a message version and are also used for persistence
         // We set the value to -1 to indicate it is set but irrelevant
-        return fromProto(proto, -1);
+        return fromProto(proto, "-1");
     }
 
 

--- a/core/src/main/java/bisq/core/support/messages/SupportMessage.java
+++ b/core/src/main/java/bisq/core/support/messages/SupportMessage.java
@@ -35,7 +35,7 @@ public abstract class SupportMessage extends NetworkEnvelope implements MailboxM
     // Added with v1.1.6. Old clients will not have set that field and we fall back to entry 0 which is ARBITRATION.
     protected final SupportType supportType;
 
-    public SupportMessage(int messageVersion, String uid, SupportType supportType) {
+    public SupportMessage(String messageVersion, String uid, SupportType supportType) {
         super(messageVersion);
         this.uid = uid;
         this.supportType = supportType;

--- a/core/src/main/java/bisq/core/trade/messages/CounterCurrencyTransferStartedMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/CounterCurrencyTransferStartedMessage.java
@@ -72,7 +72,7 @@ public final class CounterCurrencyTransferStartedMessage extends TradeMailboxMes
                                                   @Nullable String counterCurrencyTxId,
                                                   @Nullable String counterCurrencyExtraData,
                                                   String uid,
-                                                  int messageVersion) {
+                                                  String messageVersion) {
         super(messageVersion, tradeId, uid);
         this.buyerPayoutAddress = buyerPayoutAddress;
         this.senderNodeAddress = senderNodeAddress;
@@ -97,7 +97,7 @@ public final class CounterCurrencyTransferStartedMessage extends TradeMailboxMes
     }
 
     public static CounterCurrencyTransferStartedMessage fromProto(protobuf.CounterCurrencyTransferStartedMessage proto,
-                                                                  int messageVersion) {
+                                                                  String messageVersion) {
         return new CounterCurrencyTransferStartedMessage(proto.getTradeId(),
                 proto.getBuyerPayoutAddress(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),

--- a/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureRequest.java
@@ -52,7 +52,7 @@ public final class DelayedPayoutTxSignatureRequest extends TradeMessage implemen
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private DelayedPayoutTxSignatureRequest(int messageVersion,
+    private DelayedPayoutTxSignatureRequest(String messageVersion,
                                             String uid,
                                             String tradeId,
                                             NodeAddress senderNodeAddress,
@@ -78,7 +78,7 @@ public final class DelayedPayoutTxSignatureRequest extends TradeMessage implemen
     }
 
     public static DelayedPayoutTxSignatureRequest fromProto(protobuf.DelayedPayoutTxSignatureRequest proto,
-                                                            int messageVersion) {
+                                                            String messageVersion) {
         return new DelayedPayoutTxSignatureRequest(messageVersion,
                 proto.getUid(),
                 proto.getTradeId(),

--- a/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureResponse.java
+++ b/core/src/main/java/bisq/core/trade/messages/DelayedPayoutTxSignatureResponse.java
@@ -52,7 +52,7 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private DelayedPayoutTxSignatureResponse(int messageVersion,
+    private DelayedPayoutTxSignatureResponse(String messageVersion,
                                              String uid,
                                              String tradeId,
                                              NodeAddress senderNodeAddress,
@@ -79,7 +79,7 @@ public final class DelayedPayoutTxSignatureResponse extends TradeMessage impleme
     }
 
     public static DelayedPayoutTxSignatureResponse fromProto(protobuf.DelayedPayoutTxSignatureResponse proto,
-                                                             int messageVersion) {
+                                                             String messageVersion) {
         return new DelayedPayoutTxSignatureResponse(messageVersion,
                 proto.getUid(),
                 proto.getTradeId(),

--- a/core/src/main/java/bisq/core/trade/messages/DepositRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/DepositRequest.java
@@ -41,7 +41,7 @@ public final class DepositRequest extends TradeMessage implements DirectMessage 
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate,
                                      String contractSignature,
                                      String depositTxHex,
@@ -77,7 +77,7 @@ public final class DepositRequest extends TradeMessage implements DirectMessage 
 
     public static DepositRequest fromProto(protobuf.DepositRequest proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new DepositRequest(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/trade/messages/DepositResponse.java
+++ b/core/src/main/java/bisq/core/trade/messages/DepositResponse.java
@@ -38,7 +38,7 @@ public final class DepositResponse extends TradeMessage implements DirectMessage
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
@@ -65,7 +65,7 @@ public final class DepositResponse extends TradeMessage implements DirectMessage
 
     public static DepositResponse fromProto(protobuf.DepositResponse proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new DepositResponse(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/trade/messages/DepositTxAndDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/DepositTxAndDelayedPayoutTxMessage.java
@@ -53,7 +53,7 @@ public final class DepositTxAndDelayedPayoutTxMessage extends TradeMailboxMessag
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private DepositTxAndDelayedPayoutTxMessage(int messageVersion,
+    private DepositTxAndDelayedPayoutTxMessage(String messageVersion,
                                                String uid,
                                                String tradeId,
                                                NodeAddress senderNodeAddress,
@@ -78,7 +78,7 @@ public final class DepositTxAndDelayedPayoutTxMessage extends TradeMailboxMessag
     }
 
     public static DepositTxAndDelayedPayoutTxMessage fromProto(protobuf.DepositTxAndDelayedPayoutTxMessage proto,
-                                                               int messageVersion) {
+                                                               String messageVersion) {
         return new DepositTxAndDelayedPayoutTxMessage(messageVersion,
                 proto.getUid(),
                 proto.getTradeId(),

--- a/core/src/main/java/bisq/core/trade/messages/DepositTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/DepositTxMessage.java
@@ -67,7 +67,7 @@ public final class DepositTxMessage extends TradeMessage implements DirectMessag
       return getNetworkEnvelopeBuilder().setDepositTxMessage(builder).build();
     }
 
-    public static DepositTxMessage fromProto(protobuf.DepositTxMessage proto, int messageVersion) {
+    public static DepositTxMessage fromProto(protobuf.DepositTxMessage proto, String messageVersion) {
         return new DepositTxMessage(proto.getUid(),
                 proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),

--- a/core/src/main/java/bisq/core/trade/messages/InitMultisigRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/InitMultisigRequest.java
@@ -47,7 +47,7 @@ public final class InitMultisigRequest extends TradeMessage implements DirectMes
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate,
                                      String preparedMultisigHex,
                                      String madeMultisigHex) {
@@ -82,7 +82,7 @@ public final class InitMultisigRequest extends TradeMessage implements DirectMes
 
     public static InitMultisigRequest fromProto(protobuf.InitMultisigRequest proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new InitMultisigRequest(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/trade/messages/InitTradeRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/InitTradeRequest.java
@@ -78,7 +78,7 @@ public final class InitTradeRequest extends TradeMessage implements DirectMessag
                                      String paymentAccountId,
                                      String paymentMethodId,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      @Nullable byte[] accountAgeWitnessSignatureOfOfferId,
                                      long currentDate,
                                      NodeAddress makerNodeAddress,
@@ -145,7 +145,7 @@ public final class InitTradeRequest extends TradeMessage implements DirectMessag
 
     public static InitTradeRequest fromProto(protobuf.InitTradeRequest proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new InitTradeRequest(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/trade/messages/InputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/InputsForDepositTxRequest.java
@@ -90,7 +90,7 @@ public final class InputsForDepositTxRequest extends TradeMessage implements Dir
                                      NodeAddress mediatorNodeAddress,
                                      NodeAddress refundAgentNodeAddress,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      byte[] accountAgeWitnessSignatureOfOfferId,
                                      long currentDate) {
         super(messageVersion, tradeId, uid);
@@ -160,7 +160,7 @@ public final class InputsForDepositTxRequest extends TradeMessage implements Dir
 
     public static InputsForDepositTxRequest fromProto(protobuf.InputsForDepositTxRequest proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         List<RawTransactionInput> rawTransactionInputs = proto.getRawTransactionInputsList().stream()
                 .map(rawTransactionInput -> new RawTransactionInput(rawTransactionInput.getIndex(),
                         rawTransactionInput.getParentTransaction().toByteArray(), rawTransactionInput.getValue()))

--- a/core/src/main/java/bisq/core/trade/messages/InputsForDepositTxResponse.java
+++ b/core/src/main/java/bisq/core/trade/messages/InputsForDepositTxResponse.java
@@ -106,7 +106,7 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                                        List<RawTransactionInput> makerInputs,
                                        NodeAddress senderNodeAddress,
                                        String uid,
-                                       int messageVersion,
+                                       String messageVersion,
                                        @Nullable byte[] accountAgeWitnessSignatureOfPreparedDepositTx,
                                        long currentDate,
                                        long lockTime) {
@@ -149,7 +149,7 @@ public final class InputsForDepositTxResponse extends TradeMessage implements Di
                 .build();
     }
 
-    public static InputsForDepositTxResponse fromProto(protobuf.InputsForDepositTxResponse proto, CoreProtoResolver coreProtoResolver, int messageVersion) {
+    public static InputsForDepositTxResponse fromProto(protobuf.InputsForDepositTxResponse proto, CoreProtoResolver coreProtoResolver, String messageVersion) {
         List<RawTransactionInput> makerInputs = proto.getMakerInputsList().stream()
                 .map(RawTransactionInput::fromProto)
                 .collect(Collectors.toList());

--- a/core/src/main/java/bisq/core/trade/messages/MediatedPayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/MediatedPayoutTxPublishedMessage.java
@@ -54,7 +54,7 @@ public final class MediatedPayoutTxPublishedMessage extends TradeMailboxMessage 
                                              byte[] payoutTx,
                                              NodeAddress senderNodeAddress,
                                              String uid,
-                                             int messageVersion) {
+                                             String messageVersion) {
         super(messageVersion, tradeId, uid);
         this.payoutTx = payoutTx;
         this.senderNodeAddress = senderNodeAddress;
@@ -71,7 +71,7 @@ public final class MediatedPayoutTxPublishedMessage extends TradeMailboxMessage 
                 .build();
     }
 
-    public static NetworkEnvelope fromProto(protobuf.MediatedPayoutTxPublishedMessage proto, int messageVersion) {
+    public static NetworkEnvelope fromProto(protobuf.MediatedPayoutTxPublishedMessage proto, String messageVersion) {
         return new MediatedPayoutTxPublishedMessage(proto.getTradeId(),
                 proto.getPayoutTx().toByteArray(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),

--- a/core/src/main/java/bisq/core/trade/messages/MediatedPayoutTxSignatureMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/MediatedPayoutTxSignatureMessage.java
@@ -55,7 +55,7 @@ public class MediatedPayoutTxSignatureMessage extends TradeMailboxMessage {
                                              String tradeId,
                                              NodeAddress senderNodeAddress,
                                              String uid,
-                                             int messageVersion) {
+                                             String messageVersion) {
         super(messageVersion, tradeId, uid);
         this.txSignature = txSignature;
         this.senderNodeAddress = senderNodeAddress;
@@ -73,7 +73,7 @@ public class MediatedPayoutTxSignatureMessage extends TradeMailboxMessage {
     }
 
     public static MediatedPayoutTxSignatureMessage fromProto(protobuf.MediatedPayoutTxSignatureMessage proto,
-                                                             int messageVersion) {
+                                                             String messageVersion) {
         return new MediatedPayoutTxSignatureMessage(proto.getTxSignature().toByteArray(),
                 proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),

--- a/core/src/main/java/bisq/core/trade/messages/PaymentAccountPayloadRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/PaymentAccountPayloadRequest.java
@@ -40,7 +40,7 @@ public final class PaymentAccountPayloadRequest extends TradeMessage implements 
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate,
                                      PaymentAccountPayload paymentAccountPayload) {
         super(messageVersion, tradeId, uid);
@@ -70,7 +70,7 @@ public final class PaymentAccountPayloadRequest extends TradeMessage implements 
 
     public static PaymentAccountPayloadRequest fromProto(protobuf.PaymentAccountPayloadRequest proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new PaymentAccountPayloadRequest(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/trade/messages/PayoutTxPublishedMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/PayoutTxPublishedMessage.java
@@ -66,7 +66,7 @@ public final class PayoutTxPublishedMessage extends TradeMailboxMessage {
                                      NodeAddress senderNodeAddress,
                                      @Nullable SignedWitness signedWitness,
                                      String uid,
-                                     int messageVersion) {
+                                     String messageVersion) {
         super(messageVersion, tradeId, uid);
         this.signedMultisigTxHex = signedMultisigTxHex;
         this.senderNodeAddress = senderNodeAddress;
@@ -84,7 +84,7 @@ public final class PayoutTxPublishedMessage extends TradeMailboxMessage {
         return getNetworkEnvelopeBuilder().setPayoutTxPublishedMessage(builder).build();
     }
 
-    public static NetworkEnvelope fromProto(protobuf.PayoutTxPublishedMessage proto, int messageVersion) {
+    public static NetworkEnvelope fromProto(protobuf.PayoutTxPublishedMessage proto, String messageVersion) {
         // There is no method to check for a nullable non-primitive data type object but we know that all fields
         // are empty/null, so we check for the signature to see if we got a valid signedWitness.
         protobuf.SignedWitness protoSignedWitness = proto.getSignedWitness();

--- a/core/src/main/java/bisq/core/trade/messages/PeerPublishedDelayedPayoutTxMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/PeerPublishedDelayedPayoutTxMessage.java
@@ -43,7 +43,7 @@ public final class PeerPublishedDelayedPayoutTxMessage extends TradeMailboxMessa
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private PeerPublishedDelayedPayoutTxMessage(int messageVersion,
+    private PeerPublishedDelayedPayoutTxMessage(String messageVersion,
                                                 String uid,
                                                 String tradeId,
                                                 NodeAddress senderNodeAddress) {
@@ -60,7 +60,7 @@ public final class PeerPublishedDelayedPayoutTxMessage extends TradeMailboxMessa
         return getNetworkEnvelopeBuilder().setPeerPublishedDelayedPayoutTxMessage(builder).build();
     }
 
-    public static PeerPublishedDelayedPayoutTxMessage fromProto(protobuf.PeerPublishedDelayedPayoutTxMessage proto, int messageVersion) {
+    public static PeerPublishedDelayedPayoutTxMessage fromProto(protobuf.PeerPublishedDelayedPayoutTxMessage proto, String messageVersion) {
         return new PeerPublishedDelayedPayoutTxMessage(messageVersion,
                 proto.getUid(),
                 proto.getTradeId(),

--- a/core/src/main/java/bisq/core/trade/messages/RefreshTradeStateRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/RefreshTradeStateRequest.java
@@ -39,7 +39,7 @@ public class RefreshTradeStateRequest extends TradeMailboxMessage {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private RefreshTradeStateRequest(int messageVersion,
+    private RefreshTradeStateRequest(String messageVersion,
                                      String uid,
                                      String tradeId,
                                      NodeAddress senderNodeAddress) {
@@ -56,7 +56,7 @@ public class RefreshTradeStateRequest extends TradeMailboxMessage {
         return getNetworkEnvelopeBuilder().setRefreshTradeStateRequest(builder).build();
     }
 
-    public static RefreshTradeStateRequest fromProto(protobuf.RefreshTradeStateRequest proto, int messageVersion) {
+    public static RefreshTradeStateRequest fromProto(protobuf.RefreshTradeStateRequest proto, String messageVersion) {
         return new RefreshTradeStateRequest(messageVersion,
                 proto.getUid(),
                 proto.getTradeId(),

--- a/core/src/main/java/bisq/core/trade/messages/SignContractRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/SignContractRequest.java
@@ -42,7 +42,7 @@ public final class SignContractRequest extends TradeMessage implements DirectMes
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate,
                                      String accountId,
                                      byte[] paymentAccountPayloadHash,
@@ -82,7 +82,7 @@ public final class SignContractRequest extends TradeMessage implements DirectMes
 
     public static SignContractRequest fromProto(protobuf.SignContractRequest proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new SignContractRequest(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/trade/messages/SignContractResponse.java
+++ b/core/src/main/java/bisq/core/trade/messages/SignContractResponse.java
@@ -44,7 +44,7 @@ public final class SignContractResponse extends TradeMessage implements DirectMe
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate,
                                      String contractSignature) {
         super(messageVersion, tradeId, uid);
@@ -76,7 +76,7 @@ public final class SignContractResponse extends TradeMessage implements DirectMe
 
     public static SignContractResponse fromProto(protobuf.SignContractResponse proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new SignContractResponse(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/trade/messages/TradeMailboxMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/TradeMailboxMessage.java
@@ -29,7 +29,7 @@ import lombok.ToString;
 public abstract class TradeMailboxMessage extends TradeMessage implements MailboxMessage {
     public static final long TTL = TimeUnit.DAYS.toMillis(15);
 
-    protected TradeMailboxMessage(int messageVersion, String tradeId, String uid) {
+    protected TradeMailboxMessage(String messageVersion, String tradeId, String uid) {
         super(messageVersion, tradeId, uid);
     }
 

--- a/core/src/main/java/bisq/core/trade/messages/TradeMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/TradeMessage.java
@@ -32,7 +32,7 @@ public abstract class TradeMessage extends NetworkEnvelope implements UidMessage
     protected final String tradeId;
     protected final String uid;
 
-    protected TradeMessage(int messageVersion, String tradeId, String uid) {
+    protected TradeMessage(String messageVersion, String tradeId, String uid) {
         super(messageVersion);
         this.tradeId = tradeId;
         this.uid = uid;

--- a/core/src/main/java/bisq/core/trade/messages/TraderSignedWitnessMessage.java
+++ b/core/src/main/java/bisq/core/trade/messages/TraderSignedWitnessMessage.java
@@ -53,7 +53,7 @@ public class TraderSignedWitnessMessage extends TradeMailboxMessage {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private TraderSignedWitnessMessage(int messageVersion,
+    private TraderSignedWitnessMessage(String messageVersion,
                                        String uid,
                                        String tradeId,
                                        NodeAddress senderNodeAddress,
@@ -73,7 +73,7 @@ public class TraderSignedWitnessMessage extends TradeMailboxMessage {
         return getNetworkEnvelopeBuilder().setTraderSignedWitnessMessage(builder).build();
     }
 
-    public static TraderSignedWitnessMessage fromProto(protobuf.TraderSignedWitnessMessage proto, int messageVersion) {
+    public static TraderSignedWitnessMessage fromProto(protobuf.TraderSignedWitnessMessage proto, String messageVersion) {
         return new TraderSignedWitnessMessage(messageVersion,
                 proto.getUid(),
                 proto.getTradeId(),

--- a/core/src/main/java/bisq/core/trade/messages/UpdateMultisigRequest.java
+++ b/core/src/main/java/bisq/core/trade/messages/UpdateMultisigRequest.java
@@ -45,7 +45,7 @@ public final class UpdateMultisigRequest extends TradeMessage implements DirectM
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate,
                                      String updatedMultisigHex) {
         super(messageVersion, tradeId, uid);
@@ -77,7 +77,7 @@ public final class UpdateMultisigRequest extends TradeMessage implements DirectM
 
     public static UpdateMultisigRequest fromProto(protobuf.UpdateMultisigRequest proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new UpdateMultisigRequest(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/core/src/main/java/bisq/core/trade/messages/UpdateMultisigResponse.java
+++ b/core/src/main/java/bisq/core/trade/messages/UpdateMultisigResponse.java
@@ -45,7 +45,7 @@ public final class UpdateMultisigResponse extends TradeMessage implements Direct
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
-                                     int messageVersion,
+                                     String messageVersion,
                                      long currentDate,
                                      String updatedMultisigHex) {
         super(messageVersion, tradeId, uid);
@@ -77,7 +77,7 @@ public final class UpdateMultisigResponse extends TradeMessage implements Direct
 
     public static UpdateMultisigResponse fromProto(protobuf.UpdateMultisigResponse proto,
                                                       CoreProtoResolver coreProtoResolver,
-                                                      int messageVersion) {
+                                                      String messageVersion) {
         return new UpdateMultisigResponse(proto.getTradeId(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 PubKeyRing.fromProto(proto.getPubKeyRing()),

--- a/p2p/src/main/java/bisq/network/p2p/AckMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/AckMessage.java
@@ -98,7 +98,7 @@ public final class AckMessage extends NetworkEnvelope implements MailboxMessage,
                        String sourceId,
                        boolean success,
                        @Nullable String errorMessage,
-                       int messageVersion) {
+                       String messageVersion) {
         super(messageVersion);
         this.uid = uid;
         this.senderNodeAddress = senderNodeAddress;
@@ -132,7 +132,7 @@ public final class AckMessage extends NetworkEnvelope implements MailboxMessage,
         return builder;
     }
 
-    public static AckMessage fromProto(protobuf.AckMessage proto, int messageVersion) {
+    public static AckMessage fromProto(protobuf.AckMessage proto, String messageVersion) {
         AckMessageSourceType sourceType = ProtoUtil.enumFromProto(AckMessageSourceType.class, proto.getSourceType());
         return new AckMessage(proto.getUid(),
                 NodeAddress.fromProto(proto.getSenderNodeAddress()),

--- a/p2p/src/main/java/bisq/network/p2p/BundleOfEnvelopes.java
+++ b/p2p/src/main/java/bisq/network/p2p/BundleOfEnvelopes.java
@@ -57,7 +57,7 @@ public final class BundleOfEnvelopes extends BroadcastMessage implements Extende
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private BundleOfEnvelopes(List<NetworkEnvelope> envelopes, int messageVersion) {
+    private BundleOfEnvelopes(List<NetworkEnvelope> envelopes, String messageVersion) {
         super(messageVersion);
         this.envelopes = envelopes;
     }
@@ -74,7 +74,7 @@ public final class BundleOfEnvelopes extends BroadcastMessage implements Extende
 
     public static BundleOfEnvelopes fromProto(protobuf.BundleOfEnvelopes proto,
                                               NetworkProtoResolver resolver,
-                                              int messageVersion) {
+                                              String messageVersion) {
         List<NetworkEnvelope> envelopes = proto.getEnvelopesList()
                 .stream()
                 .map(envelope -> {

--- a/p2p/src/main/java/bisq/network/p2p/CloseConnectionMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/CloseConnectionMessage.java
@@ -37,7 +37,7 @@ public final class CloseConnectionMessage extends NetworkEnvelope {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private CloseConnectionMessage(String reason, int messageVersion) {
+    private CloseConnectionMessage(String reason, String messageVersion) {
         super(messageVersion);
         this.reason = reason;
     }
@@ -51,7 +51,7 @@ public final class CloseConnectionMessage extends NetworkEnvelope {
                 .build();
     }
 
-    public static CloseConnectionMessage fromProto(protobuf.CloseConnectionMessage proto, int messageVersion) {
+    public static CloseConnectionMessage fromProto(protobuf.CloseConnectionMessage proto, String messageVersion) {
         return new CloseConnectionMessage(proto.getReason(), messageVersion);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/PrefixedSealedAndSignedMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/PrefixedSealedAndSignedMessage.java
@@ -64,7 +64,7 @@ public final class PrefixedSealedAndSignedMessage extends NetworkEnvelope implem
                                            SealedAndSigned sealedAndSigned,
                                            byte[] addressPrefixHash,
                                            String uid,
-                                           int messageVersion) {
+                                           String messageVersion) {
         super(messageVersion);
         this.senderNodeAddress = checkNotNull(senderNodeAddress, "senderNodeAddress must not be null");
         this.sealedAndSigned = sealedAndSigned;
@@ -84,7 +84,7 @@ public final class PrefixedSealedAndSignedMessage extends NetworkEnvelope implem
     }
 
     public static PrefixedSealedAndSignedMessage fromProto(protobuf.PrefixedSealedAndSignedMessage proto,
-                                                           int messageVersion) {
+                                                           String messageVersion) {
         return new PrefixedSealedAndSignedMessage(NodeAddress.fromProto(proto.getNodeAddress()),
                 SealedAndSigned.fromProto(proto.getSealedAndSigned()),
                 proto.getAddressPrefixHash().toByteArray(),
@@ -101,7 +101,7 @@ public final class PrefixedSealedAndSignedMessage extends NetworkEnvelope implem
                 SealedAndSigned.fromProto(proto.getSealedAndSigned()),
                 proto.getAddressPrefixHash().toByteArray(),
                 proto.getUid(),
-                -1);
+                "-1");
     }
 
     @Override

--- a/p2p/src/main/java/bisq/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/Connection.java
@@ -50,6 +50,8 @@ import javax.inject.Inject;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
@@ -81,6 +83,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 
 import java.lang.ref.WeakReference;
 
@@ -842,12 +845,16 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         return;
 
                     // Check P2P network ID
-                    if (proto.getMessageVersion() != Version.getP2PMessageVersion()
-                            && reportInvalidRequest(RuleViolation.WRONG_NETWORK_ID)) {
+                    boolean comparison = proto.getMessageVersion().compareTo(Version.getP2PMessageVersion()) == 0 ? true : false;
+
+                    if (!comparison && reportInvalidRequest(RuleViolation.WRONG_NETWORK_ID)) {
                         log.warn("RuleViolation.WRONG_NETWORK_ID. version of message={}, app version={}, " +
                                         "proto.toTruncatedString={}", proto.getMessageVersion(),
                                 Version.getP2PMessageVersion(),
                                 Utilities.toTruncatedString(proto.toString()));
+                        if (StringUtils.isNumeric(proto.getMessageVersion()) || proto.getMessageVersion().compareTo("") == 0 ? true : false || proto.getMessageVersion().compareTo(" ") == 0 ? true : false )
+                            log.warn("Peer NETWORK_ID is numeric. Bisq seednode detected, adding peer {} to BANNED_SEED_NODES", peersNodeAddressOptional.get());
+                            networkFilter.banNode(peersNodeAddressOptional.get());
                         return;
                     }
 

--- a/p2p/src/main/java/bisq/network/p2p/network/NetworkFilter.java
+++ b/p2p/src/main/java/bisq/network/p2p/network/NetworkFilter.java
@@ -25,4 +25,6 @@ public interface NetworkFilter {
     boolean isPeerBanned(NodeAddress nodeAddress);
 
     void setBannedNodeFunction(Function<NodeAddress, Boolean> isNodeAddressBanned);
+
+    void banNode(NodeAddress nodeAddress);
 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataRequest.java
@@ -44,7 +44,7 @@ public abstract class GetDataRequest extends NetworkEnvelope implements Extended
     @Nullable
     protected final String version;
 
-    public GetDataRequest(int messageVersion,
+    public GetDataRequest(String messageVersion,
                           int nonce,
                           Set<byte[]> excludedKeys,
                           @Nullable String version) {

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetDataResponse.java
@@ -77,7 +77,7 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
                             int requestNonce,
                             boolean isGetUpdatedDataResponse,
                             @NotNull Capabilities supportedCapabilities,
-                            int messageVersion) {
+                            String messageVersion) {
         super(messageVersion);
 
         this.dataSet = dataSet;
@@ -116,7 +116,7 @@ public final class GetDataResponse extends NetworkEnvelope implements SupportedC
 
     public static GetDataResponse fromProto(protobuf.GetDataResponse proto,
                                             NetworkProtoResolver resolver,
-                                            int messageVersion) {
+                                            String messageVersion) {
         log.info("Received a GetDataResponse with {}", Utilities.readableFileSize(proto.getSerializedSize()));
         Set<ProtectedStorageEntry> dataSet = proto.getDataSetList().stream()
                 .map(entry -> (ProtectedStorageEntry) resolver.fromProto(entry)).collect(Collectors.toSet());

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/GetUpdatedDataRequest.java
@@ -62,7 +62,7 @@ public final class GetUpdatedDataRequest extends GetDataRequest implements Sende
                                   int nonce,
                                   Set<byte[]> excludedKeys,
                                   @Nullable String version,
-                                  int messageVersion) {
+                                  String messageVersion) {
         super(messageVersion,
                 nonce,
                 excludedKeys,
@@ -87,7 +87,7 @@ public final class GetUpdatedDataRequest extends GetDataRequest implements Sende
         return proto;
     }
 
-    public static GetUpdatedDataRequest fromProto(protobuf.GetUpdatedDataRequest proto, int messageVersion) {
+    public static GetUpdatedDataRequest fromProto(protobuf.GetUpdatedDataRequest proto, String messageVersion) {
         Set<byte[]> excludedKeys = ProtoUtil.byteSetFromProtoByteStringList(proto.getExcludedKeysList());
         String requestersVersion = ProtoUtil.stringOrNullFromProto(proto.getVersion());
         log.info("Received a GetUpdatedDataRequest with {} kB and {} excluded key entries. Requesters version={}",

--- a/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/getdata/messages/PreliminaryGetDataRequest.java
@@ -61,7 +61,7 @@ public final class PreliminaryGetDataRequest extends GetDataRequest implements A
                                       Set<byte[]> excludedKeys,
                                       @Nullable String version,
                                       Capabilities supportedCapabilities,
-                                      int messageVersion) {
+                                      String messageVersion) {
         super(messageVersion, nonce, excludedKeys, version);
 
         this.supportedCapabilities = supportedCapabilities;
@@ -84,7 +84,7 @@ public final class PreliminaryGetDataRequest extends GetDataRequest implements A
         return proto;
     }
 
-    public static PreliminaryGetDataRequest fromProto(protobuf.PreliminaryGetDataRequest proto, int messageVersion) {
+    public static PreliminaryGetDataRequest fromProto(protobuf.PreliminaryGetDataRequest proto, String messageVersion) {
         Set<byte[]> excludedKeys = ProtoUtil.byteSetFromProtoByteStringList(proto.getExcludedKeysList());
         String requestersVersion = ProtoUtil.stringOrNullFromProto(proto.getVersion());
         log.info("Received a PreliminaryGetDataRequest with {} kB and {} excluded key entries. Requesters version={}",

--- a/p2p/src/main/java/bisq/network/p2p/peers/keepalive/messages/Ping.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/keepalive/messages/Ping.java
@@ -38,7 +38,7 @@ public final class Ping extends NetworkEnvelope implements KeepAliveMessage {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private Ping(int nonce, int lastRoundTripTime, int messageVersion) {
+    private Ping(int nonce, int lastRoundTripTime, String messageVersion) {
         super(messageVersion);
         this.nonce = nonce;
         this.lastRoundTripTime = lastRoundTripTime;
@@ -53,7 +53,7 @@ public final class Ping extends NetworkEnvelope implements KeepAliveMessage {
                 .build();
     }
 
-    public static Ping fromProto(protobuf.Ping proto, int messageVersion) {
+    public static Ping fromProto(protobuf.Ping proto, String messageVersion) {
         return new Ping(proto.getNonce(), proto.getLastRoundTripTime(), messageVersion);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/keepalive/messages/Pong.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/keepalive/messages/Pong.java
@@ -37,7 +37,7 @@ public final class Pong extends NetworkEnvelope implements KeepAliveMessage {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private Pong(int requestNonce, int messageVersion) {
+    private Pong(int requestNonce, String messageVersion) {
         super(messageVersion);
         this.requestNonce = requestNonce;
     }
@@ -50,7 +50,7 @@ public final class Pong extends NetworkEnvelope implements KeepAliveMessage {
                 .build();
     }
 
-    public static Pong fromProto(protobuf.Pong proto, int messageVersion) {
+    public static Pong fromProto(protobuf.Pong proto, String messageVersion) {
         return new Pong(proto.getRequestNonce(), messageVersion);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersRequest.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersRequest.java
@@ -66,7 +66,7 @@ public final class GetPeersRequest extends NetworkEnvelope implements PeerExchan
                             int nonce,
                             Set<Peer> reportedPeers,
                             @Nullable Capabilities supportedCapabilities,
-                            int messageVersion) {
+                            String messageVersion) {
         super(messageVersion);
         checkNotNull(senderNodeAddress, "senderNodeAddress must not be null at GetPeersRequest");
         this.senderNodeAddress = senderNodeAddress;
@@ -93,7 +93,7 @@ public final class GetPeersRequest extends NetworkEnvelope implements PeerExchan
                 .build();
     }
 
-    public static GetPeersRequest fromProto(protobuf.GetPeersRequest proto, int messageVersion) {
+    public static GetPeersRequest fromProto(protobuf.GetPeersRequest proto, String messageVersion) {
         return new GetPeersRequest(NodeAddress.fromProto(proto.getSenderNodeAddress()),
                 proto.getNonce(),
                 new HashSet<>(proto.getReportedPeersList().stream()

--- a/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersResponse.java
+++ b/p2p/src/main/java/bisq/network/p2p/peers/peerexchange/messages/GetPeersResponse.java
@@ -59,7 +59,7 @@ public final class GetPeersResponse extends NetworkEnvelope implements PeerExcha
     private GetPeersResponse(int requestNonce,
                              Set<Peer> reportedPeers,
                              @Nullable Capabilities supportedCapabilities,
-                             int messageVersion) {
+                             String messageVersion) {
         super(messageVersion);
         this.requestNonce = requestNonce;
         this.reportedPeers = reportedPeers;
@@ -83,7 +83,7 @@ public final class GetPeersResponse extends NetworkEnvelope implements PeerExcha
                 .build();
     }
 
-    public static GetPeersResponse fromProto(protobuf.GetPeersResponse proto, int messageVersion) {
+    public static GetPeersResponse fromProto(protobuf.GetPeersResponse proto, String messageVersion) {
         HashSet<Peer> reportedPeers = proto.getReportedPeersList()
                 .stream()
                 .map(peer -> {

--- a/p2p/src/main/java/bisq/network/p2p/storage/messages/AddDataMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/messages/AddDataMessage.java
@@ -42,7 +42,7 @@ public final class AddDataMessage extends BroadcastMessage {
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private AddDataMessage(ProtectedStorageEntry protectedStorageEntry, int messageVersion) {
+    private AddDataMessage(ProtectedStorageEntry protectedStorageEntry, String messageVersion) {
         super(messageVersion);
         this.protectedStorageEntry = protectedStorageEntry;
     }
@@ -62,7 +62,7 @@ public final class AddDataMessage extends BroadcastMessage {
                 .build();
     }
 
-    public static AddDataMessage fromProto(protobuf.AddDataMessage proto, NetworkProtoResolver resolver, int messageVersion) {
+    public static AddDataMessage fromProto(protobuf.AddDataMessage proto, NetworkProtoResolver resolver, String messageVersion) {
         return new AddDataMessage((ProtectedStorageEntry) resolver.fromProto(proto.getEntry()), messageVersion);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/messages/AddPersistableNetworkPayloadMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/messages/AddPersistableNetworkPayloadMessage.java
@@ -39,7 +39,7 @@ public final class AddPersistableNetworkPayloadMessage extends BroadcastMessage 
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private AddPersistableNetworkPayloadMessage(PersistableNetworkPayload persistableNetworkPayload, int messageVersion) {
+    private AddPersistableNetworkPayloadMessage(PersistableNetworkPayload persistableNetworkPayload, String messageVersion) {
         super(messageVersion);
         this.persistableNetworkPayload = persistableNetworkPayload;
     }
@@ -54,7 +54,7 @@ public final class AddPersistableNetworkPayloadMessage extends BroadcastMessage 
 
     public static AddPersistableNetworkPayloadMessage fromProto(protobuf.AddPersistableNetworkPayloadMessage proto,
                                                                 NetworkProtoResolver resolver,
-                                                                int messageVersion) {
+                                                                String messageVersion) {
         return new AddPersistableNetworkPayloadMessage((PersistableNetworkPayload) resolver.fromProto(proto.getPayload()),
                 messageVersion);
     }

--- a/p2p/src/main/java/bisq/network/p2p/storage/messages/BroadcastMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/messages/BroadcastMessage.java
@@ -23,7 +23,7 @@ import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 public abstract class BroadcastMessage extends NetworkEnvelope {
-    protected BroadcastMessage(int messageVersion) {
+    protected BroadcastMessage(String messageVersion) {
         super(messageVersion);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/messages/RefreshOfferMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/messages/RefreshOfferMessage.java
@@ -48,7 +48,7 @@ public final class RefreshOfferMessage extends BroadcastMessage {
                                 byte[] signature,
                                 byte[] hashOfPayload,
                                 int sequenceNumber,
-                                int messageVersion) {
+                                String messageVersion) {
         super(messageVersion);
         this.hashOfDataAndSeqNr = hashOfDataAndSeqNr;
         this.signature = signature;
@@ -67,7 +67,7 @@ public final class RefreshOfferMessage extends BroadcastMessage {
                 .build();
     }
 
-    public static RefreshOfferMessage fromProto(protobuf.RefreshOfferMessage proto, int messageVersion) {
+    public static RefreshOfferMessage fromProto(protobuf.RefreshOfferMessage proto, String messageVersion) {
         return new RefreshOfferMessage(proto.getHashOfDataAndSeqNr().toByteArray(),
                 proto.getSignature().toByteArray(),
                 proto.getHashOfPayload().toByteArray(),

--- a/p2p/src/main/java/bisq/network/p2p/storage/messages/RemoveDataMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/messages/RemoveDataMessage.java
@@ -40,7 +40,7 @@ public final class RemoveDataMessage extends BroadcastMessage {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private RemoveDataMessage(ProtectedStorageEntry protectedStorageEntry,
-                              int messageVersion) {
+                              String messageVersion) {
         super(messageVersion);
         this.protectedStorageEntry = protectedStorageEntry;
     }
@@ -53,7 +53,7 @@ public final class RemoveDataMessage extends BroadcastMessage {
                 .build();
     }
 
-    public static RemoveDataMessage fromProto(protobuf.RemoveDataMessage proto, NetworkProtoResolver resolver, int messageVersion) {
+    public static RemoveDataMessage fromProto(protobuf.RemoveDataMessage proto, NetworkProtoResolver resolver, String messageVersion) {
         return new RemoveDataMessage(ProtectedStorageEntry.fromProto(proto.getProtectedStorageEntry(), resolver), messageVersion);
     }
 }

--- a/p2p/src/main/java/bisq/network/p2p/storage/messages/RemoveMailboxDataMessage.java
+++ b/p2p/src/main/java/bisq/network/p2p/storage/messages/RemoveMailboxDataMessage.java
@@ -40,7 +40,7 @@ public final class RemoveMailboxDataMessage extends BroadcastMessage {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private RemoveMailboxDataMessage(ProtectedMailboxStorageEntry protectedMailboxStorageEntry,
-                                     int messageVersion) {
+                                     String messageVersion) {
         super(messageVersion);
         this.protectedMailboxStorageEntry = protectedMailboxStorageEntry;
     }
@@ -53,7 +53,7 @@ public final class RemoveMailboxDataMessage extends BroadcastMessage {
                 .build();
     }
 
-    public static RemoveMailboxDataMessage fromProto(protobuf.RemoveMailboxDataMessage proto, NetworkProtoResolver resolver, int messageVersion) {
+    public static RemoveMailboxDataMessage fromProto(protobuf.RemoveMailboxDataMessage proto, NetworkProtoResolver resolver, String messageVersion) {
         return new RemoveMailboxDataMessage(ProtectedMailboxStorageEntry.fromProto(proto.getProtectedStorageEntry(), resolver), messageVersion);
     }
 }

--- a/p2p/src/test/java/bisq/network/crypto/EncryptionServiceTests.java
+++ b/p2p/src/test/java/bisq/network/crypto/EncryptionServiceTests.java
@@ -117,13 +117,13 @@ public class EncryptionServiceTests {
         public final int nonce;
 
         public MockMessage(int nonce) {
-            super(0);
+            super("0");
             this.nonce = nonce;
         }
 
         @Override
-        public int getMessageVersion() {
-            return 0;
+        public String getMessageVersion() {
+            return "0";
         }
 
         @Override
@@ -135,7 +135,7 @@ public class EncryptionServiceTests {
 /*@Value
 final class TestMessage implements MailboxMessage {
     public String data = "test";
-    private final int messageVersion = Version.getP2PMessageVersion();
+    private final String messageVersion = Version.getP2PMessageVersion();
     private final String uid;
     private final String senderNodeAddress;
 

--- a/p2p/src/test/java/bisq/network/p2p/mocks/MockMailboxPayload.java
+++ b/p2p/src/test/java/bisq/network/p2p/mocks/MockMailboxPayload.java
@@ -32,14 +32,14 @@ import lombok.Getter;
 
 @Getter
 public final class MockMailboxPayload extends NetworkEnvelope implements MailboxMessage, ExpirablePayload {
-    private final int messageVersion = Version.getP2PMessageVersion();
+    private final String messageVersion = Version.getP2PMessageVersion();
     public final String msg;
     public final NodeAddress senderNodeAddress;
     public long ttl = 0;
     private final String uid;
 
     public MockMailboxPayload(String msg, NodeAddress senderNodeAddress) {
-        super(0);
+        super("0");
         this.msg = msg;
         this.senderNodeAddress = senderNodeAddress;
         uid = UUID.randomUUID().toString();

--- a/p2p/src/test/java/bisq/network/p2p/mocks/MockPayload.java
+++ b/p2p/src/test/java/bisq/network/p2p/mocks/MockPayload.java
@@ -28,15 +28,15 @@ import org.apache.commons.lang3.NotImplementedException;
 public final class MockPayload extends NetworkEnvelope implements ExpirablePayload {
     public final String msg;
     public long ttl;
-    private final int messageVersion = Version.getP2PMessageVersion();
+    private final String messageVersion = Version.getP2PMessageVersion();
 
     public MockPayload(String msg) {
-        super(0);
+        super("0");
         this.msg = msg;
     }
 
     @Override
-    public int getMessageVersion() {
+    public String getMessageVersion() {
         return messageVersion;
     }
 

--- a/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageOnMessageHandlerTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/P2PDataStorageOnMessageHandlerTest.java
@@ -53,7 +53,7 @@ public class P2PDataStorageOnMessageHandlerTest {
     static class UnsupportedBroadcastMessage extends BroadcastMessage {
 
         UnsupportedBroadcastMessage() {
-            super(0);
+            super("0");
         }
     }
 

--- a/p2p/src/test/java/bisq/network/p2p/storage/messages/AddDataMessageTest.java
+++ b/p2p/src/test/java/bisq/network/p2p/storage/messages/AddDataMessageTest.java
@@ -23,6 +23,7 @@ import bisq.network.p2p.storage.payload.MailboxStoragePayload;
 import bisq.network.p2p.storage.payload.ProtectedMailboxStorageEntry;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
 
+import bisq.common.app.Version;
 import bisq.common.crypto.CryptoException;
 import bisq.common.crypto.KeyRing;
 import bisq.common.crypto.KeyStorage;
@@ -62,6 +63,7 @@ public class AddDataMessageTest {
         //noinspection ResultOfMethodCallIgnored
         dir1.mkdir();
         keyRing1 = new KeyRing(new KeyStorage(dir1), null, true);
+        Version.setBaseCryptoNetworkId(1);
     }
 
     @Test

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -14,7 +14,7 @@ option java_multiple_files = true;
 
 // Those are messages sent over wire
 message NetworkEnvelope {
-    int32 message_version = 1;
+    string message_version = 1;
     oneof message {
         PreliminaryGetDataRequest preliminary_get_data_request = 2;
         GetDataResponse get_data_response = 3;


### PR DESCRIPTION
Proposes to change version_message to String, sets as default P2P_NETWORK_VERSION the string "A"  and uses a different algorithm to calculate p2pMessageVersion from P2P_NETWORK_VERSION and BASE_CURRENCY_NETWORK that uses string concatenation instead of numeric multiplication.

Checks remote peers P2P_NETWORK_VERSION during connection and if null, empty or only contains digits, adds peer to BANNED_SEED_NODES.

closes #200