### PR TITLE
Add API functions to start and stop local Monero node

### DIFF
--- a/common/src/main/java/bisq/common/crypto/KeyStorage.java
+++ b/common/src/main/java/bisq/common/crypto/KeyStorage.java
@@ -172,7 +172,7 @@ public class KeyStorage {
                         // Most of the time (probably of slightly less than 255/256, around 99.61%) a bad password
                         // will result in BadPaddingException before HMAC check.
                         // See https://stackoverflow.com/questions/8049872/given-final-block-not-properly-padded
-                        if (ce.getCause() instanceof BadPaddingException || ce.getMessage() == Encryption.HMAC_ERROR_MSG)
+                        if (ce.getCause() instanceof BadPaddingException || Encryption.HMAC_ERROR_MSG.equals(ce.getMessage()))
                             throw new IncorrectPasswordException("Incorrect password");
                         else
                             throw ce;

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -36,6 +36,8 @@ import bisq.core.support.messages.ChatMessage;
 import bisq.core.trade.Trade;
 import bisq.core.trade.statistics.TradeStatistics3;
 import bisq.core.trade.statistics.TradeStatisticsManager;
+import bisq.core.xmr.MoneroNodeSettings;
+
 import bisq.common.app.Version;
 import bisq.common.config.Config;
 import bisq.common.crypto.IncorrectPasswordException;
@@ -247,8 +249,12 @@ public class CoreApi {
         return coreMoneroNodeService.isMoneroNodeStarted();
     }
 
-    public void startMoneroNode(String rpcUsername, String rpcPassword) throws IOException {
-        coreMoneroNodeService.startMoneroNode(rpcUsername, rpcPassword);
+    public MoneroNodeSettings getMoneroNodeSettings() {
+        return coreMoneroNodeService.getMoneroNodeSettings();
+    }
+
+    public void startMoneroNode(MoneroNodeSettings settings) throws IOException {
+        coreMoneroNodeService.startMoneroNode(settings);
     }
 
     public void stopMoneroNode() {

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -53,6 +53,7 @@ import javax.inject.Singleton;
 
 import com.google.common.util.concurrent.FutureCallback;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import java.util.ArrayList;
@@ -94,6 +95,7 @@ public class CoreApi {
     private final TradeStatisticsManager tradeStatisticsManager;
     private final CoreNotificationService notificationService;
     private final CoreMoneroConnectionsService coreMoneroConnectionsService;
+    private final CoreMoneroNodeService coreMoneroNodeService;
 
     @Inject
     public CoreApi(Config config,
@@ -109,7 +111,8 @@ public class CoreApi {
                    CoreWalletsService walletsService,
                    TradeStatisticsManager tradeStatisticsManager,
                    CoreNotificationService notificationService,
-                   CoreMoneroConnectionsService coreMoneroConnectionsService) {
+                   CoreMoneroConnectionsService coreMoneroConnectionsService,
+                   CoreMoneroNodeService coreMoneroNodeService) {
         this.config = config;
         this.appStartupState = appStartupState;
         this.coreAccountService = coreAccountService;
@@ -124,6 +127,7 @@ public class CoreApi {
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.notificationService = notificationService;
         this.coreMoneroConnectionsService = coreMoneroConnectionsService;
+        this.coreMoneroNodeService = coreMoneroNodeService;
     }
 
     @SuppressWarnings("SameReturnValue")
@@ -233,6 +237,22 @@ public class CoreApi {
 
     public void setMoneroConnectionAutoSwitch(boolean autoSwitch) {
         coreMoneroConnectionsService.setAutoSwitch(autoSwitch);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Monero node
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public boolean isMoneroNodeStarted() {
+        return coreMoneroNodeService.isMoneroNodeStarted();
+    }
+
+    public void startMoneroNode(String rpcUsername, String rpcPassword) throws IOException {
+        coreMoneroNodeService.startMoneroNode(rpcUsername, rpcPassword);
+    }
+
+    public void stopMoneroNode() {
+        coreMoneroNodeService.stopMoneroNode();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -245,8 +245,8 @@ public class CoreApi {
     // Monero node
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    public boolean isMoneroNodeStarted() {
-        return coreMoneroNodeService.isMoneroNodeStarted();
+    public boolean isMoneroNodeRunning() {
+        return coreMoneroNodeService.isMoneroNodeRunning();
     }
 
     public MoneroNodeSettings getMoneroNodeSettings() {

--- a/core/src/main/java/bisq/core/api/CoreMoneroNodeService.java
+++ b/core/src/main/java/bisq/core/api/CoreMoneroNodeService.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+package bisq.core.api;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import monero.daemon.MoneroDaemon;
+import monero.daemon.MoneroDaemonRpc;
+import monero.daemon.model.MoneroNetworkType;
+
+/**
+ * Manages a Monero node instance or connection to an instance.
+ */
+@Slf4j
+@Singleton
+public class CoreMoneroNodeService {
+
+    // Monero configuration
+    // TODO: don't hard code configuration, inject into classes?
+    private static final MoneroNetworkType MONERO_NETWORK_TYPE = MoneroNetworkType.STAGENET;
+    private static final String MONEROD_PATH = System.getProperty("user.dir") + File.separator + ".localnet" + File.separator + "monerod";
+    private static final String MONEROD_DATADIR =  System.getProperty("user.dir") + File.separator + ".localnet" + File.separator + MONERO_NETWORK_TYPE.toString().toLowerCase();
+    private static final String MONEROD_P2PPORT = "58080";
+    private static final String MONEROD_RPCPORT = "58081";
+    private static final String MONEROD_ZMQPORT = "58082";
+
+    private List<MoneroNodeServiceListener> listeners = new ArrayList<>();
+
+    private static final List<String> DevArgs = Arrays.asList(
+            MONEROD_PATH,
+            "--" + MONERO_NETWORK_TYPE.toString().toLowerCase(),
+            "--no-igd",
+            "--hide-my-port",
+            "--data-dir", MONEROD_DATADIR,
+            "--p2p-bind-port", MONEROD_P2PPORT,
+            "--rpc-bind-port", MONEROD_RPCPORT,
+            "--zmq-rpc-bind-port", MONEROD_ZMQPORT
+    );
+
+    @Getter
+    private MoneroDaemon daemon;
+
+    @Inject
+    public CoreMoneroNodeService() {
+        this.daemon = null;
+    }
+
+    public void addListener(MoneroNodeServiceListener listener) {
+        listeners.add(listener);
+    }
+
+    public boolean removeListener(MoneroNodeServiceListener listener) {
+        return listeners.remove(listener);
+    }
+
+    public boolean isMoneroNodeStarted() {
+        return daemon != null;
+    }
+
+    /**
+     * Starts a local monero node. Throws MoneroError if the node cannot be started.
+     */
+    public void startMoneroNode(String rpcUsername, String rpcPassword) throws IOException {
+        if (daemon != null) throw new IllegalStateException("Monero node already running");
+        var args = new ArrayList<>(DevArgs);
+        args.add("--rpc-login");
+        args.add(rpcUsername + ":" + rpcPassword);
+        daemon = new MoneroDaemonRpc(args);
+        for (var listener : listeners) listener.onNodeStarted(daemon);
+    }
+
+    public void stopMoneroNode() {
+        if (daemon == null) throw new IllegalStateException("Monero node is not running");
+        daemon.stop();
+        daemon = null;
+        for (var listener : listeners) listener.onNodeStopped();
+    }
+}

--- a/core/src/main/java/bisq/core/api/MoneroNodeServiceListener.java
+++ b/core/src/main/java/bisq/core/api/MoneroNodeServiceListener.java
@@ -16,9 +16,9 @@
  */
 package bisq.core.api;
 
-import monero.daemon.MoneroDaemon;
+import monero.daemon.MoneroDaemonRpc;
 
 public class MoneroNodeServiceListener {
-    public void onNodeStarted(MoneroDaemon daemon) {}
+    public void onNodeStarted(MoneroDaemonRpc daemon) {}
     public void onNodeStopped() {}
 }

--- a/core/src/main/java/bisq/core/api/MoneroNodeServiceListener.java
+++ b/core/src/main/java/bisq/core/api/MoneroNodeServiceListener.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+package bisq.core.api;
+
+import monero.daemon.MoneroDaemon;
+
+public class MoneroNodeServiceListener {
+    public void onNodeStarted(MoneroDaemon daemon) {}
+    public void onNodeStopped() {}
+}

--- a/core/src/main/java/bisq/core/user/Preferences.java
+++ b/core/src/main/java/bisq/core/user/Preferences.java
@@ -30,6 +30,7 @@ import bisq.core.locale.TradeCurrency;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.PaymentAccountUtil;
 import bisq.core.provider.fee.FeeService;
+import bisq.core.xmr.MoneroNodeSettings;
 
 import bisq.network.p2p.network.BridgeAddressProvider;
 
@@ -165,7 +166,6 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
     private final String btcNodesFromOptions;
     @Getter
     private final BooleanProperty useStandbyModeProperty = new SimpleBooleanProperty(prefPayload.isUseStandbyMode());
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -687,7 +687,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         prefPayload.setTakeOfferSelectedPaymentAccountId(value);
         requestPersistence();
     }
-    
+
     public void setIgnoreDustThreshold(int value) {
         prefPayload.setIgnoreDustThreshold(value);
         requestPersistence();
@@ -708,6 +708,10 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         requestPersistence();
     }
 
+    public void setMoneroNodeSettings(MoneroNodeSettings settings) {
+        prefPayload.setMoneroNodeSettings(settings);
+        requestPersistence();
+    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Getter
@@ -957,5 +961,7 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         void setDenyApiTaker(boolean value);
 
         void setNotifyOnPreRelease(boolean value);
+
+        void setMoneroNodeSettings(MoneroNodeSettings settings);
     }
 }

--- a/core/src/main/java/bisq/core/user/PreferencesPayload.java
+++ b/core/src/main/java/bisq/core/user/PreferencesPayload.java
@@ -23,6 +23,7 @@ import bisq.core.locale.FiatCurrency;
 import bisq.core.locale.TradeCurrency;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.proto.CoreProtoResolver;
+import bisq.core.xmr.MoneroNodeSettings;
 
 import bisq.common.proto.ProtoUtil;
 import bisq.common.proto.persistable.PersistableEnvelope;
@@ -130,6 +131,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
     private boolean denyApiTaker;
     private boolean notifyOnPreRelease;
 
+    private MoneroNodeSettings moneroNodeSettings;
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -201,8 +204,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
         Optional.ofNullable(tradeChartsScreenCurrencyCode).ifPresent(builder::setTradeChartsScreenCurrencyCode);
         Optional.ofNullable(buyScreenCurrencyCode).ifPresent(builder::setBuyScreenCurrencyCode);
         Optional.ofNullable(sellScreenCurrencyCode).ifPresent(builder::setSellScreenCurrencyCode);
-        Optional.ofNullable(selectedPaymentAccountForCreateOffer).ifPresent(
-                account -> builder.setSelectedPaymentAccountForCreateOffer(selectedPaymentAccountForCreateOffer.toProtoMessage()));
+        Optional.ofNullable(selectedPaymentAccountForCreateOffer).ifPresent(account -> builder.setSelectedPaymentAccountForCreateOffer(account.toProtoMessage()));
         Optional.ofNullable(bridgeAddresses).ifPresent(builder::addAllBridgeAddresses);
         Optional.ofNullable(customBridges).ifPresent(builder::setCustomBridges);
         Optional.ofNullable(referralId).ifPresent(builder::setReferralId);
@@ -210,7 +212,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
         Optional.ofNullable(rpcUser).ifPresent(builder::setRpcUser);
         Optional.ofNullable(rpcPw).ifPresent(builder::setRpcPw);
         Optional.ofNullable(takeOfferSelectedPaymentAccountId).ifPresent(builder::setTakeOfferSelectedPaymentAccountId);
-
+        Optional.ofNullable(moneroNodeSettings).ifPresent(settings -> builder.setMoneroNodeSettings(settings.toProtoMessage()));
         return protobuf.PersistableEnvelope.newBuilder().setPreferencesPayload(builder).build();
     }
 
@@ -286,7 +288,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.getHideNonAccountPaymentMethods(),
                 proto.getShowOffersMatchingMyAccounts(),
                 proto.getDenyApiTaker(),
-                proto.getNotifyOnPreRelease()
+                proto.getNotifyOnPreRelease(),
+                MoneroNodeSettings.fromProto(proto.getMoneroNodeSettings())
         );
     }
 }

--- a/core/src/main/java/bisq/core/xmr/MoneroNodeSettings.java
+++ b/core/src/main/java/bisq/core/xmr/MoneroNodeSettings.java
@@ -29,7 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class MoneroNodeSettings implements PersistableEnvelope {
 
-    // todo: apply encryption since there may be sensitive flags
     String blockchainPath;
     String bootstrapUrl;
     List<String> startupFlags;

--- a/core/src/main/java/bisq/core/xmr/MoneroNodeSettings.java
+++ b/core/src/main/java/bisq/core/xmr/MoneroNodeSettings.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+package bisq.core.xmr;
+
+import bisq.common.proto.persistable.PersistableEnvelope;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Data
+@AllArgsConstructor
+public class MoneroNodeSettings implements PersistableEnvelope {
+
+    // todo: apply encryption since there may be sensitive flags
+    String blockchainPath;
+    String bootstrapUrl;
+    List<String> startupFlags;
+
+    public static MoneroNodeSettings fromProto(protobuf.MoneroNodeSettings proto) {
+        return new MoneroNodeSettings(
+                proto.getBlockchainPath(),
+                proto.getBootstrapUrl(),
+                proto.getStartupFlagsList());
+    }
+
+    @Override
+    public protobuf.MoneroNodeSettings toProtoMessage() {
+        return protobuf.MoneroNodeSettings.newBuilder()
+                .setBlockchainPath(blockchainPath)
+                .setBootstrapUrl(bootstrapUrl)
+                .addAllStartupFlags(startupFlags).build();
+    }
+}

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcMoneroNodeService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcMoneroNodeService.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+package bisq.daemon.grpc;
+
+import bisq.core.api.CoreApi;
+
+import bisq.proto.grpc.IsMoneroNodeStartedReply;
+import bisq.proto.grpc.IsMoneroNodeStartedRequest;
+import bisq.proto.grpc.MoneroNodeGrpc.MoneroNodeImplBase;
+import bisq.proto.grpc.StartMoneroNodeReply;
+import bisq.proto.grpc.StartMoneroNodeRequest;
+import bisq.proto.grpc.StopMoneroNodeReply;
+import bisq.proto.grpc.StopMoneroNodeRequest;
+
+import io.grpc.ServerInterceptor;
+import io.grpc.stub.StreamObserver;
+
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig.getCustomRateMeteringInterceptor;
+import static bisq.proto.grpc.MoneroNodeGrpc.getStartMoneroNodeMethod;
+import static bisq.proto.grpc.MoneroNodeGrpc.getStopMoneroNodeMethod;
+import static bisq.proto.grpc.MoneroNodeGrpc.getIsMoneroNodeStartedMethod;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import bisq.daemon.grpc.interceptor.CallRateMeteringInterceptor;
+import bisq.daemon.grpc.interceptor.GrpcCallRateMeter;
+import monero.common.MoneroError;
+
+@Slf4j
+public class GrpcMoneroNodeService extends MoneroNodeImplBase {
+
+    private final CoreApi coreApi;
+    private final GrpcExceptionHandler exceptionHandler;
+
+    @Inject
+    public GrpcMoneroNodeService(CoreApi coreApi, GrpcExceptionHandler exceptionHandler) {
+        this.coreApi = coreApi;
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    @Override
+    public void isMoneroNodeStarted(IsMoneroNodeStartedRequest request,
+                                    StreamObserver<IsMoneroNodeStartedReply> responseObserver) {
+        try {
+            var reply = IsMoneroNodeStartedReply.newBuilder()
+                    .setIsRunning(coreApi.isMoneroNodeStarted())
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
+    public void startMoneroNode(StartMoneroNodeRequest request,
+                                StreamObserver<StartMoneroNodeReply> responseObserver) {
+        try {
+            coreApi.startMoneroNode(request.getRpcUsername(), request.getRpcPassword());
+            var reply = StartMoneroNodeReply.newBuilder().build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (MoneroError me) {
+            // MoneroError is caused by the node startup failing, don't treat as unknown server error
+            // by wrapping with a handled exception type.
+            exceptionHandler.handleException(log, new IllegalStateException(me), responseObserver);
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
+    public void stopMoneroNode(StopMoneroNodeRequest request,
+                               StreamObserver<StopMoneroNodeReply> responseObserver) {
+        try {
+            coreApi.stopMoneroNode();
+            var reply = StopMoneroNodeReply.newBuilder().build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    final ServerInterceptor[] interceptors() {
+        Optional<ServerInterceptor> rateMeteringInterceptor = rateMeteringInterceptor();
+        return rateMeteringInterceptor.map(serverInterceptor ->
+                new ServerInterceptor[]{serverInterceptor}).orElseGet(() -> new ServerInterceptor[0]);
+    }
+
+    private Optional<ServerInterceptor> rateMeteringInterceptor() {
+        return getCustomRateMeteringInterceptor(coreApi.getConfig().appDataDir, this.getClass())
+                .or(() -> Optional.of(CallRateMeteringInterceptor.valueOf(
+                        new HashMap<>() {{
+                            int allowedCallsPerTimeWindow = 10;
+                            put(getIsMoneroNodeStartedMethod().getFullMethodName(), new GrpcCallRateMeter(allowedCallsPerTimeWindow, SECONDS));
+                            put(getStartMoneroNodeMethod().getFullMethodName(), new GrpcCallRateMeter(allowedCallsPerTimeWindow, SECONDS));
+                            put(getStopMoneroNodeMethod().getFullMethodName(), new GrpcCallRateMeter(allowedCallsPerTimeWindow, SECONDS));
+                        }}
+                )));
+    }
+}

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcServer.java
@@ -62,7 +62,8 @@ public class GrpcServer {
                       GrpcTradesService tradesService,
                       GrpcWalletsService walletsService,
                       GrpcNotificationsService notificationsService,
-                      GrpcMoneroConnectionsService moneroConnectionsService) {
+                      GrpcMoneroConnectionsService moneroConnectionsService,
+                      GrpcMoneroNodeService moneroNodeService) {
         this.server = ServerBuilder.forPort(config.apiPort)
                 .executor(UserThread.getExecutor())
                 .addService(interceptForward(accountService, accountService.interceptors()))
@@ -79,6 +80,7 @@ public class GrpcServer {
                 .addService(interceptForward(walletsService, walletsService.interceptors()))
                 .addService(interceptForward(notificationsService, notificationsService.interceptors()))
                 .addService(interceptForward(moneroConnectionsService, moneroConnectionsService.interceptors()))
+                .addService(interceptForward(moneroNodeService, moneroNodeService.interceptors()))
                 .intercept(passwordAuthInterceptor)
                 .build();
         coreContext.setApiUser(true);

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -387,7 +387,9 @@ message SetAutoSwitchReply {}
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 service MoneroNode {
-    rpc IsMoneroNodeStarted (IsMoneroNodeStartedRequest) returns (IsMoneroNodeStartedReply) {
+    rpc IsMoneroNodeRunning (IsMoneroNodeRunningRequest) returns (IsMoneroNodeRunningReply) {
+    }
+    rpc GetMoneroNodeSettings (GetMoneroNodeSettingsRequest) returns (GetMoneroNodeSettingsReply) {
     }
     rpc StartMoneroNode (StartMoneroNodeRequest) returns (StartMoneroNodeReply) {
     }
@@ -395,16 +397,22 @@ service MoneroNode {
     }
 }
 
-message IsMoneroNodeStartedRequest {
+message IsMoneroNodeRunningRequest {
 }
 
-message IsMoneroNodeStartedReply {
+message IsMoneroNodeRunningReply {
     bool is_running = 1;
 }
 
+message GetMoneroNodeSettingsRequest {
+}
+
+message GetMoneroNodeSettingsReply {
+    MoneroNodeSettings settings = 1; // pb.proto
+}
+
 message StartMoneroNodeRequest {
-    string rpc_username = 1;
-    string rpc_password = 2;
+    MoneroNodeSettings settings = 1;
 }
 
 message StartMoneroNodeReply {

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -383,6 +383,40 @@ message SetAutoSwitchRequest {
 message SetAutoSwitchReply {}
 
 ///////////////////////////////////////////////////////////////////////////////////////////
+// MoneroNode
+///////////////////////////////////////////////////////////////////////////////////////////
+
+service MoneroNode {
+    rpc IsMoneroNodeStarted (IsMoneroNodeStartedRequest) returns (IsMoneroNodeStartedReply) {
+    }
+    rpc StartMoneroNode (StartMoneroNodeRequest) returns (StartMoneroNodeReply) {
+    }
+    rpc StopMoneroNode (StopMoneroNodeRequest) returns (StopMoneroNodeReply) {
+    }
+}
+
+message IsMoneroNodeStartedRequest {
+}
+
+message IsMoneroNodeStartedReply {
+    bool is_running = 1;
+}
+
+message StartMoneroNodeRequest {
+    string rpc_username = 1;
+    string rpc_password = 2;
+}
+
+message StartMoneroNodeReply {
+}
+
+message StopMoneroNodeRequest {
+}
+
+message StopMoneroNodeReply {
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
 // Offers
 ///////////////////////////////////////////////////////////////////////////////////////////
 

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1814,6 +1814,7 @@ message PreferencesPayload {
     bool show_offers_matching_my_accounts = 55;
     bool deny_api_taker = 56;
     bool notify_on_pre_release = 57;
+    MoneroNodeSettings monero_node_settings = 58;
 }
 
 message AutoConfirmSettings {
@@ -1822,6 +1823,12 @@ message AutoConfirmSettings {
     int64 trade_limit = 3;
     repeated string service_addresses = 4;
     string currency_code = 5;
+}
+
+message MoneroNodeSettings {
+    string blockchainPath = 1;
+    string bootstrapUrl = 2;
+    repeated string startupFlags = 3;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Implemented a gRPC service `GrpcMoneroNodeService` which calls into `CoreMoneroNodeService` to start and stop a local monero node. The configuration for the node parameters have not been implemented yet as it appears they should be done along with the parameters in the `XmrWalletService` class.

The service provides a listener interface so if the user starts the local monero node, the `CoreMoneroConnectionsService` set its connection to null, and provide the local node as the daemon interface. When the local node is stopped, the connection is restored.

I've also added `isMoneroNodeStarted` function in order query the local node state. 

Resolves Issue #137