### PR TITLE
Support restoring an account without restarting havenod

### DIFF
--- a/common/src/main/java/bisq/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/bisq/common/persistence/PersistenceManager.java
@@ -108,6 +108,15 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         flushAllDataToDisk(completeHandler, true);
     }
 
+    /**
+     * Resets the static members of PersistenceManager to restart the application.
+     */
+    public static void reset() {
+        ALL_PERSISTENCE_MANAGERS.clear();
+        flushAtShutdownCalled = false;
+        allServicesInitialized.set(false);
+    }
+
     // We require being called only once from the global shutdown routine. As the shutdown routine has a timeout
     // and error condition where we call the method as well beside the standard path and it could be that those
     // alternative code paths call our method after it was called already, so it is a valid but rare case.

--- a/common/src/main/java/bisq/common/setup/GracefulShutDownHandler.java
+++ b/common/src/main/java/bisq/common/setup/GracefulShutDownHandler.java
@@ -21,7 +21,5 @@ import bisq.common.handlers.ResultHandler;
 
 public interface GracefulShutDownHandler {
     void gracefulShutDown(ResultHandler resultHandler);
-
-    // This might need to be overwritten in case the application is not using all modules
     void gracefulShutDown(ResultHandler resultHandler, boolean systemExit);
 }

--- a/common/src/main/java/bisq/common/setup/GracefulShutDownHandler.java
+++ b/common/src/main/java/bisq/common/setup/GracefulShutDownHandler.java
@@ -21,4 +21,7 @@ import bisq.common.handlers.ResultHandler;
 
 public interface GracefulShutDownHandler {
     void gracefulShutDown(ResultHandler resultHandler);
+
+    // This might need to be overwritten in case the application is not using all modules
+    void gracefulShutDown(ResultHandler resultHandler, boolean systemExit);
 }

--- a/core/src/main/java/bisq/core/api/CoreMoneroConnectionsService.java
+++ b/core/src/main/java/bisq/core/api/CoreMoneroConnectionsService.java
@@ -243,7 +243,7 @@ public final class CoreMoneroConnectionsService {
 
     /**
      * Signals that both the daemon and wallet have synced.
-     * 
+     *
      * TODO: separate daemon and wallet download/done listeners
      */
     public void doneDownload() {

--- a/core/src/main/java/bisq/core/app/ConsoleInput.java
+++ b/core/src/main/java/bisq/core/app/ConsoleInput.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
  */
-package bisq.daemon.app;
+package bisq.core.app;
 
 import java.util.concurrent.*;
 

--- a/core/src/main/java/bisq/core/app/ConsoleInputReadTask.java
+++ b/core/src/main/java/bisq/core/app/ConsoleInputReadTask.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
  */
-package bisq.daemon.app;
+package bisq.core.app;
 
 import java.io.*;
 import java.util.concurrent.Callable;

--- a/core/src/main/java/bisq/core/app/HavenoHeadlessAppMain.java
+++ b/core/src/main/java/bisq/core/app/HavenoHeadlessAppMain.java
@@ -47,10 +47,10 @@ public class HavenoHeadlessAppMain extends HavenoExecutable {
     }
 
     @Override
-    protected void doExecute() {
+    protected int doExecute() {
         super.doExecute();
 
-        keepRunning();
+        return keepRunning();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -113,15 +113,5 @@ public class HavenoHeadlessAppMain extends HavenoExecutable {
 
         // In headless mode we don't have an async behaviour so we trigger the setup by calling onApplicationStarted
         onApplicationStarted();
-    }
-
-    // TODO: implement interactive console which allows user to input commands; login, logoff, exit
-    private void keepRunning() {
-        while (true) {
-            try {
-                Thread.sleep(Long.MAX_VALUE);
-            } catch (InterruptedException ignore) {
-            }
-        }
     }
 }

--- a/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
+++ b/core/src/main/java/bisq/core/app/misc/ExecutableForAppWithP2p.java
@@ -97,7 +97,7 @@ public abstract class ExecutableForAppWithP2p extends HavenoExecutable {
                         });
                     });
                     injector.getInstance(WalletsSetup.class).shutDown();
-                    injector.getInstance(XmrWalletService.class).shutDown(); // TODO (woodser): this is not actually called, perhaps because WalletsSetup.class completes too quick so its listener calls System.exit(0)
+                    injector.getInstance(XmrWalletService.class).shutDown(true); // TODO (woodser): this is not actually called, perhaps because WalletsSetup.class completes too quick so its listener calls System.exit(0)
                     injector.getInstance(BtcWalletService.class).shutDown();
                 }));
                 // we wait max 5 sec.
@@ -185,16 +185,6 @@ public abstract class ExecutableForAppWithP2p extends HavenoExecutable {
                 }
             }, TimeUnit.MINUTES.toSeconds(10));
         }, TimeUnit.HOURS.toSeconds(2));
-    }
-
-    @SuppressWarnings("InfiniteLoopStatement")
-    protected void keepRunning() {
-        while (true) {
-            try {
-                Thread.sleep(Long.MAX_VALUE);
-            } catch (InterruptedException ignore) {
-            }
-        }
     }
 
     protected void checkMemory(Config config, GracefulShutDownHandler gracefulShutDownHandler) {

--- a/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
+++ b/core/src/main/java/bisq/core/btc/setup/WalletConfig.java
@@ -469,9 +469,13 @@ public class WalletConfig extends AbstractIdleService {
         try {
             Context.propagate(context);
 
-            vBtcWallet.saveToFile(vBtcWalletFile);
+            try {
+                vBtcWallet.saveToFile(vBtcWalletFile);
+                log.info("BtcWallet saved to file");
+            } catch (Exception e) {
+                log.error("Exception in WalletConfig.shutdown(), expected if the account was deleted" + e);
+            }
             vBtcWallet = null;
-            log.info("BtcWallet saved to file");
 
             vStore.close();
             vStore = null;

--- a/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
+++ b/seednode/src/main/java/bisq/seednode/SeedNodeMain.java
@@ -60,12 +60,12 @@ public class SeedNodeMain extends ExecutableForAppWithP2p {
     }
 
     @Override
-    protected void doExecute() {
+    protected int doExecute() {
         super.doExecute();
 
         checkMemory(config, this);
 
-        keepRunning();
+        return keepRunning();
     }
 
     @Override

--- a/statsnode/src/main/java/bisq/statistics/StatisticsMain.java
+++ b/statsnode/src/main/java/bisq/statistics/StatisticsMain.java
@@ -40,12 +40,12 @@ public class StatisticsMain extends ExecutableForAppWithP2p {
     }
 
     @Override
-    protected void doExecute() {
+    protected int doExecute() {
         super.doExecute();
 
         checkMemory(config, this);
 
-        keepRunning();
+        return keepRunning();
     }
 
     @Override


### PR DESCRIPTION
Requesting review for haveno-dex/haveno#310.

Added a return value to HavenoDaemonMain's execute which allows delete / restore account RPC commands to restart in process. In addition, the `keepRunning` loop allows console input which the user can type the `restart` and `exit` command to the application.

The persistence manager has a new reset function which allows the static object to be reset on restart.

Fixed a race condition when the account API starts up and a listener is removed on a different thread while the API is executed causing the listener list to throw `java.util.ConcurrentModificationException` .

Fixed a shutdown error when attempting to save the BTC and XMR wallet files after the account has been deleted.