### PR TITLE
handle errors initializing trade after deposits requested

### DIFF
--- a/core/src/main/java/bisq/core/trade/ClosedTradableFormatter.java
+++ b/core/src/main/java/bisq/core/trade/ClosedTradableFormatter.java
@@ -22,14 +22,11 @@ import bisq.core.locale.Res;
 import bisq.core.monetary.Altcoin;
 import bisq.core.monetary.Volume;
 import bisq.core.offer.OpenOffer;
-import bisq.core.trade.Tradable;
-import bisq.core.trade.Trade;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
-import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.utils.Fiat;
 
 import javax.inject.Inject;

--- a/core/src/main/java/bisq/core/trade/Trade.java
+++ b/core/src/main/java/bisq/core/trade/Trade.java
@@ -635,7 +635,7 @@ public abstract class Trade implements Tradable, Model {
         isInitialized = true;
 
         // start listening to trade wallet
-        if (isDepositPublished()) {
+        if (isDepositRequested()) {
             updateSyncing();
 
             // allow state notifications to process before returning
@@ -1462,9 +1462,14 @@ public abstract class Trade implements Tradable, Model {
             if (isDepositUnlocked()) getWallet().rescanSpent();
 
             // get txs with outputs
-            List<MoneroTxWallet> txs = getWallet().getTxs(new MoneroTxQuery()
-                    .setHashes(Arrays.asList(processModel.getMaker().getDepositTxHash(), processModel.getTaker().getDepositTxHash()))
-                    .setIncludeOutputs(true));
+            List<MoneroTxWallet> txs;
+            try {
+                txs = getWallet().getTxs(new MoneroTxQuery()
+                        .setHashes(Arrays.asList(processModel.getMaker().getDepositTxHash(), processModel.getTaker().getDepositTxHash()))
+                        .setIncludeOutputs(true));
+            } catch (Exception e) {
+                return;
+            }
 
             // check deposit txs
             if (!isDepositUnlocked()) {

--- a/core/src/main/java/bisq/core/trade/messages/DepositResponse.java
+++ b/core/src/main/java/bisq/core/trade/messages/DepositResponse.java
@@ -21,8 +21,11 @@ import bisq.core.proto.CoreProtoResolver;
 
 import bisq.network.p2p.DirectMessage;
 import bisq.network.p2p.NodeAddress;
-import bisq.common.crypto.PubKeyRing;
 
+import java.util.Optional;
+
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.proto.ProtoUtil;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
@@ -32,17 +35,20 @@ public final class DepositResponse extends TradeMessage implements DirectMessage
     private final NodeAddress senderNodeAddress;
     private final PubKeyRing pubKeyRing;
     private final long currentDate;
+    private final String errorMessage;
 
     public DepositResponse(String tradeId,
                                      NodeAddress senderNodeAddress,
                                      PubKeyRing pubKeyRing,
                                      String uid,
                                      String messageVersion,
-                                     long currentDate) {
+                                     long currentDate,
+                                     String errorMessage) {
         super(messageVersion, tradeId, uid);
         this.senderNodeAddress = senderNodeAddress;
         this.pubKeyRing = pubKeyRing;
         this.currentDate = currentDate;
+        this.errorMessage = errorMessage;
     }
 
 
@@ -58,6 +64,7 @@ public final class DepositResponse extends TradeMessage implements DirectMessage
                 .setPubKeyRing(pubKeyRing.toProtoMessage())
                 .setUid(uid);
         builder.setCurrentDate(currentDate);
+        Optional.ofNullable(errorMessage).ifPresent(e -> builder.setErrorMessage(errorMessage));
 
         return getNetworkEnvelopeBuilder().setDepositResponse(builder).build();
     }
@@ -70,7 +77,8 @@ public final class DepositResponse extends TradeMessage implements DirectMessage
                 PubKeyRing.fromProto(proto.getPubKeyRing()),
                 proto.getUid(),
                 messageVersion,
-                proto.getCurrentDate());
+                proto.getCurrentDate(),
+                ProtoUtil.stringOrNullFromProto(proto.getErrorMessage()));
     }
 
     @Override
@@ -79,6 +87,7 @@ public final class DepositResponse extends TradeMessage implements DirectMessage
                 "\n     senderNodeAddress=" + senderNodeAddress +
                 ",\n     pubKeyRing=" + pubKeyRing +
                 ",\n     currentDate=" + currentDate +
+                ",\n     errorMessage=" + errorMessage +
                 "\n} " + super.toString();
     }
 }

