### PR TITLE
run haveno_deps script on gradle build instead of from make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # See docs/installing.md
 
-build: nodes localnet haveno
+build: localnet haveno
 
 clean:
 	./gradlew clean
@@ -10,9 +10,6 @@ clean-localnet:
 
 localnet:
 	mkdir -p .localnet
-
-nodes: localnet
-	./scripts/haveno_deps.sh
 
 haveno:
 	./gradlew build
@@ -159,7 +156,7 @@ monero-private2:
 		--rpc-login superuser:abctesting123 \
 		--rpc-access-control-origins http://localhost:8080 \
 		--fixed-difficulty 100
-		
+
 funding-wallet:
 	./.localnet/monero-wallet-rpc \
 		--stagenet \

--- a/build.gradle
+++ b/build.gradle
@@ -280,7 +280,7 @@ configure(project(':common')) {
         annotationProcessor "org.projectlombok:lombok:$lombokVersion"
         testCompile "org.hamcrest:hamcrest-all:$hamcrestVersion"
 
-        // override transitive dependency version from 1.5 to the same version just identified by commit number. 
+        // override transitive dependency version from 1.5 to the same version just identified by commit number.
         // Remove this if transitive dependency is changed to something else than 1.5
         compile( group: 'com.github.JesusMcCloud', name: 'jtorctl') { version { strictly "[9b5ba2036b]" } }
 
@@ -363,6 +363,13 @@ configure(project(':core')) {
     test {
         systemProperty 'jdk.attach.allowAttachSelf', true
     }
+
+    task havenoDeps(type: Exec) {
+        workingDir '..'
+        commandLine './scripts/haveno_deps.sh'
+    }
+    if (osdetector.os != 'windows') processResources.dependsOn havenoDeps // before both test and build
+    else println "Haveno dependencies must be downloaded manually on Windows"
 }
 
 configure(project(':cli')) {


### PR DESCRIPTION
Closes #184

Maybe it would be "nicer" to download the binaries with a gradle task utilising gradle tasks' inputs and outputs but that's for someone more skilled with gradle