### PR TITLE
Base/counter currencies and price inverted for crypto offers

### DIFF
--- a/cli/src/main/java/bisq/cli/CurrencyFormat.java
+++ b/cli/src/main/java/bisq/cli/CurrencyFormat.java
@@ -96,14 +96,14 @@ public class CurrencyFormat {
         return NUMBER_FORMAT.format(price);
     }
 
-    public static String formatPrice(long price) {
+    public static String formatPrice(double price) {
         NUMBER_FORMAT.setMinimumFractionDigits(4);
         NUMBER_FORMAT.setMaximumFractionDigits(4);
         NUMBER_FORMAT.setRoundingMode(UNNECESSARY);
         return NUMBER_FORMAT.format((double) price / 10_000);
     }
 
-    public static String formatCryptoCurrencyPrice(long price) {
+    public static String formatCryptoCurrencyPrice(double price) {
         NUMBER_FORMAT.setMinimumFractionDigits(8);
         NUMBER_FORMAT.setMaximumFractionDigits(8);
         NUMBER_FORMAT.setRoundingMode(UNNECESSARY);

--- a/core/src/main/java/bisq/core/api/CorePriceService.java
+++ b/core/src/main/java/bisq/core/api/CorePriceService.java
@@ -141,7 +141,7 @@ class CorePriceService {
 
         return new MarketDepthInfo(currencyCode, buyPrices, buyDepth, sellPrices, sellDepth);
     }
-    
+
     /**
      * PriceProvider returns different values for crypto and fiat,
      * e.g. 1 XMR = X USD
@@ -149,7 +149,7 @@ class CorePriceService {
      * Here we convert all to:
      * 1 XMR = X (FIAT or CRYPTO)
      */
-    private double mapPriceFeedServicePrice(double price, String currencyCode) {
+    public double mapPriceFeedServicePrice(double price, String currencyCode) {
         if (CurrencyUtil.isFiatCurrency(currencyCode)) {
             return price;
         }

--- a/core/src/main/java/bisq/core/offer/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/CreateOfferService.java
@@ -149,9 +149,8 @@ public class CreateOfferService {
         double marketPriceMarginParam = useMarketBasedPriceValue ? marketPriceMargin : 0;
         long amountAsLong = amount != null ? amount.getValue() : 0L;
         long minAmountAsLong = minAmount != null ? minAmount.getValue() : 0L;
-        boolean isCryptoCurrency = CurrencyUtil.isCryptoCurrency(currencyCode);
-        String baseCurrencyCode = isCryptoCurrency ? currencyCode : Res.getBaseCurrencyCode();
-        String counterCurrencyCode = isCryptoCurrency ? Res.getBaseCurrencyCode() : currencyCode;
+        String baseCurrencyCode = Res.getBaseCurrencyCode();
+        String counterCurrencyCode = currencyCode;
         List<NodeAddress> acceptedArbitratorAddresses = user.getAcceptedArbitratorAddresses();
         ArrayList<NodeAddress> arbitratorNodeAddresses = acceptedArbitratorAddresses != null ?
                 Lists.newArrayList(acceptedArbitratorAddresses) :

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -444,9 +444,7 @@ public class Offer implements NetworkPayload, PersistablePayload {
             return currencyCode;
         }
 
-        currencyCode = offerPayload.getBaseCurrencyCode().equals("XMR") ?
-                offerPayload.getCounterCurrencyCode() :
-                offerPayload.getBaseCurrencyCode();
+        currencyCode = offerPayload.getCurrencyCode();
         return currencyCode;
     }
 
@@ -541,7 +539,7 @@ public class Offer implements NetworkPayload, PersistablePayload {
     }
 
     public boolean isXmr() {
-        return getCurrencyCode().equals("XMR");
+        return getCurrencyCode().equals("XMR"); // TODO: this never returns true
     }
 
     @Override

--- a/core/src/main/java/bisq/core/offer/OfferBookService.java
+++ b/core/src/main/java/bisq/core/offer/OfferBookService.java
@@ -204,7 +204,7 @@ public class OfferBookService {
 
     public List<Offer> getOffersByCurrency(String direction, String currencyCode) {
         return getOffers().stream()
-                .filter(o -> o.getOfferPayload().getBaseCurrencyCode().equalsIgnoreCase(currencyCode) && o.getDirection().name() == direction)
+                .filter(o -> o.getCurrencyCode().equalsIgnoreCase(currencyCode) && o.getDirection().name() == direction)
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bisq/core/offer/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayload.java
@@ -372,12 +372,6 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
         return pubKeyRing.getSignaturePubKey();
     }
 
-    // In the offer we support base and counter currency
-    // Fiat offers have base currency XMR and counterCurrency Fiat
-    // Altcoins have base currency Altcoin and counterCurrency XMR
-    // The rest of the app does not support yet that concept of base currency and counter currencies
-    // so we map here for convenience
-    // NOTE: Altcoins now use XMR base currency in grpc created offers since CreateOfferService
     public String getCurrencyCode() {
         return getBaseCurrencyCode().equals("XMR") ? getCounterCurrencyCode() : getBaseCurrencyCode();
     }

--- a/core/src/main/java/bisq/core/offer/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayload.java
@@ -114,8 +114,6 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     private final long amount;
     private final long minAmount;
 
-    // For fiat offer the baseCurrencyCode is BTC and the counterCurrencyCode is the fiat currency
-    // For altcoin offers it is the opposite. baseCurrencyCode is the altcoin and the counterCurrencyCode is BTC.
     private final String baseCurrencyCode;
     private final String counterCurrencyCode;
 
@@ -166,7 +164,7 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     @Nullable
     private final Map<String, String> extraDataMap;
     private final int protocolVersion;
-    
+
     // address and signature of signing arbitrator
     @Setter
     private NodeAddress arbitratorSigner;
@@ -379,6 +377,7 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     // Altcoins have base currency Altcoin and counterCurrency XMR
     // The rest of the app does not support yet that concept of base currency and counter currencies
     // so we map here for convenience
+    // NOTE: Altcoins now use XMR base currency in grpc created offers since CreateOfferService
     public String getCurrencyCode() {
         return getBaseCurrencyCode().equals("XMR") ? getCounterCurrencyCode() : getBaseCurrencyCode();
     }

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -504,7 +504,7 @@ message CancelOfferReply {
 message OfferInfo {
     string id = 1;
     string direction = 2;
-    uint64 price = 3;
+    double price = 3;
     bool use_market_based_price = 4;
     double market_price_margin = 5;
     uint64 amount = 6;


### PR DESCRIPTION
Requesting review for changes for haveno-dex/haveno#293.

I first attempted to remove all of the price inversions but hit major issues due to the extensive usage of the crypto currency price inversions. They are all over the place and will be quite destabilizing to change (see all callers of [CurrencyUtil.isCryptoCurrency](https://github.com/haveno-dex/haveno/blob/e91b96227f0fa4392a7b119588ecd193e58d081a/core/src/main/java/bisq/core/locale/CurrencyUtil.java#L426) and  [CurrencyUtil.isFiatCurrency](https://github.com/haveno-dex/haveno/blob/e91b96227f0fa4392a7b119588ecd193e58d081a/core/src/main/java/bisq/core/locale/CurrencyUtil.java#L387).

The proposed changes removes the crypto currency pair inversion correctly, but does not change the price inversion logic as required from the underlying logic pervasive throughout the application. Instead, the interface called from grpc offer service will automatically invert and un-invert the prices so the grpc client will expect to pass in XMR based prices and recieve the same offer price values as passed in.

I ran `Can post and remove offers`, `Can get market depth`, and `Can complete a trade`.