--- a/core/src/main/java/bisq/core/trade/protocol/tasks/ProcessDepositResponse.java
+++ b/core/src/main/java/bisq/core/trade/protocol/tasks/ProcessDepositResponse.java
@@ -20,6 +20,7 @@ package bisq.core.trade.protocol.tasks;
 
 import bisq.common.taskrunner.TaskRunner;
 import bisq.core.trade.Trade;
+import bisq.core.trade.messages.DepositResponse;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -34,6 +35,14 @@ public class ProcessDepositResponse extends TradeTask {
     protected void run() {
         try {
           runInterceptHook();
+
+          // throw if error
+          DepositResponse message = (DepositResponse) processModel.getTradeMessage();
+          if (message.getErrorMessage() != null) {
+            throw new RuntimeException(message.getErrorMessage());
+          }
+
+          // set success state
           trade.setStateIfValidTransitionTo(Trade.State.ARBITRATOR_PUBLISHED_DEPOSIT_TXS);
           processModel.getTradeManager().requestPersistence();
           complete();

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2036,7 +2036,7 @@ The above error message will be copied to the clipboard when you click either of
 It will make debugging easier if you include the haveno.log file by pressing "Open log file", saving a copy, and attaching it to your bug report.
 
 popup.error.tryRestart=Please try to restart your application and check your network connection to see if you can resolve the issue.
-popup.error.takeOfferRequestFailed=An error occurred when someone tried to take one of your offers:\n{0}
+popup.error.takeOfferRequestFailed=An error occurred while taking an offer:\n{0}
 
 error.spvFileCorrupted=An error occurred when reading the SPV chain file.\nIt might be that the SPV chain file is corrupted.\n\nError message: {0}\n\nDo you want to delete it and start a resync?
 error.deleteAddressEntryListFailed=Could not delete AddressEntryList file.\nError: {0}

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -269,12 +269,12 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
                         Res.get(contract.getPaymentMethodId()));
         }
 
-        if (trade.getMakerDepositTx() != null)
+        if (trade.getMaker().getDepositTxHash() != null)
             addLabelTxIdTextField(gridPane, ++rowIndex, Res.get("shared.makerDepositTransactionId"),
-                    trade.getMakerDepositTx().getHash());
-          if (trade.getTakerDepositTx() != null)
+                    trade.getMaker().getDepositTxHash());
+          if (trade.getTaker().getDepositTxHash() != null)
             addLabelTxIdTextField(gridPane, ++rowIndex, Res.get("shared.takerDepositTransactionId"),
-                    trade.getTakerDepositTx().getHash());
+                    trade.getTaker().getDepositTxHash());
 
         if (trade.getPayoutTxId() != null && !trade.getPayoutTxId().isBlank())
             addLabelTxIdTextField(gridPane, ++rowIndex, Res.get("shared.payoutTxId"),

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -344,6 +344,7 @@ message DepositResponse {
     PubKeyRing pub_key_ring = 3;
     string uid = 4;
     int64 current_date = 5;
+    string error_message = 6;
 }
 
 message DepositsConfirmedMessage {


### PR DESCRIPTION
offer remains valid until trade initialized
delete maker and taker trades on error after deposits requested
schedule trade deletion if unfunded after timeout or startup
DepositResponse supports error message to confirm failure
show deposit tx ids in trade details window