### PR TITLE
Feature to add scrollbar on message of overlays

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/account/content/traditionalaccounts/TraditionalAccountsView.java
+++ b/desktop/src/main/java/haveno/desktop/main/account/content/traditionalaccounts/TraditionalAccountsView.java
@@ -271,6 +271,7 @@ public class TraditionalAccountsView extends PaymentAccountsView<GridPane, Tradi
                     .closeButtonText(Res.get("shared.cancel"))
                     .actionButtonText(Res.get("shared.iUnderstand"))
                     .onAction(() -> doSaveNewAccount(paymentAccount))
+                    .showScrollPane()
                     .show();
         } else if (paymentAccount instanceof CashAtAtmAccount) {
             // CashAtAtm has no chargeback risk so we don't show the text from payment.limits.info.

--- a/desktop/src/main/java/haveno/desktop/main/overlays/Overlay.java
+++ b/desktop/src/main/java/haveno/desktop/main/overlays/Overlay.java
@@ -54,6 +54,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.ScrollPane.ScrollBarPolicy;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
@@ -154,6 +156,7 @@ public abstract class Overlay<T extends Overlay<T>> {
     protected Integer displayOrderPriority = Integer.MAX_VALUE;
 
     protected boolean useAnimation = true;
+    protected boolean showScrollPane = false;
 
     protected Label headlineIcon, headLineLabel, messageLabel;
     protected String headLine, message, closeButtonText, actionButtonText,
@@ -164,6 +167,7 @@ public abstract class Overlay<T extends Overlay<T>> {
     protected Button actionButton, secondaryActionButton;
     private HBox buttonBox;
     protected AutoTooltipButton closeButton;
+    protected ScrollPane scrollPane;
 
     private HPos buttonAlignment = HPos.RIGHT;
 
@@ -467,6 +471,11 @@ public abstract class Overlay<T extends Overlay<T>> {
 
     public T disableActionButton() {
         this.disableActionButton = true;
+        return cast();
+    }
+
+    public T showScrollPane() {
+        this.showScrollPane = true;
         return cast();
     }
 
@@ -807,13 +816,26 @@ public abstract class Overlay<T extends Overlay<T>> {
             messageLabel = new AutoTooltipLabel(truncatedMessage);
             messageLabel.setMouseTransparent(true);
             messageLabel.setWrapText(true);
-            GridPane.setHalignment(messageLabel, HPos.LEFT);
-            GridPane.setHgrow(messageLabel, Priority.ALWAYS);
-            GridPane.setMargin(messageLabel, new Insets(3, 0, 0, 0));
-            GridPane.setRowIndex(messageLabel, ++rowIndex);
-            GridPane.setColumnIndex(messageLabel, 0);
-            GridPane.setColumnSpan(messageLabel, 2);
-            gridPane.getChildren().add(messageLabel);
+
+            Region messageRegion;
+            if (showScrollPane) {
+                scrollPane = new ScrollPane(messageLabel);
+                scrollPane.setHbarPolicy(ScrollBarPolicy.NEVER);
+                scrollPane.setVbarPolicy(ScrollBarPolicy.AS_NEEDED);
+                scrollPane.setFitToWidth(true);
+
+                messageRegion = scrollPane;
+            } else
+                messageRegion = messageLabel;
+
+            GridPane.setHalignment(messageRegion, HPos.LEFT);
+            GridPane.setHgrow(messageRegion, Priority.ALWAYS);
+            GridPane.setMargin(messageRegion, new Insets(3, 0, 0, 0));
+            GridPane.setRowIndex(messageRegion, ++rowIndex);
+            GridPane.setColumnIndex(messageRegion, 0);
+            GridPane.setColumnSpan(messageRegion, 2);
+            gridPane.getChildren().add(messageRegion);
+
             addFooter();
         }
     }

--- a/desktop/src/main/java/haveno/desktop/main/overlays/windows/TacWindow.java
+++ b/desktop/src/main/java/haveno/desktop/main/overlays/windows/TacWindow.java
@@ -91,6 +91,7 @@ public class TacWindow extends Overlay<TacWindow> {
                 "    - The arbitrator will then make a reimbursement request to the Haveno to get reimbursed for the refund they paid to the trader.\n\n" +
                 "For more details and a general overview please read the full documentation about dispute resolution.";
         message(text);
+        showScrollPane();
         actionButtonText(Res.get("tacWindow.agree"));
         closeButtonText(Res.get("tacWindow.disagree"));
         onClose(HavenoApp.getShutDownHandler());


### PR DESCRIPTION
Resolves: #656

This is a "minimal" implementation. My idea is to manually add `showScrollPane()` on selected popups/windows. So far, I added this only on T&C and Pay by mail info:
![PBM scroll](https://github.com/haveno-dex/haveno/assets/87281755/21c10fa2-3801-4b71-9a2a-6d0e08d0affd)

Will add to more windows once this is approved.