### PR TITLE
Encrypt persisted data using password protected symmetric key

### DIFF
--- a/common/src/main/java/bisq/common/crypto/Encryption.java
+++ b/common/src/main/java/bisq/common/crypto/Encryption.java
@@ -218,9 +218,9 @@ public class Encryption {
 
     public static SecretKey generateSecretKey(int bits) {
         try {
-            KeyGenerator keyPairGenerator = KeyGenerator.getInstance(SYM_KEY_ALGO);
-            keyPairGenerator.init(bits);
-            return keyPairGenerator.generateKey();
+            KeyGenerator keyGenerator = KeyGenerator.getInstance(SYM_KEY_ALGO);
+            keyGenerator.init(bits);
+            return keyGenerator.generateKey();
         } catch (Throwable e) {
             log.error("Couldn't generate key", e);
             throw new RuntimeException("Couldn't generate key");

--- a/common/src/main/java/bisq/common/crypto/KeyStorage.java
+++ b/common/src/main/java/bisq/common/crypto/KeyStorage.java
@@ -175,7 +175,7 @@ public class KeyStorage {
      * @param password Optional password that protects the key
      */
     public SecretKey loadSecretKey(KeyEntry keyEntry, String password) throws IncorrectPasswordException {
-        char[] passwordChars = password == null ? null : password.toCharArray();
+        char[] passwordChars = password == null ? new char[0] : password.toCharArray();
         try {
             KeyStore keyStore = KeyStore.getInstance("PKCS12");
             keyStore.load(new FileInputStream(storageDir + "/" + keyEntry.getFileName()), passwordChars);

--- a/common/src/main/java/bisq/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/bisq/common/persistence/PersistenceManager.java
@@ -465,7 +465,10 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         }
         if (keyRing != null && !keyRing.isUnlocked()) {
             log.warn("Account is not open, ignoring writeToDisk.");
-            UserThread.execute(completeHandler);
+            if (completeHandler != null) {
+                UserThread.execute(completeHandler);
+            }
+            return;
         }
 
         long ts = System.currentTimeMillis();

--- a/common/src/main/java/bisq/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/bisq/common/persistence/PersistenceManager.java
@@ -460,7 +460,9 @@ public class PersistenceManager<T extends PersistableEnvelope> {
     public void writeToDisk(protobuf.PersistableEnvelope serialized, @Nullable Runnable completeHandler) {
         if (!allServicesInitialized.get()) {
             log.warn("Application has not completed start up yet so we do not permit writing data to disk.");
-            UserThread.execute(completeHandler);
+            if (completeHandler != null) {
+                UserThread.execute(completeHandler);
+            }
             return;
         }
         if (keyRing != null && !keyRing.isUnlocked()) {

--- a/common/src/main/java/bisq/common/util/ZipUtils.java
+++ b/common/src/main/java/bisq/common/util/ZipUtils.java
@@ -35,7 +35,7 @@ public class ZipUtils {
 
     /**
      * Zips directory into the output stream. Empty directories are not included.
-     * 
+     *
      * @param dir The directory to create the zip from.
      * @param out The stream to write to.
      */
@@ -64,6 +64,8 @@ public class ZipUtils {
 
                     // Close the zip entry.
                     zos.closeEntry();
+                } catch (Exception e) {
+                    log.warn(e.getMessage());
                 }
             }
         }
@@ -88,7 +90,7 @@ public class ZipUtils {
     /**
      * Unzips the zipStream into the specified directory, overwriting any files.
      * Existing files are preserved.
-     * 
+     *
      * @param dir The directory to write to.
      * @param inputStream The raw stream assumed to be in zip format.
      * @param bufferSize The buffer used to read from efficiently.

--- a/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
@@ -6,6 +6,8 @@ import bisq.core.trade.TradableList;
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.peers.PeerManager;
 
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.KeyStorage;
 import bisq.common.file.CorruptedStorageFileHandler;
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
@@ -34,8 +36,9 @@ public class OpenOfferManagerTest {
     public void setUp() throws Exception {
         var corruptedStorageFileHandler = mock(CorruptedStorageFileHandler.class);
         var storageDir = Files.createTempDirectory("storage").toFile();
-        persistenceManager = new PersistenceManager<>(storageDir, null, corruptedStorageFileHandler);
-        signedOfferPersistenceManager = new PersistenceManager<>(storageDir, null, corruptedStorageFileHandler);
+        var keyRing = new KeyRing(new KeyStorage(storageDir));
+        persistenceManager = new PersistenceManager<>(storageDir, null, corruptedStorageFileHandler, keyRing);
+        signedOfferPersistenceManager = new PersistenceManager<>(storageDir, null, corruptedStorageFileHandler, keyRing);
         coreContext = new CoreContext();
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/altcoinaccounts/AltCoinAccountsDataModel.java
@@ -31,6 +31,7 @@ import bisq.core.trade.TradeManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
+import bisq.common.crypto.KeyRing;
 import bisq.common.file.CorruptedStorageFileHandler;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
 
@@ -59,6 +60,7 @@ class AltCoinAccountsDataModel extends ActivatableDataModel {
     private final String accountsFileName = "AltcoinPaymentAccounts";
     private final PersistenceProtoResolver persistenceProtoResolver;
     private final CorruptedStorageFileHandler corruptedStorageFileHandler;
+    private final KeyRing keyRing;
 
     @Inject
     public AltCoinAccountsDataModel(User user,
@@ -67,7 +69,8 @@ class AltCoinAccountsDataModel extends ActivatableDataModel {
                                     TradeManager tradeManager,
                                     AccountAgeWitnessService accountAgeWitnessService,
                                     PersistenceProtoResolver persistenceProtoResolver,
-                                    CorruptedStorageFileHandler corruptedStorageFileHandler) {
+                                    CorruptedStorageFileHandler corruptedStorageFileHandler,
+                                    KeyRing keyRing) {
         this.user = user;
         this.preferences = preferences;
         this.openOfferManager = openOfferManager;
@@ -75,6 +78,7 @@ class AltCoinAccountsDataModel extends ActivatableDataModel {
         this.accountAgeWitnessService = accountAgeWitnessService;
         this.persistenceProtoResolver = persistenceProtoResolver;
         this.corruptedStorageFileHandler = corruptedStorageFileHandler;
+        this.keyRing = keyRing;
         setChangeListener = change -> fillAndSortPaymentAccounts();
     }
 
@@ -150,12 +154,12 @@ class AltCoinAccountsDataModel extends ActivatableDataModel {
             ArrayList<PaymentAccount> accounts = new ArrayList<>(user.getPaymentAccounts().stream()
                     .filter(paymentAccount -> paymentAccount instanceof AssetAccount)
                     .collect(Collectors.toList()));
-            GUIUtil.exportAccounts(accounts, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler);
+            GUIUtil.exportAccounts(accounts, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler, keyRing);
         }
     }
 
     public void importAccounts(Stage stage) {
-        GUIUtil.importAccounts(user, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler);
+        GUIUtil.importAccounts(user, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler, keyRing);
     }
 
     public int getNumPaymentAccounts() {

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsDataModel.java
@@ -32,6 +32,7 @@ import bisq.core.trade.TradeManager;
 import bisq.core.user.Preferences;
 import bisq.core.user.User;
 
+import bisq.common.crypto.KeyRing;
 import bisq.common.file.CorruptedStorageFileHandler;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
 
@@ -60,6 +61,7 @@ class FiatAccountsDataModel extends ActivatableDataModel {
     private final String accountsFileName = "FiatPaymentAccounts";
     private final PersistenceProtoResolver persistenceProtoResolver;
     private final CorruptedStorageFileHandler corruptedStorageFileHandler;
+    private final KeyRing keyRing;
 
     @Inject
     public FiatAccountsDataModel(User user,
@@ -68,7 +70,8 @@ class FiatAccountsDataModel extends ActivatableDataModel {
                                  TradeManager tradeManager,
                                  AccountAgeWitnessService accountAgeWitnessService,
                                  PersistenceProtoResolver persistenceProtoResolver,
-                                 CorruptedStorageFileHandler corruptedStorageFileHandler) {
+                                 CorruptedStorageFileHandler corruptedStorageFileHandler,
+                                 KeyRing keyRing) {
         this.user = user;
         this.preferences = preferences;
         this.openOfferManager = openOfferManager;
@@ -76,6 +79,7 @@ class FiatAccountsDataModel extends ActivatableDataModel {
         this.accountAgeWitnessService = accountAgeWitnessService;
         this.persistenceProtoResolver = persistenceProtoResolver;
         this.corruptedStorageFileHandler = corruptedStorageFileHandler;
+        this.keyRing = keyRing;
         setChangeListener = change -> fillAndSortPaymentAccounts();
     }
 
@@ -153,12 +157,12 @@ class FiatAccountsDataModel extends ActivatableDataModel {
             ArrayList<PaymentAccount> accounts = new ArrayList<>(user.getPaymentAccounts().stream()
                     .filter(paymentAccount -> !(paymentAccount instanceof AssetAccount))
                     .collect(Collectors.toList()));
-            GUIUtil.exportAccounts(accounts, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler);
+            GUIUtil.exportAccounts(accounts, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler, keyRing);
         }
     }
 
     public void importAccounts(Stage stage) {
-        GUIUtil.importAccounts(user, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler);
+        GUIUtil.importAccounts(user, accountsFileName, preferences, stage, persistenceProtoResolver, corruptedStorageFileHandler, keyRing);
     }
 
     public int getNumPaymentAccounts() {

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -54,6 +54,7 @@ import bisq.network.p2p.P2PService;
 import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
 import bisq.common.config.Config;
+import bisq.common.crypto.KeyRing;
 import bisq.common.file.CorruptedStorageFileHandler;
 import bisq.common.persistence.PersistenceManager;
 import bisq.common.proto.persistable.PersistableEnvelope;
@@ -203,11 +204,12 @@ public class GUIUtil {
                                       Preferences preferences,
                                       Stage stage,
                                       PersistenceProtoResolver persistenceProtoResolver,
-                                      CorruptedStorageFileHandler corruptedStorageFileHandler) {
+                                      CorruptedStorageFileHandler corruptedStorageFileHandler,
+                                      KeyRing keyRing) {
         if (!accounts.isEmpty()) {
             String directory = getDirectoryFromChooser(preferences, stage);
             if (!directory.isEmpty()) {
-                PersistenceManager<PersistableEnvelope> persistenceManager = new PersistenceManager<>(new File(directory), persistenceProtoResolver, corruptedStorageFileHandler);
+                PersistenceManager<PersistableEnvelope> persistenceManager = new PersistenceManager<>(new File(directory), persistenceProtoResolver, corruptedStorageFileHandler, keyRing);
                 PaymentAccountList paymentAccounts = new PaymentAccountList(accounts);
                 persistenceManager.initialize(paymentAccounts, fileName, PersistenceManager.Source.PRIVATE_LOW_PRIO);
                 persistenceManager.persistNow(() -> {
@@ -227,7 +229,8 @@ public class GUIUtil {
                                       Preferences preferences,
                                       Stage stage,
                                       PersistenceProtoResolver persistenceProtoResolver,
-                                      CorruptedStorageFileHandler corruptedStorageFileHandler) {
+                                      CorruptedStorageFileHandler corruptedStorageFileHandler,
+                                      KeyRing keyRing) {
         FileChooser fileChooser = new FileChooser();
         File initDir = new File(preferences.getDirectoryChooserPath());
         if (initDir.isDirectory()) {
@@ -240,7 +243,7 @@ public class GUIUtil {
             if (Paths.get(path).getFileName().toString().equals(fileName)) {
                 String directory = Paths.get(path).getParent().toString();
                 preferences.setDirectoryChooserPath(directory);
-                PersistenceManager<PaymentAccountList> persistenceManager = new PersistenceManager<>(new File(directory), persistenceProtoResolver, corruptedStorageFileHandler);
+                PersistenceManager<PaymentAccountList> persistenceManager = new PersistenceManager<>(new File(directory), persistenceProtoResolver, corruptedStorageFileHandler, keyRing);
                 persistenceManager.readPersisted(fileName, persisted -> {
                             StringBuilder msg = new StringBuilder();
                             HashSet<PaymentAccount> paymentAccounts = new HashSet<>();

--- a/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PNetworkLoad.java
@@ -131,7 +131,7 @@ public class P2PNetworkLoad extends Metric implements MessageListener, SetupList
                 CorePersistenceProtoResolver persistenceProtoResolver = new CorePersistenceProtoResolver(null, null, networkProtoResolver);
                 DefaultSeedNodeRepository seedNodeRepository = new DefaultSeedNodeRepository(config);
                 PeerManager peerManager = new PeerManager(networkNode, seedNodeRepository, new ClockWatcher(),
-                        new PersistenceManager<>(torHiddenServiceDir, persistenceProtoResolver, corruptedStorageFileHandler), maxConnections);
+                        new PersistenceManager<>(torHiddenServiceDir, persistenceProtoResolver, corruptedStorageFileHandler, null), maxConnections);
 
                 // init file storage
                 peerManager.readPersisted(() -> {

--- a/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
+++ b/monitor/src/main/java/bisq/monitor/metric/P2PSeedNodeSnapshotBase.java
@@ -120,7 +120,7 @@ public abstract class P2PSeedNodeSnapshotBase extends Metric implements MessageL
                 //TODO will not work with historical data... should be refactored to re-use code for reading resource files
                 TradeStatistics3Store tradeStatistics3Store = new TradeStatistics3Store();
                 PersistenceManager<TradeStatistics3Store> tradeStatistics3PersistenceManager = new PersistenceManager<>(dir,
-                        persistenceProtoResolver, null);
+                        persistenceProtoResolver, null, null);
                 tradeStatistics3PersistenceManager.initialize(tradeStatistics3Store,
                         tradeStatistics3Store.getDefaultStorageFileName() + networkPostfix,
                         PersistenceManager.Source.NETWORK);
@@ -133,7 +133,7 @@ public abstract class P2PSeedNodeSnapshotBase extends Metric implements MessageL
 
                 AccountAgeWitnessStore accountAgeWitnessStore = new AccountAgeWitnessStore();
                 PersistenceManager<AccountAgeWitnessStore> accountAgeWitnessPersistenceManager = new PersistenceManager<>(dir,
-                        persistenceProtoResolver, null);
+                        persistenceProtoResolver, null, null);
                 accountAgeWitnessPersistenceManager.initialize(accountAgeWitnessStore,
                         accountAgeWitnessStore.getDefaultStorageFileName() + networkPostfix,
                         PersistenceManager.Source.NETWORK);

--- a/p2p/src/test/java/bisq/network/p2p/MockNode.java
+++ b/p2p/src/test/java/bisq/network/p2p/MockNode.java
@@ -30,6 +30,8 @@ import bisq.network.p2p.peers.peerexchange.PeerList;
 import bisq.network.p2p.seed.SeedNodeRepository;
 
 import bisq.common.ClockWatcher;
+import bisq.common.crypto.KeyRing;
+import bisq.common.crypto.KeyStorage;
 import bisq.common.file.CorruptedStorageFileHandler;
 import bisq.common.persistence.PersistenceManager;
 import bisq.common.proto.persistable.PersistenceProtoResolver;
@@ -64,7 +66,7 @@ public class MockNode {
         this.maxConnections = maxConnections;
         networkNode = mock(NetworkNode.class);
         File storageDir = Files.createTempDirectory("storage").toFile();
-        persistenceManager = new PersistenceManager<>(storageDir, mock(PersistenceProtoResolver.class), mock(CorruptedStorageFileHandler.class));
+        persistenceManager = new PersistenceManager<>(storageDir, mock(PersistenceProtoResolver.class), mock(CorruptedStorageFileHandler.class), mock(KeyRing.class));
         peerManager = new PeerManager(networkNode, mock(SeedNodeRepository.class), new ClockWatcher(), persistenceManager, maxConnections);
         connections = new HashSet<>();
         when(networkNode.getAllConnections()).thenReturn(connections);


### PR DESCRIPTION
Encrypts all persisted data using a symmetric key. The symmetric key is account password protected. This greatly simplifies the original account key ring password protection mechanism by using the standard PKCS12 file format with password protected encryption.

I ran `Can manage an account` to validate changes. Fixed an issue where a removal of a temp file in the middle of an account backup causes `Can manage an account` to fail.