### PR TITLE
When amount is below minimum for order, show warning 

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferViewModel.java
@@ -687,11 +687,9 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                 if (minAmount.get() != null)
                     minAmountValidationResult.set(isXmrInputValid(minAmount.get()));
             } else if (amount.get() != null && xmrValidator.getMaxTradeLimit() != null && xmrValidator.getMaxTradeLimit().longValueExact() == OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.longValueExact()) {
-
-                if (Double.parseDouble(amount.get()) < HavenoUtils.atomicUnitsToXmr(Restrictions.getMinTradeAmount())){
+                if (Double.parseDouble(amount.get()) < HavenoUtils.atomicUnitsToXmr(Restrictions.getMinTradeAmount())) {
                     amountValidationResult.set(result);
-                }
-                else{
+                } else {
                     amount.set(HavenoUtils.formatXmr(xmrValidator.getMaxTradeLimit()));
                     boolean isBuy = dataModel.getDirection() == OfferDirection.BUY;
                     new Popup().information(Res.get(isBuy ? "popup.warning.tradeLimitDueAccountAgeRestriction.buyer" : "popup.warning.tradeLimitDueAccountAgeRestriction.seller",
@@ -700,7 +698,6 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                             .width(900)
                             .show();
                 }
-
             }
             // We want to trigger a recalculation of the volume
             UserThread.execute(() -> {

--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferViewModel.java
@@ -687,13 +687,20 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
                 if (minAmount.get() != null)
                     minAmountValidationResult.set(isXmrInputValid(minAmount.get()));
             } else if (amount.get() != null && xmrValidator.getMaxTradeLimit() != null && xmrValidator.getMaxTradeLimit().longValueExact() == OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT.longValueExact()) {
-                amount.set(HavenoUtils.formatXmr(xmrValidator.getMaxTradeLimit()));
-                boolean isBuy = dataModel.getDirection() == OfferDirection.BUY;
-                new Popup().information(Res.get(isBuy ? "popup.warning.tradeLimitDueAccountAgeRestriction.buyer" : "popup.warning.tradeLimitDueAccountAgeRestriction.seller",
-                        HavenoUtils.formatXmr(OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT, true),
-                        Res.get("offerbook.warning.newVersionAnnouncement")))
-                        .width(900)
-                        .show();
+
+                if (Double.parseDouble(amount.get()) < HavenoUtils.atomicUnitsToXmr(Restrictions.getMinTradeAmount())){
+                    amountValidationResult.set(result);
+                }
+                else{
+                    amount.set(HavenoUtils.formatXmr(xmrValidator.getMaxTradeLimit()));
+                    boolean isBuy = dataModel.getDirection() == OfferDirection.BUY;
+                    new Popup().information(Res.get(isBuy ? "popup.warning.tradeLimitDueAccountAgeRestriction.buyer" : "popup.warning.tradeLimitDueAccountAgeRestriction.seller",
+                                    HavenoUtils.formatXmr(OfferRestrictions.TOLERATED_SMALL_TRADE_AMOUNT, true),
+                                    Res.get("offerbook.warning.newVersionAnnouncement")))
+                            .width(900)
+                            .show();
+                }
+
             }
             // We want to trigger a recalculation of the volume
             UserThread.execute(() -> {


### PR DESCRIPTION
When amount is below minimum for order, show warning on the text field instead of popup like so:
![image](https://github.com/haveno-dex/haveno/assets/73935082/b891e2d6-2789-4f88-8e7c-ab1f8954aa3c)

The amount does not get reset to the maximum possible.
I could make it reset to the minimum but then the warning below the field isn't shown.

Resolves: https://github.com/haveno-dex/haveno/issues/658

