### PR TITLE
Replace JFXDatePicker with DatePicker

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/account/content/seedwords/SeedWordsView.java
+++ b/desktop/src/main/java/haveno/desktop/main/account/content/seedwords/SeedWordsView.java
@@ -106,6 +106,8 @@ public class SeedWordsView extends ActivatableView<GridPane, Void> {
         displaySeedWordsTextArea.setEditable(false);
 
         datePicker = addTopLabelDatePicker(root, ++gridRow, Res.get("seed.date"), 10).second;
+        //note: on MacOS this datePicker does not actually list a date...is it
+        //supposed to?
         datePicker.setMouseTransparent(true);
 
         addTitledGroupBg(root, ++gridRow, 3, Res.get("seed.restore.title"), Layout.GROUP_DISTANCE);

--- a/desktop/src/main/java/haveno/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/haveno/desktop/util/FormBuilder.java
@@ -669,7 +669,13 @@ public class FormBuilder {
                                                                   int columnIndex,
                                                                   String title,
                                                                   double top) {
-        DatePicker datePicker = new JFXDatePicker();
+        //DatePicker datePicker = new JFXDatePicker();
+        //
+        //Temporary solution to fix issue 527; a more
+        //permanant solution would require this issue to be solved: 
+        //(https://github.com/sshahine/JFoenix/issues/1245)
+        DatePicker datePicker = new DatePicker();
+        
         Tuple2<Label, VBox> topLabelWithVBox = addTopLabelWithVBox(gridPane, rowIndex, columnIndex, title, datePicker, top);
         return new Tuple2<>(topLabelWithVBox.first, datePicker);
     }


### PR DESCRIPTION
This PR replaces JFXDatePicker with DatePicker in the Account Seed View. This is a temporary fix for the "growing DatePicker" issue in #527. 

It should be noted that I was unable to use the Seed Recovery feature on the Account Seed View, nor was I able to see the date associated with the current wallet seed. This issue was present both before and after the PR, and is likely unrelated to the "growing DatePicker" issue.