### PR TITLE
remove what's left of git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,4 +12,3 @@
 *.jpg           binary
 *.jpeg          binary
 *.png           binary
-p2p/src/main/resources/*XMR_LOCAL filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,6 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
           cache: gradle
-      - name: Pull lfs
-        run: git lfs pull
       - name: Build with make
         run: make
       - name: cache nodes dependencies
@@ -57,7 +55,5 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Pull lfs
-        run: git lfs pull
       - name: Build with Gradle
         run: ./gradlew build --stacktrace --scan

--- a/build.gradle
+++ b/build.gradle
@@ -307,17 +307,6 @@ configure(project(':p2p')) {
         testAnnotationProcessor "org.projectlombok:lombok:$lombokVersion"
         testCompile("org.mockito:mockito-core:$mockitoVersion")
     }
-
-    processResources.doFirst {
-        // Sanity check that Git LFS-managed data store files have actually been sync'd.
-        // If they have not, e.g. because Git LFS is not installed, they will be text files
-        // containing a sha256 hash of the remote object, indicating we should stop the
-        // build and inform the user how to fix the problem.
-        if (file('src/main/resources/AccountAgeWitnessStore_XMR_LOCAL_placeholder').text.contains("oid sha256:"))
-            throw new GradleException("p2p data store files have not been synchronized. " +
-                "To fix this, ensure you have Git LFS installed and run `git lfs pull`. " +
-                "See docs/build.md for more information.")
-    }
 }
 
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -4,7 +4,7 @@ These are the steps needed to build Haveno and test it on our test network or lo
 
 ## Install dependencies
 
-On Ubuntu: `sudo apt install make wget git git-lfs openjdk-11-jdk`. The Monero binaries will be downloaded and verified automatically in the next step.
+On Ubuntu: `sudo apt install make wget git openjdk-11-jdk`. The Monero binaries will be downloaded and verified automatically in the next step.
 
 ## Build Haveno
 

--- a/p2p/src/main/resources/AccountAgeWitnessStore_XMR_LOCAL_placeholder
+++ b/p2p/src/main/resources/AccountAgeWitnessStore_XMR_LOCAL_placeholder
@@ -1,1 +1,0 @@
-TODO (woodser): this is a placeholder for git lfs files; replace with stored Haveno network data

--- a/pricenode/install_pricenode_debian.sh
+++ b/pricenode/install_pricenode_debian.sh
@@ -34,11 +34,6 @@ echo "[*] Upgrading apt packages"
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get update -q
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get upgrade -qq -y
 
-echo "[*] Installing Git LFS"
-sudo -H -i -u "${ROOT_USER}" curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-sudo -H -i -u "${ROOT_USER}" apt-get -y install git-lfs
-sudo -H -i -u "${ROOT_USER}" git lfs install
-
 echo "[*] Installing Tor"
 sudo -H -i -u "${ROOT_USER}" DEBIAN_FRONTEND=noninteractive apt-get install -qq -y "${TOR_PKG}"
 
@@ -65,9 +60,6 @@ sudo -H -i -u "${ROOT_USER}" apt-get install -qq -y openjdk-11-jdk
 
 echo "[*] Checking out Haveno ${HAVENO_LATEST_RELEASE}"
 sudo -H -i -u "${HAVENO_USER}" sh -c "cd ${HAVENO_HOME}/${HAVENO_REPO_NAME} && git checkout ${HAVENO_LATEST_RELEASE}"
-
-echo "[*] Performing Git LFS pull"
-sudo -H -i -u "${HAVENO_USER}" sh -c "cd ${HAVENO_HOME}/${HAVENO_REPO_NAME} && git lfs pull"
 
 echo "[*] Building Haveno from source"
 sudo -H -i -u "${HAVENO_USER}" sh -c "cd ${HAVENO_HOME}/${HAVENO_REPO_NAME} && ./gradlew :pricenode:installDist  -x test < /dev/null" # redirect from /dev/null is necessary to workaround gradlew non-interactive shell hanging issue


### PR DESCRIPTION
Closes #309 

We inherited the use of git lfs from Bisq, but were considering switching to something else. Now that Bisq is removing it (https://github.com/bisq-network/bisq/pull/6360), makes sense for us to get rid of it as well. Needs to be discussed internally, but opening the PR in the meantime.