### PR TITLE
Trigger haveno-ts e2e tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 continuation_indent_size = 8
 end_of_line = lf
 charset = utf-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths-ignore:
       - '**/README.md'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -14,11 +15,11 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           lfs: true
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -26,7 +27,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --stacktrace --scan
       - name: cache nodes dependencies
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cached-localnet
           path: .localnet

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,11 +33,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,4 +56,4 @@ jobs:
        ./gradlew build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/trigger-haveno-ts.yml
+++ b/.github/workflows/trigger-haveno-ts.yml
@@ -1,0 +1,59 @@
+name: Trigger e2e haveno-ts tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/README.md'
+  workflow_dispatch:
+    inputs:
+      haveno-owner:
+        description: 'Owner of the haveno repository.'
+        required: false
+        default: 'haveno-dex'
+      haveno-branch:
+        description: 'Haveno branch to run haveno-ts against.'
+        required: false
+        default: 'master'
+      haveno-ts-owner:
+        description: 'Owner of the haveno-ts repository.'
+        required: false
+        default: 'haveno-dex'
+      haveno-ts-branch:
+        description: 'Haveno-ts branch to use.'
+        required: false
+        default: 'master'
+
+jobs:
+  dispatch_haveno_e2e_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Haveno TS e2e tests
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.HAVENO_TS_PAT }}
+          script: |
+            if (github.event_name !== 'pull_request') {
+              // manual trigger
+              github.rest.actions.createWorkflowDispatch({
+                owner: '${{ github.event.inputs.haveno-ts-owner }}',
+                repo: 'haveno-ts',
+                workflow_id: 'build.yml',
+                ref: '${{ github.event.inputs.haveno-ts-branch }}',
+                inputs: {
+                  "owner": "${{ github.event.inputs.haveno-owner }}",
+                  "branch": "${{ github.event.inputs.haveno-branch }}",
+                },
+              })
+            } else {
+              // pull request with default values
+              github.rest.actions.createWorkflowDispatch({
+                owner: 'haveno-dex',
+                repo: 'haveno-ts',
+                workflow_id: 'build.yml',
+                ref: 'master',
+                inputs: {
+                  "owner": "haveno-dex",
+                  "branch": "master",
+                },
+              })
+            }


### PR DESCRIPTION
After the dockerization and automation of end to end tests there was a private request to chain haveno builds with haveno-ts. Implementation was a bit cumbersome since it is wrapped around still evolving 'Github Actions' with documentation scrambled all around the internet and my limited experience with this product. The original request was to make it trigger by each push. This was not really feasible as 'Github Actions' needs a PAT (personal access token) to trigger the 'remote' repository. So the solution I came up here is more like semi-automatic.. so if someone creates a PR it should trigger the build against the default haveno-ts master branch. And there is also possibility to trigger manually.

Also reviewing these PRs might be cumbersome. The reason is that the 'Github Actions' sees some workflows and changes only from master branch. So one might need to check my current master and try there

![run_workflow_manually](https://user-images.githubusercontent.com/211778/210133995-373c530a-596e-4c49-8d2f-3c89ee4dcc03.png)

Pls test this thoroughly as I might missed smthng here.. This should / could be also applied to pricenode repository as well.

haveno-ts part: https://github.com/haveno-dex/haveno-ts/pull/165