### PR TITLE
Base/counter currencies and price inverted for crypto offers

### DIFF
--- a/core/src/main/java/bisq/core/api/CoreOffersService.java
+++ b/core/src/main/java/bisq/core/api/CoreOffersService.java
@@ -141,7 +141,7 @@ class CoreOffersService {
     }
 
     List<Offer> getMyOffers(String direction, String currencyCode) {
-        
+
         // get my open offers
         List<Offer> offers = openOfferManager.getObservableList().stream()
                 .map(OpenOffer::getOffer)
@@ -163,10 +163,10 @@ class CoreOffersService {
 
         return offers;
     }
-    
+
     private Set<Offer> getUnreservedOffers(List<Offer> offers) {
         Set<Offer> unreservedOffers = new HashSet<Offer>();
-        
+
         // collect reserved key images and check for duplicate funds
         List<String> allKeyImages = new ArrayList<String>();
         for (Offer offer : offers) {
@@ -178,7 +178,7 @@ class CoreOffersService {
             }
           }
         }
-        
+
         // get spent key images
         // TODO (woodser): paginate offers and only check key images of current page
         List<String> spentKeyImages = new ArrayList<String>();
@@ -186,7 +186,7 @@ class CoreOffersService {
         for (int i = 0; i < spentStatuses.size(); i++) {
           if (spentStatuses.get(i) != MoneroKeyImageSpentStatus.NOT_SPENT) spentKeyImages.add(allKeyImages.get(i));
         }
-        
+
         // check for offers with spent key images
         for (Offer offer : offers) {
           if (offer.getOfferPayload().getReserveTxKeyImages() == null) continue;
@@ -198,7 +198,7 @@ class CoreOffersService {
             }
           }
         }
-        
+
         return unreservedOffers;
     }
 
@@ -321,7 +321,7 @@ class CoreOffersService {
                                                      String direction,
                                                      String currencyCode) {
         var offerOfWantedDirection = offer.getDirection().name().equalsIgnoreCase(direction);
-        var counterAssetCode = isCryptoCurrency(currencyCode) ? offer.getOfferPayload().getBaseCurrencyCode() : offer.getOfferPayload().getCounterCurrencyCode(); // TODO: crypto pairs invert base and counter currencies
+        var counterAssetCode = offer.getOfferPayload().getCounterCurrencyCode();
         var offerInWantedCurrency = counterAssetCode.equalsIgnoreCase(currencyCode);
         return offerOfWantedDirection && offerInWantedCurrency;
     }

