### PR TITLE
Fix legacy arbitration tab

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/support/SupportView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/SupportView.java
@@ -118,21 +118,17 @@ public class SupportView extends ActivatableView<TabPane, Void> {
         tradersRefundDisputesTab.setClosable(false);
         root.getTabs().add(tradersRefundDisputesTab);
 
-        // We only show tradersArbitrationDisputesTab if we have cases
-        if (!arbitrationManager.getDisputesAsObservableList().isEmpty()) {
-            tradersArbitrationDisputesTab = new Tab();
-            tradersArbitrationDisputesTab.setClosable(false);
-            root.getTabs().add(tradersArbitrationDisputesTab);
-        }
+        tradersArbitrationDisputesTab = new Tab();
+        tradersArbitrationDisputesTab.setClosable(false);
+        root.getTabs().add(tradersArbitrationDisputesTab);
 
         // Has to be called before loadView
         updateAgentTabs();
 
         tradersMediationDisputesTab.setText(Res.get("support.tab.mediation.support").toUpperCase());
         tradersRefundDisputesTab.setText(Res.get("support.tab.arbitration.support").toUpperCase());
-        if (tradersArbitrationDisputesTab != null) {
-            tradersArbitrationDisputesTab.setText(Res.get("support.tab.legacyArbitration.support").toUpperCase());
-        }
+        tradersArbitrationDisputesTab.setText(Res.get("support.tab.legacyArbitration.support").toUpperCase());
+
         navigationListener = (viewPath, data) -> {
             if (viewPath.size() == 3 && viewPath.indexOf(SupportView.class) == 1)
                 loadView(viewPath.tip());


### PR DESCRIPTION
Legacy arbitration tab had a condition that would only be visible if there are open disputes to show unlike the two other support tabs. Changed it to be visible like the other tabs and first dispute is now immediately visible.

closes: #59 