--- a/core/src/main/java/bisq/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/bisq/core/locale/CurrencyUtil.java
@@ -417,17 +417,11 @@ public class CurrencyUtil {
     }
 
     public static String getCurrencyPair(String currencyCode) {
-        if (isFiatCurrency(currencyCode))
-            return Res.getBaseCurrencyCode() + "/" + currencyCode;
-        else
-            return currencyCode + "/" + Res.getBaseCurrencyCode();
+        return Res.getBaseCurrencyCode() + "/" + currencyCode;
     }
 
     public static String getCounterCurrency(String currencyCode) {
-        if (isFiatCurrency(currencyCode))
-            return currencyCode;
-        else
-            return Res.getBaseCurrencyCode();
+        return currencyCode;
     }
 
     public static String getPriceWithCurrencyCode(String currencyCode) {
@@ -435,10 +429,7 @@ public class CurrencyUtil {
     }
 
     public static String getPriceWithCurrencyCode(String currencyCode, String translationKey) {
-        if (isCryptoCurrency(currencyCode))
-            return Res.get(translationKey, Res.getBaseCurrencyCode(), currencyCode);
-        else
-            return Res.get(translationKey, currencyCode, Res.getBaseCurrencyCode());
+        return Res.get(translationKey, currencyCode, Res.getBaseCurrencyCode());
     }
 
     public static String getOfferVolumeCode(String currencyCode) {

--- a/core/src/main/java/bisq/core/monetary/AltcoinExchangeRate.java
+++ b/core/src/main/java/bisq/core/monetary/AltcoinExchangeRate.java
@@ -60,9 +60,8 @@ public class AltcoinExchangeRate {
      * @throws ArithmeticException if the converted altcoin amount is too high or too low.
      */
     public Altcoin coinToAltcoin(Coin convertCoin) {
-        BigInteger converted = BigInteger.valueOf(coin.value)
-                .multiply(BigInteger.valueOf(convertCoin.value))
-                .divide(BigInteger.valueOf(altcoin.value));
+        BigInteger converted = BigInteger.valueOf(convertCoin.value).multiply(BigInteger.valueOf(altcoin.value))
+                .divide(BigInteger.valueOf(coin.value));
         if (converted.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0
                 || converted.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0)
             throw new ArithmeticException("Overflow");
@@ -78,9 +77,8 @@ public class AltcoinExchangeRate {
         checkArgument(convertAltcoin.currencyCode.equals(altcoin.currencyCode), "Currency mismatch: %s vs %s",
                 convertAltcoin.currencyCode, altcoin.currencyCode);
         // Use BigInteger because it's much easier to maintain full precision without overflowing.
-        BigInteger converted = BigInteger.valueOf(altcoin.value)
-                .multiply(BigInteger.valueOf(convertAltcoin.value))
-                .divide(BigInteger.valueOf(coin.value));
+        BigInteger converted = BigInteger.valueOf(convertAltcoin.value).multiply(BigInteger.valueOf(coin.value))
+                .divide(BigInteger.valueOf(altcoin.value));
         if (converted.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0
                 || converted.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0)
             throw new ArithmeticException("Overflow");

--- a/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
+++ b/core/src/main/java/bisq/core/notifications/alerts/market/MarketAlerts.java
@@ -122,7 +122,6 @@ public class MarketAlerts {
         if (marketPrice != null && offerPrice != null) {
             boolean isSellOffer = offer.getDirection() == OfferDirection.SELL;
             String shortOfferId = offer.getShortId();
-            boolean isFiatCurrency = CurrencyUtil.isFiatCurrency(currencyCode);
             String alertId = getAlertId(offer);
             user.getMarketAlertFilters().stream()
                     .filter(marketAlertFilter -> !offer.isMyOffer(keyRing))
@@ -139,9 +138,9 @@ public class MarketAlerts {
                         double offerPriceValue = offerPrice.getValue();
                         double ratio = offerPriceValue / marketPriceAsDouble;
                         ratio = 1 - ratio;
-                        if (isFiatCurrency && isSellOffer)
+                        if (isSellOffer)
                             ratio *= -1;
-                        else if (!isFiatCurrency && !isSellOffer)
+                        else
                             ratio *= -1;
 
                         ratio = ratio * 10000;
@@ -154,26 +153,14 @@ public class MarketAlerts {
                         if (isTriggerForBuyOfferAndTriggered || isTriggerForSellOfferAndTriggered) {
                             String direction = isSellOffer ? Res.get("shared.sell") : Res.get("shared.buy");
                             String marketDir;
-                            if (isFiatCurrency) {
-                                if (isSellOffer) {
-                                    marketDir = ratio > 0 ?
-                                            Res.get("account.notifications.marketAlert.message.msg.above") :
-                                            Res.get("account.notifications.marketAlert.message.msg.below");
-                                } else {
-                                    marketDir = ratio < 0 ?
-                                            Res.get("account.notifications.marketAlert.message.msg.above") :
-                                            Res.get("account.notifications.marketAlert.message.msg.below");
-                                }
+                            if (isSellOffer) {
+                                marketDir = ratio > 0 ?
+                                        Res.get("account.notifications.marketAlert.message.msg.above") :
+                                        Res.get("account.notifications.marketAlert.message.msg.below");
                             } else {
-                                if (isSellOffer) {
-                                    marketDir = ratio < 0 ?
-                                            Res.get("account.notifications.marketAlert.message.msg.above") :
-                                            Res.get("account.notifications.marketAlert.message.msg.below");
-                                } else {
-                                    marketDir = ratio > 0 ?
-                                            Res.get("account.notifications.marketAlert.message.msg.above") :
-                                            Res.get("account.notifications.marketAlert.message.msg.below");
-                                }
+                                marketDir = ratio < 0 ?
+                                        Res.get("account.notifications.marketAlert.message.msg.above") :
+                                        Res.get("account.notifications.marketAlert.message.msg.below");
                             }
 
                             ratio = Math.abs(ratio);

--- a/core/src/main/java/bisq/core/offer/CreateOfferService.java
+++ b/core/src/main/java/bisq/core/offer/CreateOfferService.java
@@ -151,9 +151,8 @@ public class CreateOfferService {
         double marketPriceMarginParam = useMarketBasedPriceValue ? marketPriceMargin : 0;
         long amountAsLong = amount != null ? amount.getValue() : 0L;
         long minAmountAsLong = minAmount != null ? minAmount.getValue() : 0L;
-        boolean isCryptoCurrency = CurrencyUtil.isCryptoCurrency(currencyCode);
-        String baseCurrencyCode = isCryptoCurrency ? currencyCode : Res.getBaseCurrencyCode();
-        String counterCurrencyCode = isCryptoCurrency ? Res.getBaseCurrencyCode() : currencyCode;
+        String baseCurrencyCode = Res.getBaseCurrencyCode();
+        String counterCurrencyCode = currencyCode;
         List<NodeAddress> acceptedArbitratorAddresses = user.getAcceptedArbitratorAddresses();
         ArrayList<NodeAddress> arbitratorNodeAddresses = acceptedArbitratorAddresses != null ?
                 Lists.newArrayList(acceptedArbitratorAddresses) :

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -171,15 +171,12 @@ public class Offer implements NetworkPayload, PersistablePayload {
         checkNotNull(priceFeedService, "priceFeed must not be null");
         MarketPrice marketPrice = priceFeedService.getMarketPrice(currencyCode);
         if (marketPrice != null && marketPrice.isRecentExternalPriceAvailable()) {
-            double factor;
             double marketPriceMargin = offerPayload.getMarketPriceMarginPct();
-            if (CurrencyUtil.isCryptoCurrency(currencyCode)) {
-                factor = getDirection() == OfferDirection.SELL ?
-                        1 - marketPriceMargin : 1 + marketPriceMargin;
-            } else {
-                factor = getDirection() == OfferDirection.BUY ?
-                        1 - marketPriceMargin : 1 + marketPriceMargin;
-            }
+
+            // if buying the base currency you would want a lower price
+            double factor = getDirection() == OfferDirection.BUY ?
+                    1 - marketPriceMargin : 1 + marketPriceMargin;
+
             double marketPriceAsDouble = marketPrice.getPrice();
             double targetPriceAsDouble = marketPriceAsDouble * factor;
             try {
@@ -445,9 +442,7 @@ public class Offer implements NetworkPayload, PersistablePayload {
             return currencyCode;
         }
 
-        currencyCode = offerPayload.getBaseCurrencyCode().equals("XMR") ?
-                offerPayload.getCounterCurrencyCode() :
-                offerPayload.getBaseCurrencyCode();
+        currencyCode = offerPayload.getCurrencyCode();
         return currencyCode;
     }
 
@@ -533,7 +528,7 @@ public class Offer implements NetworkPayload, PersistablePayload {
     }
 
     public boolean isXmr() {
-        return getCurrencyCode().equals("XMR");
+        return getCurrencyCode().equals("XMR"); // TODO: this never returns true
     }
 
     public boolean isFiatOffer() {

--- a/core/src/main/java/bisq/core/offer/OfferBookService.java
+++ b/core/src/main/java/bisq/core/offer/OfferBookService.java
@@ -204,7 +204,7 @@ public class OfferBookService {
 
     public List<Offer> getOffersByCurrency(String direction, String currencyCode) {
         return getOffers().stream()
-                .filter(o -> o.getOfferPayload().getBaseCurrencyCode().equalsIgnoreCase(currencyCode) && o.getDirection().name() == direction)
+                .filter(o -> o.getCurrencyCode().equalsIgnoreCase(currencyCode) && o.getDirection().name() == direction)
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bisq/core/offer/OfferForJson.java
+++ b/core/src/main/java/bisq/core/offer/OfferForJson.java
@@ -103,44 +103,23 @@ public class OfferForJson {
     private void setDisplayStrings() {
         try {
             final Price price = getPrice();
-            if (CurrencyUtil.isCryptoCurrency(currencyCode)) {
-                primaryMarketDirection = direction == OfferDirection.BUY ? OfferDirection.SELL : OfferDirection.BUY;
-                currencyPair = currencyCode + "/" + Res.getBaseCurrencyCode();
+            boolean isCrypto = CurrencyUtil.isCryptoCurrency(currencyCode);
+            primaryMarketDirection = direction;
+            currencyPair = Res.getBaseCurrencyCode() + "/" + currencyCode;
 
-                // int precision = 8;
-                //decimalFormat.setMaximumFractionDigits(precision);
+            priceDisplayString = fiatFormat.noCode().format(price.getMonetary()).toString();
+            primaryMarketMinAmountDisplayString = coinFormat.noCode().format(getMinAmountAsCoin()).toString();
+            primaryMarketAmountDisplayString = coinFormat.noCode().format(getAmountAsCoin()).toString();
+            primaryMarketMinVolumeDisplayString = fiatFormat.noCode().format(getMinVolume().getMonetary()).toString();
+            primaryMarketVolumeDisplayString = fiatFormat.noCode().format(getVolume().getMonetary()).toString();
 
-                // amount and volume is inverted for json
-                priceDisplayString = altcoinFormat.noCode().format(price.getMonetary()).toString();
-                primaryMarketMinAmountDisplayString = altcoinFormat.noCode().format(getMinVolume().getMonetary()).toString();
-                primaryMarketAmountDisplayString = altcoinFormat.noCode().format(getVolume().getMonetary()).toString();
-                primaryMarketMinVolumeDisplayString = coinFormat.noCode().format(getMinAmountAsCoin()).toString();
-                primaryMarketVolumeDisplayString = coinFormat.noCode().format(getAmountAsCoin()).toString();
+            // we use precision 4 for fiat based price but on the markets api we use precision 8 so we scale up by 10000
+            primaryMarketPrice = isCrypto ? price.getValue() : (long) MathUtils.scaleUpByPowerOf10(price.getValue(), 4);
+            primaryMarketMinVolume = isCrypto ? getMinVolume().getValue() : (long) MathUtils.scaleUpByPowerOf10(getMinVolume().getValue(), 4);
+            primaryMarketVolume = isCrypto ? getVolume().getValue() : (long) MathUtils.scaleUpByPowerOf10(getVolume().getValue(), 4);
 
-                primaryMarketPrice = price.getValue();
-                primaryMarketMinAmount = getMinVolume().getValue();
-                primaryMarketAmount = getVolume().getValue();
-                primaryMarketMinVolume = getMinAmountAsCoin().getValue();
-                primaryMarketVolume = getAmountAsCoin().getValue();
-            } else {
-                primaryMarketDirection = direction;
-                currencyPair = Res.getBaseCurrencyCode() + "/" + currencyCode;
-
-                priceDisplayString = fiatFormat.noCode().format(price.getMonetary()).toString();
-                primaryMarketMinAmountDisplayString = coinFormat.noCode().format(getMinAmountAsCoin()).toString();
-                primaryMarketAmountDisplayString = coinFormat.noCode().format(getAmountAsCoin()).toString();
-                primaryMarketMinVolumeDisplayString = fiatFormat.noCode().format(getMinVolume().getMonetary()).toString();
-                primaryMarketVolumeDisplayString = fiatFormat.noCode().format(getVolume().getMonetary()).toString();
-
-                // we use precision 4 for fiat based price but on the markets api we use precision 8 so we scale up by 10000
-                primaryMarketPrice = (long) MathUtils.scaleUpByPowerOf10(price.getValue(), 4);
-                primaryMarketMinVolume = (long) MathUtils.scaleUpByPowerOf10(getMinVolume().getValue(), 4);
-                primaryMarketVolume = (long) MathUtils.scaleUpByPowerOf10(getVolume().getValue(), 4);
-
-                primaryMarketMinAmount = getMinAmountAsCoin().getValue();
-                primaryMarketAmount = getAmountAsCoin().getValue();
-            }
-
+            primaryMarketMinAmount = getMinAmountAsCoin().getValue();
+            primaryMarketAmount = getAmountAsCoin().getValue();
         } catch (Throwable t) {
             log.error("Error at setDisplayStrings: " + t.getMessage());
         }

--- a/core/src/main/java/bisq/core/offer/OfferPayload.java
+++ b/core/src/main/java/bisq/core/offer/OfferPayload.java
@@ -55,8 +55,6 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
 
     protected final String id;
     protected final long date;
-    // For fiat offer the baseCurrencyCode is BTC and the counterCurrencyCode is the fiat currency
-    // For altcoin offers it is the opposite. baseCurrencyCode is the altcoin and the counterCurrencyCode is BTC.
     protected final String baseCurrencyCode;
     protected final String counterCurrencyCode;
     // price if fixed price is used (usePercentageBasedPrice = false), otherwise 0
@@ -75,7 +73,7 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     protected transient byte[] hash;
     @Nullable
     protected final Map<String, String> extraDataMap;
-    
+
     // address and signature of signing arbitrator
     @Setter
     protected NodeAddress arbitratorSigner;
@@ -85,7 +83,7 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     @Setter
     @Nullable
     protected List<String> reserveTxKeyImages;
-    
+
     // Keys for extra map
     // Only set for fiat offers
     public static final String ACCOUNT_AGE_WITNESS_HASH = "accountAgeWitnessHash";
@@ -254,11 +252,6 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
         return pubKeyRing.getSignaturePubKey();
     }
 
-    // In the offer we support base and counter currency
-    // Fiat offers have base currency XMR and counterCurrency Fiat
-    // Altcoins have base currency Altcoin and counterCurrency XMR
-    // The rest of the app does not support yet that concept of base currency and counter currencies
-    // so we map here for convenience
     public String getCurrencyCode() {
         return getBaseCurrencyCode().equals("XMR") ? getCounterCurrencyCode() : getBaseCurrencyCode();
     }

--- a/core/src/main/java/bisq/core/offer/TriggerPriceService.java
+++ b/core/src/main/java/bisq/core/offer/TriggerPriceService.java
@@ -129,8 +129,7 @@ public class TriggerPriceService {
 
         OfferDirection direction = openOffer.getOffer().getDirection();
         boolean isSellOffer = direction == OfferDirection.SELL;
-        boolean condition = isSellOffer && !cryptoCurrency || !isSellOffer && cryptoCurrency;
-        return condition ?
+        return isSellOffer ?
                 marketPriceAsLong < triggerPrice :
                 marketPriceAsLong > triggerPrice;
     }

--- a/core/src/main/java/bisq/core/provider/price/PriceProvider.java
+++ b/core/src/main/java/bisq/core/provider/price/PriceProvider.java
@@ -83,7 +83,7 @@ public class PriceProvider extends HttpClientProvider {
                 // convert price from btc to xmr
                 boolean isFiat = CurrencyUtil.isFiatCurrency(currencyCode);
                 if (isFiat) price = price * btcPerXmr;
-                else price = price / btcPerXmr;
+                else price = btcPerXmr / price;
 
                 // add currency price to map
                 marketPriceMap.put(currencyCode, new MarketPrice(currencyCode, price, timestampSec, true));
@@ -94,7 +94,7 @@ public class PriceProvider extends HttpClientProvider {
         }
 
         // add btc to price map, remove xmr since base currency
-        marketPriceMap.put("BTC", new MarketPrice("BTC", 1 / btcPerXmr, marketPriceMap.get("XMR").getTimestampSec(), true));
+        marketPriceMap.put("BTC", new MarketPrice("BTC", btcPerXmr, marketPriceMap.get("XMR").getTimestampSec(), true));
         marketPriceMap.remove("XMR");
         return new Tuple2<>(tsMap, marketPriceMap);
     }

--- a/core/src/main/java/bisq/core/trade/TradeUtil.java
+++ b/core/src/main/java/bisq/core/trade/TradeUtil.java
@@ -36,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nullable;
 
 import static bisq.core.locale.CurrencyUtil.getCurrencyPair;
-import static bisq.core.locale.CurrencyUtil.isFiatCurrency;
 import static bisq.core.util.FormattingUtils.formatDurationAsWords;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -204,25 +203,14 @@ public class TradeUtil {
      * @return String describing a trader's role
      */
     public String getRole(boolean isBuyerMakerAndSellerTaker, boolean isMaker, String currencyCode) {
-        if (isFiatCurrency(currencyCode)) {
-            String baseCurrencyCode = Res.getBaseCurrencyCode();
-            if (isBuyerMakerAndSellerTaker)
-                return isMaker
-                        ? Res.get("formatter.asMaker", baseCurrencyCode, Res.get("shared.buyer"))
-                        : Res.get("formatter.asTaker", baseCurrencyCode, Res.get("shared.seller"));
-            else
-                return isMaker
-                        ? Res.get("formatter.asMaker", baseCurrencyCode, Res.get("shared.seller"))
-                        : Res.get("formatter.asTaker", baseCurrencyCode, Res.get("shared.buyer"));
-        } else {
-            if (isBuyerMakerAndSellerTaker)
-                return isMaker
-                        ? Res.get("formatter.asMaker", currencyCode, Res.get("shared.seller"))
-                        : Res.get("formatter.asTaker", currencyCode, Res.get("shared.buyer"));
-            else
-                return isMaker
-                        ? Res.get("formatter.asMaker", currencyCode, Res.get("shared.buyer"))
-                        : Res.get("formatter.asTaker", currencyCode, Res.get("shared.seller"));
-        }
+        String baseCurrencyCode = Res.getBaseCurrencyCode();
+        if (isBuyerMakerAndSellerTaker)
+            return isMaker
+                    ? Res.get("formatter.asMaker", baseCurrencyCode, Res.get("shared.buyer"))
+                    : Res.get("formatter.asTaker", baseCurrencyCode, Res.get("shared.seller"));
+        else
+            return isMaker
+                    ? Res.get("formatter.asMaker", baseCurrencyCode, Res.get("shared.seller"))
+                    : Res.get("formatter.asTaker", baseCurrencyCode, Res.get("shared.buyer"));
     }
 }

--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsForJson.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsForJson.java
@@ -59,23 +59,15 @@ public final class TradeStatisticsForJson {
 
         try {
             Price tradePrice = getPrice();
-            if (CurrencyUtil.isCryptoCurrency(currency)) {
-                currencyPair = currency + "/" + Res.getBaseCurrencyCode();
-                primaryMarketTradePrice = tradePrice.getValue();
-                primaryMarketTradeAmount = getTradeVolume() != null ?
-                        getTradeVolume().getValue() :
-                        0;
-                primaryMarketTradeVolume = getTradeAmount().getValue();
-            } else {
-                currencyPair = Res.getBaseCurrencyCode() + "/" + currency;
-                // we use precision 4 for fiat based price but on the markets api we use precision 8 so we scale up by 10000
-                primaryMarketTradePrice = (long) MathUtils.scaleUpByPowerOf10(tradePrice.getValue(), 4);
-                primaryMarketTradeAmount = getTradeAmount().getValue();
-                // we use precision 4 for fiat but on the markets api we use precision 8 so we scale up by 10000
-                primaryMarketTradeVolume = getTradeVolume() != null ?
-                        (long) MathUtils.scaleUpByPowerOf10(getTradeVolume().getValue(), 4) :
-                        0;
-            }
+            boolean isCrypto = CurrencyUtil.isCryptoCurrency(currency);
+            currencyPair = Res.getBaseCurrencyCode() + "/" + currency;
+            // we use precision 4 for fiat based price but on the markets api we use precision 8 so we scale up by 10000
+            primaryMarketTradePrice = isCrypto ? tradePrice.getValue() : (long) MathUtils.scaleUpByPowerOf10(tradePrice.getValue(), 4);
+            primaryMarketTradeAmount = getTradeAmount().getValue();
+            // we use precision 4 for fiat but on the markets api we use precision 8 so we scale up by 10000
+            primaryMarketTradeVolume = getTradeVolume() != null ?
+                    (isCrypto ? getTradeVolume().getValue() : (long) MathUtils.scaleUpByPowerOf10(getTradeVolume().getValue(), 4)) :
+                    0;
         } catch (Throwable t) {
             log.error(t.getMessage());
             t.printStackTrace();

--- a/core/src/main/java/bisq/core/util/PriceUtil.java
+++ b/core/src/main/java/bisq/core/util/PriceUtil.java
@@ -80,7 +80,7 @@ public class PriceUtil {
         long marketPriceAsLong = PriceUtil.getMarketPriceAsLong("" +  marketPrice.getPrice(), marketPrice.getCurrencyCode());
         String marketPriceAsString = FormattingUtils.formatMarketPrice(marketPrice.getPrice(), marketPrice.getCurrencyCode());
 
-        if ((isSellOffer && isFiatCurrency) || (!isSellOffer && !isFiatCurrency)) {
+        if (isSellOffer) {
             if (triggerPriceAsLong >= marketPriceAsLong) {
                 return new InputValidator.ValidationResult(false,
                         Res.get("createOffer.triggerPrice.invalid.tooHigh", marketPriceAsString));
@@ -148,29 +148,15 @@ public class PriceUtil {
         double scaled = MathUtils.scaleDownByPowerOf10(priceAsLong, precision);
         double value;
         if (direction == OfferDirection.SELL) {
-            if (CurrencyUtil.isFiatCurrency(currencyCode)) {
-                if (marketPrice == 0) {
-                    return Optional.empty();
-                }
-                value = 1 - scaled / marketPrice;
-            } else {
-                if (marketPrice == 1) {
-                    return Optional.empty();
-                }
-                value = scaled / marketPrice - 1;
+            if (marketPrice == 0) {
+                return Optional.empty();
             }
+            value = 1 - scaled / marketPrice;
         } else {
-            if (CurrencyUtil.isFiatCurrency(currencyCode)) {
-                if (marketPrice == 1) {
-                    return Optional.empty();
-                }
-                value = scaled / marketPrice - 1;
-            } else {
-                if (marketPrice == 0) {
-                    return Optional.empty();
-                }
-                value = 1 - scaled / marketPrice;
+            if (marketPrice == 1) {
+                return Optional.empty();
             }
+            value = scaled / marketPrice - 1;
         }
         return Optional.of(value);
     }

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -240,8 +240,8 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
                         }
                     });
 
-                    String viewBaseCurrencyCode = CurrencyUtil.isCryptoCurrency(code) ? code : Res.getBaseCurrencyCode();
-                    String viewPriceCurrencyCode = CurrencyUtil.isCryptoCurrency(code) ? Res.getBaseCurrencyCode() : code;
+                    String viewBaseCurrencyCode = Res.getBaseCurrencyCode();
+                    String viewPriceCurrencyCode = code;
 
                     sellHeaderLabel.setText(Res.get("market.offerBook.sellOffersHeaderLabel", viewBaseCurrencyCode));
                     sellButton.updateText(Res.get("shared.sellCurrency", viewBaseCurrencyCode, viewPriceCurrencyCode));

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartViewModel.java
@@ -312,13 +312,6 @@ class OfferBookChartViewModel extends ActivatableViewModel {
         // Offer price can be null (if price feed unavailable), thus a null-tolerant comparator is used.
         Comparator<Offer> offerPriceComparator = Comparator.comparing(Offer::getPrice, Comparator.nullsLast(Comparator.naturalOrder()));
 
-        // Trading btc-fiat is considered as buying/selling BTC, but trading btc-altcoin is
-        // considered as buying/selling Altcoin. Because of this, when viewing a btc-altcoin pair,
-        // the buy column is actually the sell column and vice versa. To maintain the expected
-        // ordering, we have to reverse the price comparator.
-        boolean isCrypto = CurrencyUtil.isCryptoCurrency(getCurrencyCode());
-//        if (isCrypto) offerPriceComparator = offerPriceComparator.reversed();
-
         // Offer amounts are used for the secondary sort. They are sorted from high to low.
         Comparator<Offer> offerAmountComparator = Comparator.comparing(Offer::getAmount).reversed();
 
@@ -329,7 +322,7 @@ class OfferBookChartViewModel extends ActivatableViewModel {
                 offerPriceComparator
                         .thenComparing(offerAmountComparator);
 
-        OfferDirection buyOfferDirection = isCrypto ? OfferDirection.SELL : OfferDirection.BUY;
+        OfferDirection buyOfferDirection = OfferDirection.BUY;
 
         List<Offer> allBuyOffers = offerBookListItems.stream()
                 .map(OfferBookListItem::getOffer)
@@ -360,7 +353,7 @@ class OfferBookChartViewModel extends ActivatableViewModel {
 
         buildChartAndTableEntries(allBuyOffers, OfferDirection.BUY, buyData, topBuyOfferList);
 
-        OfferDirection sellOfferDirection = isCrypto ? OfferDirection.BUY : OfferDirection.SELL;
+        OfferDirection sellOfferDirection = OfferDirection.SELL;
 
         List<Offer> allSellOffers = offerBookListItems.stream()
                 .map(OfferBookListItem::getOffer)

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferView.java
@@ -311,20 +311,12 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
         if (OfferViewUtil.isShownAsBuyOffer(direction, tradeCurrency)) {
             placeOfferButton.setId("buy-button-big");
-            if (CurrencyUtil.isFiatCurrency(tradeCurrency.getCode())) {
-                placeOfferButtonLabel = Res.get("createOffer.placeOfferButton", Res.get("shared.buy"));
-            } else {
-                placeOfferButtonLabel = Res.get("createOffer.placeOfferButtonAltcoin", Res.get("shared.buy"), tradeCurrency.getCode());
-            }
+            placeOfferButtonLabel = Res.get("createOffer.placeOfferButton", Res.get("shared.buy"));
             nextButton.setId("buy-button");
             fundFromSavingsWalletButton.setId("buy-button");
         } else {
             placeOfferButton.setId("sell-button-big");
-            if (CurrencyUtil.isFiatCurrency(tradeCurrency.getCode())) {
-                placeOfferButtonLabel = Res.get("createOffer.placeOfferButton", Res.get("shared.sell"));
-            } else {
-                placeOfferButtonLabel = Res.get("createOffer.placeOfferButtonAltcoin", Res.get("shared.sell"), tradeCurrency.getCode());
-            }
+            placeOfferButtonLabel = Res.get("createOffer.placeOfferButton", Res.get("shared.sell"));
             nextButton.setId("sell-button");
             fundFromSavingsWalletButton.setId("sell-button");
         }
@@ -714,15 +706,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             marketBasedPriceTextField.clear();
             volumeTextField.clear();
             triggerPriceInputTextField.clear();
-            if (!CurrencyUtil.isFiatCurrency(newValue)) {
-                if (model.isShownAsBuyOffer()) {
-                    placeOfferButton.updateText(Res.get("createOffer.placeOfferButtonAltcoin", Res.get("shared.buy"),
-                            model.getTradeCurrency().getCode()));
-                } else {
-                    placeOfferButton.updateText(Res.get("createOffer.placeOfferButtonAltcoin", Res.get("shared.sell"),
-                            model.getTradeCurrency().getCode()));
-                }
-            }
         };
 
         placeOfferCompletedListener = (o, oldValue, newValue) -> {

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -261,15 +261,11 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     private void addBindings() {
         if (dataModel.getDirection() == OfferDirection.BUY) {
             volumeDescriptionLabel.bind(createStringBinding(
-                    () -> Res.get(CurrencyUtil.isFiatCurrency(dataModel.getTradeCurrencyCode().get()) ?
-                            "createOffer.amountPriceBox.buy.volumeDescription" :
-                            "createOffer.amountPriceBox.buy.volumeDescriptionAltcoin", dataModel.getTradeCurrencyCode().get()),
+                    () -> Res.get("createOffer.amountPriceBox.buy.volumeDescription", dataModel.getTradeCurrencyCode().get()),
                     dataModel.getTradeCurrencyCode()));
         } else {
             volumeDescriptionLabel.bind(createStringBinding(
-                    () -> Res.get(CurrencyUtil.isFiatCurrency(dataModel.getTradeCurrencyCode().get()) ?
-                            "createOffer.amountPriceBox.sell.volumeDescription" :
-                            "createOffer.amountPriceBox.sell.volumeDescriptionAltcoin", dataModel.getTradeCurrencyCode().get()),
+                    () -> Res.get("createOffer.amountPriceBox.sell.volumeDescription", dataModel.getTradeCurrencyCode().get()),
                     dataModel.getTradeCurrencyCode()));
         }
         volumePromptLabel.bind(createStringBinding(
@@ -332,9 +328,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                             try {
                                 double priceAsDouble = ParsingUtils.parseNumberStringToDouble(price.get());
                                 double relation = priceAsDouble / marketPriceAsDouble;
-                                final OfferDirection compareDirection = CurrencyUtil.isCryptoCurrency(currencyCode) ?
-                                        OfferDirection.SELL :
-                                        OfferDirection.BUY;
+                                final OfferDirection compareDirection = OfferDirection.BUY;
                                 double percentage = dataModel.getDirection() == compareDirection ? 1 - relation : relation - 1;
                                 percentage = MathUtils.roundDouble(percentage, 4);
                                 dataModel.setMarketPriceMarginPct(percentage);
@@ -368,9 +362,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                                 percentage = MathUtils.roundDouble(percentage, 4);
                                 double marketPriceAsDouble = marketPrice.getPrice();
                                 final boolean isCryptoCurrency = CurrencyUtil.isCryptoCurrency(currencyCode);
-                                final OfferDirection compareDirection = isCryptoCurrency ?
-                                        OfferDirection.SELL :
-                                        OfferDirection.BUY;
+                                final OfferDirection compareDirection = OfferDirection.BUY;
                                 double factor = dataModel.getDirection() == compareDirection ?
                                         1 - percentage :
                                         1 + percentage;
@@ -585,15 +577,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
         final boolean isBuy = dataModel.getDirection() == OfferDirection.BUY;
 
-        boolean isFiatCurrency = CurrencyUtil.isFiatCurrency(tradeCurrency.getCode());
-
-        if (isFiatCurrency) {
-            amountDescription = Res.get("createOffer.amountPriceBox.amountDescription",
+        amountDescription = Res.get("createOffer.amountPriceBox.amountDescription",
                     isBuy ? Res.get("shared.buy") : Res.get("shared.sell"));
-        } else {
-            amountDescription = Res.get(isBuy ? "createOffer.amountPriceBox.sell.amountDescriptionAltcoin" :
-                    "createOffer.amountPriceBox.buy.amountDescriptionAltcoin");
-        }
 
         securityDepositValidator.setPaymentAccount(dataModel.paymentAccount);
         validateAndSetBuyerSecurityDepositToModel();
@@ -1094,26 +1079,18 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     String getTriggerPriceDescriptionLabel() {
         String details;
         if (dataModel.isBuyOffer()) {
-            details = dataModel.isCryptoCurrency() ?
-                    Res.get("account.notifications.marketAlert.message.msg.below") :
-                    Res.get("account.notifications.marketAlert.message.msg.above");
+            details = Res.get("account.notifications.marketAlert.message.msg.above");
         } else {
-            details = dataModel.isCryptoCurrency() ?
-                    Res.get("account.notifications.marketAlert.message.msg.above") :
-                    Res.get("account.notifications.marketAlert.message.msg.below");
+            details = Res.get("account.notifications.marketAlert.message.msg.below");
         }
         return Res.get("createOffer.triggerPrice.label", details);
     }
 
     String getPercentagePriceDescription() {
         if (dataModel.isBuyOffer()) {
-            return dataModel.isCryptoCurrency() ?
-                    Res.get("shared.aboveInPercent") :
-                    Res.get("shared.belowInPercent");
+            return Res.get("shared.belowInPercent");
         } else {
-            return dataModel.isCryptoCurrency() ?
-                    Res.get("shared.belowInPercent") :
-                    Res.get("shared.aboveInPercent");
+            return Res.get("shared.aboveInPercent");
         }
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/MutableOfferViewModel.java
@@ -261,11 +261,15 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     private void addBindings() {
         if (dataModel.getDirection() == OfferDirection.BUY) {
             volumeDescriptionLabel.bind(createStringBinding(
-                    () -> Res.get("createOffer.amountPriceBox.buy.volumeDescription", dataModel.getTradeCurrencyCode().get()),
+                    () -> Res.get(CurrencyUtil.isFiatCurrency(dataModel.getTradeCurrencyCode().get()) ?
+                            "createOffer.amountPriceBox.buy.volumeDescription" :
+                            "createOffer.amountPriceBox.buy.volumeDescriptionAltcoin", dataModel.getTradeCurrencyCode().get()),
                     dataModel.getTradeCurrencyCode()));
         } else {
             volumeDescriptionLabel.bind(createStringBinding(
-                    () -> Res.get("createOffer.amountPriceBox.sell.volumeDescription", dataModel.getTradeCurrencyCode().get()),
+                    () -> Res.get(CurrencyUtil.isFiatCurrency(dataModel.getTradeCurrencyCode().get()) ?
+                            "createOffer.amountPriceBox.sell.volumeDescription" :
+                            "createOffer.amountPriceBox.sell.volumeDescriptionAltcoin", dataModel.getTradeCurrencyCode().get()),
                     dataModel.getTradeCurrencyCode()));
         }
         volumePromptLabel.bind(createStringBinding(
@@ -577,8 +581,14 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
         final boolean isBuy = dataModel.getDirection() == OfferDirection.BUY;
 
-        amountDescription = Res.get("createOffer.amountPriceBox.amountDescription",
+        boolean isFiatCurrency = CurrencyUtil.isFiatCurrency(tradeCurrency.getCode());
+        if (isFiatCurrency) {
+            amountDescription = Res.get("createOffer.amountPriceBox.amountDescription",
                     isBuy ? Res.get("shared.buy") : Res.get("shared.sell"));
+        } else {
+            amountDescription = Res.get(isBuy ? "createOffer.amountPriceBox.sell.amountDescriptionAltcoin" :
+                    "createOffer.amountPriceBox.buy.amountDescriptionAltcoin");
+        }
 
         securityDepositValidator.setPaymentAccount(dataModel.paymentAccount);
         validateAndSetBuyerSecurityDepositToModel();

--- a/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/OfferView.java
@@ -30,6 +30,7 @@ import bisq.desktop.main.offer.offerbook.TopAltcoinOfferBookView;
 import bisq.desktop.main.offer.takeoffer.TakeOfferView;
 import bisq.desktop.util.GUIUtil;
 import bisq.common.UserThread;
+
 import bisq.core.locale.CurrencyUtil;
 import bisq.core.locale.GlobalSettings;
 import bisq.core.locale.Res;
@@ -182,6 +183,9 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
         TabPane tabPane = root;
         tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.ALL_TABS);
 
+        // invert the direction for cryptos
+        OfferDirection otherDirection = (this.direction == OfferDirection.SELL) ? OfferDirection.BUY : OfferDirection.SELL;
+
         if (OfferBookView.class.isAssignableFrom(viewClass)) {
 
             if (viewClass == BtcOfferBookView.class && btcOfferBookTab != null && btcOfferBookView != null) {
@@ -240,14 +244,14 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
                 } else if (viewClass == TopAltcoinOfferBookView.class) {
                     topAltcoinOfferBookView = (TopAltcoinOfferBookView) viewLoader.load(TopAltcoinOfferBookView.class);
                     topAltcoinOfferBookView.setOfferActionHandler(offerActionHandler);
-                    topAltcoinOfferBookView.setDirection(direction);
+                    topAltcoinOfferBookView.setDirection(otherDirection);
                     topAltcoinOfferBookView.onTabSelected(true);
                     tabPane.getSelectionModel().select(topAltcoinOfferBookTab);
                     topAltcoinOfferBookTab.setContent(topAltcoinOfferBookView.getRoot());
                 } else if (viewClass == OtherOfferBookView.class) {
                     otherOfferBookView = (OtherOfferBookView) viewLoader.load(OtherOfferBookView.class);
                     otherOfferBookView.setOfferActionHandler(offerActionHandler);
-                    otherOfferBookView.setDirection(direction);
+                    otherOfferBookView.setDirection(otherDirection);
                     otherOfferBookView.onTabSelected(true);
                     tabPane.getSelectionModel().select(otherOfferBookTab);
                     otherOfferBookTab.setContent(otherOfferBookView.getRoot());
@@ -269,7 +273,13 @@ public abstract class OfferView extends ActivatableView<TabPane, Void> {
         // CreateOffer and TakeOffer must not be cached by ViewLoader as we cannot use a view multiple times
         // in different graphs
         view = viewLoader.load(childViewClass);
-        ((CreateOfferView) view).initWithData(direction, tradeCurrency, offerActionHandler);
+
+        // invert the direction for cryptos
+        var offerDirection = direction;
+        if (CurrencyUtil.isCryptoCurrency(tradeCurrency.getCode())) {
+            offerDirection = direction == OfferDirection.BUY ? OfferDirection.SELL : OfferDirection.BUY;
+        }
+        ((CreateOfferView) view).initWithData(offerDirection, tradeCurrency, offerActionHandler);
 
         ((SelectableView) view).onTabSelected(true);
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/OfferViewUtil.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/OfferViewUtil.java
@@ -146,7 +146,7 @@ public class OfferViewUtil {
     }
 
     public static boolean isShownAsSellOffer(String currencyCode, OfferDirection direction) {
-        return CurrencyUtil.isFiatCurrency(currencyCode) == (direction == OfferDirection.SELL);
+        return direction == OfferDirection.SELL;
     }
 
     public static boolean isShownAsBuyOffer(Offer offer) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/createoffer/CreateOfferView.java
@@ -49,14 +49,12 @@ public class CreateOfferView extends MutableOfferView<CreateOfferViewModel> {
                             @Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter btcFormatter) {
         super(model, navigation, preferences, offerDetailsWindow, btcFormatter);
     }
-    
+
     @Override
     public void initWithData(OfferDirection direction,
                              TradeCurrency tradeCurrency,
                              OfferView.OfferActionHandler offerActionHandler) {
-        // Invert direction for non-Fiat trade currencies -> BUY BSQ is to SELL Bitcoin
-        OfferDirection offerDirection = CurrencyUtil.isFiatCurrency(tradeCurrency.getCode()) ? direction :
-                direction == OfferDirection.BUY ? OfferDirection.SELL : OfferDirection.BUY;
+        OfferDirection offerDirection = direction;
         super.initWithData(offerDirection, tradeCurrency, offerActionHandler);
     }
 

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/BtcOfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/BtcOfferBookView.java
@@ -64,4 +64,9 @@ public class BtcOfferBookView extends OfferBookView<GridPane, BtcOfferBookViewMo
     String getTradeCurrencyCode() {
         return Res.getBaseCurrencyCode();
     }
+
+    @Override
+    OfferDirection getDisplayDirection() {
+        return model.getDirection();
+    }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -587,9 +587,10 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         model.initWithDirection(direction);
         ImageView iconView = new ImageView();
         createOfferButton.setGraphic(iconView);
-        iconView.setId(direction == OfferDirection.SELL ? "image-sell-white" : "image-buy-white");
-        createOfferButton.setId(direction == OfferDirection.SELL ? "sell-button-big" : "buy-button-big");
-        avatarColumn.setTitle(direction == OfferDirection.SELL ? Res.get("shared.buyerUpperCase") : Res.get("shared.sellerUpperCase"));
+        var displayDirection = getDisplayDirection();
+        iconView.setId(displayDirection == OfferDirection.SELL ? "image-sell-white" : "image-buy-white");
+        createOfferButton.setId(displayDirection == OfferDirection.SELL ? "sell-button-big" : "buy-button-big");
+        avatarColumn.setTitle(displayDirection == OfferDirection.SELL ? Res.get("shared.buyerUpperCase") : Res.get("shared.sellerUpperCase"));
     }
 
     public void setOfferActionHandler(OfferView.OfferActionHandler offerActionHandler) {
@@ -1268,9 +1269,11 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
 
     private void updateCreateOfferButton() {
         createOfferButton.setText(Res.get("offerbook.createNewOffer",
-                model.getDirection() == OfferDirection.BUY ? Res.get("shared.buy") : Res.get("shared.sell"),
+                getDisplayDirection() == OfferDirection.BUY ? Res.get("shared.buy") : Res.get("shared.sell"),
                 getTradeCurrencyCode()).toUpperCase());
     }
 
     abstract String getTradeCurrencyCode();
+
+    abstract OfferDirection getDisplayDirection();
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -406,8 +406,7 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
     }
 
     public Optional<Double> getMarketBasedPrice(Offer offer) {
-        OfferDirection displayDirection = offer.isFiatOffer() ? direction :
-                direction.equals(OfferDirection.BUY) ? OfferDirection.SELL : OfferDirection.BUY;
+        OfferDirection displayDirection = direction;
         return priceUtil.getMarketBasedPrice(offer, displayDirection);
     }
 
@@ -632,10 +631,7 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
     }
 
     private static String getDirectionWithCodeDetailed(OfferDirection direction, String currencyCode) {
-        if (CurrencyUtil.isFiatCurrency(currencyCode))
-            return (direction == OfferDirection.BUY) ? Res.get("shared.buyingBTCWith", currencyCode) : Res.get("shared.sellingBTCFor", currencyCode);
-        else
-            return (direction == OfferDirection.SELL) ? Res.get("shared.buyingCurrency", currencyCode) : Res.get("shared.sellingCurrency", currencyCode);
+        return (direction == OfferDirection.BUY) ? Res.get("shared.buyingBTCWith", currencyCode) : Res.get("shared.sellingBTCFor", currencyCode);
     }
 
     public String formatDepositString(Coin deposit, long amount) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -631,7 +631,10 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
     }
 
     private static String getDirectionWithCodeDetailed(OfferDirection direction, String currencyCode) {
-        return (direction == OfferDirection.BUY) ? Res.get("shared.buyingBTCWith", currencyCode) : Res.get("shared.sellingBTCFor", currencyCode);
+        if (CurrencyUtil.isFiatCurrency(currencyCode))
+            return (direction == OfferDirection.BUY) ? Res.get("shared.buyingBTCWith", currencyCode) : Res.get("shared.sellingBTCFor", currencyCode);
+        else
+            return (direction == OfferDirection.SELL) ? Res.get("shared.buyingCurrency", currencyCode) : Res.get("shared.sellingCurrency", currencyCode);
     }
 
     public String formatDepositString(Coin deposit, long amount) {

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OtherOfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OtherOfferBookView.java
@@ -54,12 +54,12 @@ public class OtherOfferBookView extends OfferBookView<GridPane, OtherOfferBookVi
     @Override
     protected String getMarketTitle() {
         return model.getDirection().equals(OfferDirection.BUY) ?
-                Res.get("offerbook.availableOffersToBuy", Res.get("shared.otherAssets"), Res.getBaseCurrencyCode()) :
-                Res.get("offerbook.availableOffersToSell", Res.get("shared.otherAssets"), Res.getBaseCurrencyCode());
+                Res.get("offerbook.availableOffersToBuy", Res.getBaseCurrencyCode(), Res.get("shared.otherAssets")) :
+                Res.get("offerbook.availableOffersToSell", Res.getBaseCurrencyCode(), Res.get("shared.otherAssets"));
     }
 
     @Override
     String getTradeCurrencyCode() {
-        return model.showAllTradeCurrenciesProperty.get() ? "" : model.getSelectedTradeCurrency().getCode();
+        return model.showAllTradeCurrenciesProperty.get() ? "" : Res.getBaseCurrencyCode();
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OtherOfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OtherOfferBookView.java
@@ -54,12 +54,17 @@ public class OtherOfferBookView extends OfferBookView<GridPane, OtherOfferBookVi
     @Override
     protected String getMarketTitle() {
         return model.getDirection().equals(OfferDirection.BUY) ?
-                Res.get("offerbook.availableOffersToBuy", Res.getBaseCurrencyCode(), Res.get("shared.otherAssets")) :
-                Res.get("offerbook.availableOffersToSell", Res.getBaseCurrencyCode(), Res.get("shared.otherAssets"));
+                Res.get("offerbook.availableOffersToSell", Res.get("shared.otherAssets"), Res.getBaseCurrencyCode()) :
+                Res.get("offerbook.availableOffersToBuy", Res.get("shared.otherAssets"), Res.getBaseCurrencyCode());
     }
 
     @Override
     String getTradeCurrencyCode() {
-        return model.showAllTradeCurrenciesProperty.get() ? "" : Res.getBaseCurrencyCode();
+        return model.showAllTradeCurrenciesProperty.get() ? "" : model.getSelectedTradeCurrency().getCode();
+    }
+
+    @Override
+    OfferDirection getDisplayDirection() {
+        return model.getDirection() == OfferDirection.BUY ? OfferDirection.SELL : OfferDirection.BUY;
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/TopAltcoinOfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/TopAltcoinOfferBookView.java
@@ -54,8 +54,8 @@ public class TopAltcoinOfferBookView extends OfferBookView<GridPane, TopAltcoinO
     @Override
     protected String getMarketTitle() {
         return model.getDirection().equals(OfferDirection.BUY) ?
-                Res.get("offerbook.availableOffersToBuy", TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode(), Res.getBaseCurrencyCode()) :
-                Res.get("offerbook.availableOffersToSell", TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode(), Res.getBaseCurrencyCode());
+                Res.get("offerbook.availableOffersToBuy", Res.getBaseCurrencyCode(), TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode()) :
+                Res.get("offerbook.availableOffersToSell", Res.getBaseCurrencyCode(), TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode());
     }
 
     @Override
@@ -70,6 +70,6 @@ public class TopAltcoinOfferBookView extends OfferBookView<GridPane, TopAltcoinO
 
     @Override
     String getTradeCurrencyCode() {
-        return TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode();
+        return Res.getBaseCurrencyCode();
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/TopAltcoinOfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/TopAltcoinOfferBookView.java
@@ -54,8 +54,8 @@ public class TopAltcoinOfferBookView extends OfferBookView<GridPane, TopAltcoinO
     @Override
     protected String getMarketTitle() {
         return model.getDirection().equals(OfferDirection.BUY) ?
-                Res.get("offerbook.availableOffersToBuy", Res.getBaseCurrencyCode(), TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode()) :
-                Res.get("offerbook.availableOffersToSell", Res.getBaseCurrencyCode(), TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode());
+                Res.get("offerbook.availableOffersToSell", TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode(), Res.getBaseCurrencyCode()) :
+                Res.get("offerbook.availableOffersToBuy", TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode(), Res.getBaseCurrencyCode());
     }
 
     @Override
@@ -70,6 +70,11 @@ public class TopAltcoinOfferBookView extends OfferBookView<GridPane, TopAltcoinO
 
     @Override
     String getTradeCurrencyCode() {
-        return Res.getBaseCurrencyCode();
+        return TopAltcoinOfferBookViewModel.TOP_ALTCOIN.getCode();
+    }
+
+    @Override
+    OfferDirection getDisplayDirection() {
+        return model.getDirection() == OfferDirection.BUY ? OfferDirection.SELL : OfferDirection.BUY;
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/takeoffer/TakeOfferViewModel.java
@@ -764,13 +764,9 @@ class TakeOfferViewModel extends ActivatableWithDataModel<TakeOfferDataModel> im
 
     String getPercentagePriceDescription() {
         if (dataModel.isBuyOffer()) {
-            return dataModel.isCryptoCurrency() ?
-                    Res.get("shared.aboveInPercent") :
-                    Res.get("shared.belowInPercent");
+            return Res.get("shared.belowInPercent");
         } else {
-            return dataModel.isCryptoCurrency() ?
-                    Res.get("shared.belowInPercent") :
-                    Res.get("shared.aboveInPercent");
+            return Res.get("shared.aboveInPercent");
         }
     }
 }

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -121,7 +121,10 @@ public class DisplayUtils {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static String getDirectionWithCode(OfferDirection direction, String currencyCode) {
-        return (direction == OfferDirection.BUY) ? Res.get("shared.buyCurrency", Res.getBaseCurrencyCode()) : Res.get("shared.sellCurrency", Res.getBaseCurrencyCode());
+        if (CurrencyUtil.isFiatCurrency(currencyCode))
+            return (direction == OfferDirection.BUY) ? Res.get("shared.buyCurrency", Res.getBaseCurrencyCode()) : Res.get("shared.sellCurrency", Res.getBaseCurrencyCode());
+        else
+            return (direction == OfferDirection.SELL) ? Res.get("shared.buyCurrency", currencyCode) : Res.get("shared.sellCurrency", currencyCode);
     }
 
     public static String getDirectionBothSides(OfferDirection direction) {
@@ -132,31 +135,56 @@ public class DisplayUtils {
     }
 
     public static String getDirectionForBuyer(boolean isMyOffer, String currencyCode) {
-        String code = Res.getBaseCurrencyCode();
-        return isMyOffer ?
-                Res.get("formatter.youAreAsMaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code) :
-                Res.get("formatter.youAreAsTaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code);
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            String code = Res.getBaseCurrencyCode();
+            return isMyOffer ?
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code);
+        } else {
+            return isMyOffer ?
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.seller"), currencyCode, Res.get("shared.buyer"), currencyCode) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.seller"), currencyCode, Res.get("shared.buyer"), currencyCode);
+        }
     }
 
     public static String getDirectionForSeller(boolean isMyOffer, String currencyCode) {
-        String code = Res.getBaseCurrencyCode();
-        return isMyOffer ?
-                Res.get("formatter.youAreAsMaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code) :
-                Res.get("formatter.youAreAsTaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code);
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            String code = Res.getBaseCurrencyCode();
+            return isMyOffer ?
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code);
+        } else {
+            return isMyOffer ?
+                    Res.get("formatter.youAreAsMaker", Res.get("shared.buyer"), currencyCode, Res.get("shared.seller"), currencyCode) :
+                    Res.get("formatter.youAreAsTaker", Res.get("shared.buyer"), currencyCode, Res.get("shared.seller"), currencyCode);
+        }
     }
 
     public static String getDirectionForTakeOffer(OfferDirection direction, String currencyCode) {
         String baseCurrencyCode = Res.getBaseCurrencyCode();
-        return direction == OfferDirection.BUY ?
-                Res.get("formatter.youAre", Res.get("shared.selling"), baseCurrencyCode, Res.get("shared.buying"), currencyCode) :
-                Res.get("formatter.youAre", Res.get("shared.buying"), baseCurrencyCode, Res.get("shared.selling"), currencyCode);
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            return direction == OfferDirection.BUY ?
+                    Res.get("formatter.youAre", Res.get("shared.selling"), baseCurrencyCode, Res.get("shared.buying"), currencyCode) :
+                    Res.get("formatter.youAre", Res.get("shared.buying"), baseCurrencyCode, Res.get("shared.selling"), currencyCode);
+        } else {
+
+            return direction == OfferDirection.SELL ?
+                    Res.get("formatter.youAre", Res.get("shared.selling"), currencyCode, Res.get("shared.buying"), baseCurrencyCode) :
+                    Res.get("formatter.youAre", Res.get("shared.buying"), currencyCode, Res.get("shared.selling"), baseCurrencyCode);
+        }
     }
 
     public static String getOfferDirectionForCreateOffer(OfferDirection direction, String currencyCode) {
         String baseCurrencyCode = Res.getBaseCurrencyCode();
-        return direction == OfferDirection.BUY ?
-                Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.buy"), baseCurrencyCode) :
-                Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.sell"), baseCurrencyCode);
+        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
+            return direction == OfferDirection.BUY ?
+                    Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.buy"), baseCurrencyCode) :
+                    Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.sell"), baseCurrencyCode);
+        } else {
+            return direction == OfferDirection.SELL ?
+                    Res.get("formatter.youAreCreatingAnOffer.altcoin", Res.get("shared.buy"), currencyCode, Res.get("shared.selling"), baseCurrencyCode) :
+                    Res.get("formatter.youAreCreatingAnOffer.altcoin", Res.get("shared.sell"), currencyCode, Res.get("shared.buying"), baseCurrencyCode);
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -121,10 +121,7 @@ public class DisplayUtils {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public static String getDirectionWithCode(OfferDirection direction, String currencyCode) {
-        if (CurrencyUtil.isFiatCurrency(currencyCode))
-            return (direction == OfferDirection.BUY) ? Res.get("shared.buyCurrency", Res.getBaseCurrencyCode()) : Res.get("shared.sellCurrency", Res.getBaseCurrencyCode());
-        else
-            return (direction == OfferDirection.SELL) ? Res.get("shared.buyCurrency", currencyCode) : Res.get("shared.sellCurrency", currencyCode);
+        return (direction == OfferDirection.BUY) ? Res.get("shared.buyCurrency", Res.getBaseCurrencyCode()) : Res.get("shared.sellCurrency", Res.getBaseCurrencyCode());
     }
 
     public static String getDirectionBothSides(OfferDirection direction) {
@@ -135,56 +132,31 @@ public class DisplayUtils {
     }
 
     public static String getDirectionForBuyer(boolean isMyOffer, String currencyCode) {
-        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
-            String code = Res.getBaseCurrencyCode();
-            return isMyOffer ?
-                    Res.get("formatter.youAreAsMaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code) :
-                    Res.get("formatter.youAreAsTaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code);
-        } else {
-            return isMyOffer ?
-                    Res.get("formatter.youAreAsMaker", Res.get("shared.seller"), currencyCode, Res.get("shared.buyer"), currencyCode) :
-                    Res.get("formatter.youAreAsTaker", Res.get("shared.seller"), currencyCode, Res.get("shared.buyer"), currencyCode);
-        }
+        String code = Res.getBaseCurrencyCode();
+        return isMyOffer ?
+                Res.get("formatter.youAreAsMaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code) :
+                Res.get("formatter.youAreAsTaker", Res.get("shared.buyer"), code, Res.get("shared.seller"), code);
     }
 
     public static String getDirectionForSeller(boolean isMyOffer, String currencyCode) {
-        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
-            String code = Res.getBaseCurrencyCode();
-            return isMyOffer ?
-                    Res.get("formatter.youAreAsMaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code) :
-                    Res.get("formatter.youAreAsTaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code);
-        } else {
-            return isMyOffer ?
-                    Res.get("formatter.youAreAsMaker", Res.get("shared.buyer"), currencyCode, Res.get("shared.seller"), currencyCode) :
-                    Res.get("formatter.youAreAsTaker", Res.get("shared.buyer"), currencyCode, Res.get("shared.seller"), currencyCode);
-        }
+        String code = Res.getBaseCurrencyCode();
+        return isMyOffer ?
+                Res.get("formatter.youAreAsMaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code) :
+                Res.get("formatter.youAreAsTaker", Res.get("shared.seller"), code, Res.get("shared.buyer"), code);
     }
 
     public static String getDirectionForTakeOffer(OfferDirection direction, String currencyCode) {
         String baseCurrencyCode = Res.getBaseCurrencyCode();
-        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
-            return direction == OfferDirection.BUY ?
-                    Res.get("formatter.youAre", Res.get("shared.selling"), baseCurrencyCode, Res.get("shared.buying"), currencyCode) :
-                    Res.get("formatter.youAre", Res.get("shared.buying"), baseCurrencyCode, Res.get("shared.selling"), currencyCode);
-        } else {
-
-            return direction == OfferDirection.SELL ?
-                    Res.get("formatter.youAre", Res.get("shared.selling"), currencyCode, Res.get("shared.buying"), baseCurrencyCode) :
-                    Res.get("formatter.youAre", Res.get("shared.buying"), currencyCode, Res.get("shared.selling"), baseCurrencyCode);
-        }
+        return direction == OfferDirection.BUY ?
+                Res.get("formatter.youAre", Res.get("shared.selling"), baseCurrencyCode, Res.get("shared.buying"), currencyCode) :
+                Res.get("formatter.youAre", Res.get("shared.buying"), baseCurrencyCode, Res.get("shared.selling"), currencyCode);
     }
 
     public static String getOfferDirectionForCreateOffer(OfferDirection direction, String currencyCode) {
         String baseCurrencyCode = Res.getBaseCurrencyCode();
-        if (CurrencyUtil.isFiatCurrency(currencyCode)) {
-            return direction == OfferDirection.BUY ?
-                    Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.buy"), baseCurrencyCode) :
-                    Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.sell"), baseCurrencyCode);
-        } else {
-            return direction == OfferDirection.SELL ?
-                    Res.get("formatter.youAreCreatingAnOffer.altcoin", Res.get("shared.buy"), currencyCode, Res.get("shared.selling"), baseCurrencyCode) :
-                    Res.get("formatter.youAreCreatingAnOffer.altcoin", Res.get("shared.sell"), currencyCode, Res.get("shared.buying"), baseCurrencyCode);
-        }
+        return direction == OfferDirection.BUY ?
+                Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.buy"), baseCurrencyCode) :
+                Res.get("formatter.youAreCreatingAnOffer.fiat", Res.get("shared.sell"), baseCurrencyCode);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/test/java/bisq/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
@@ -229,7 +229,7 @@ public class CreateOfferViewModelTest {
         model.amount.set("0.01");
         model.onFocusOutPriceAsPercentageTextField(true, false); //leave focus without changing
         assertEquals("0.00", model.marketPriceMargin.get());
-        assertEquals("0.00000078", model.volume.get());
+        assertEquals("126.84045000", model.volume.get());
         assertEquals("12684.04500000", model.price.get());
     }
 }


### PR DESCRIPTION
Requesting review for haveno-dex/haveno#293. All inversions for crypto (altcoin) offers are removed. 

Removed the base currency and counter currency inversion, then removed the PriceProvider's price inversion for crypto currencies.

Lastly, removed the hack inversion logic for the price triggers and desktop application UI.

There is a bit of awkwardness when creating BUY or SELL orders, because the **MONERO** tab on the desktop application is inconsistent with the new **ETH** or **OTHER CRYPTOCURRENCIES** tab, because you are always buying Monero now, but with a different counter currency.