### PR TITLE
scrollbar fix, but better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ deploy
 .localnet
 .vscode
 .vim/*
+*/.factorypath

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.fxml
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.fxml
@@ -19,13 +19,15 @@
 
 <?import haveno.desktop.components.list.FilterBox?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
 <VBox fx:id="root" fx:controller="haveno.desktop.main.portfolio.pendingtrades.PendingTradesView"
       spacing="20" xmlns:fx="http://javafx.com/fxml">
     <padding>
-        <Insets bottom="15.0" left="15.0" right="15.0" top="15.0"/>
+        <Insets bottom="0.0" left="15.0" right="15.0" top="15.0"/>
     </padding>
     <FilterBox fx:id="filterBox" />
     <TableView fx:id="tableView" VBox.vgrow="SOMETIMES">
@@ -43,4 +45,8 @@
             <TableColumn fx:id="moveTradeToFailedColumn" minWidth="80" maxWidth="80"/>
         </columns>
     </TableView>
+    <ScrollPane fx:id="scrollView" fitToWidth="true" hbarPolicy="NEVER"
+        AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+        AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+
 </VBox>

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -75,6 +75,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
@@ -84,7 +85,6 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
@@ -117,6 +117,8 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
     @FXML
     TableColumn<PendingTradesListItem, PendingTradesListItem> priceColumn, volumeColumn, amountColumn, avatarColumn,
             marketColumn, roleColumn, paymentMethodColumn, tradeIdColumn, dateColumn, chatColumn, moveTradeToFailedColumn;
+    @FXML
+    ScrollPane scrollView;
     private FilteredList<PendingTradesListItem> filteredList;
     private SortedList<PendingTradesListItem> sortedList;
     private TradeSubView selectedSubView;
@@ -275,6 +277,8 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         sortedList = new SortedList<>(filteredList);
         sortedList.comparatorProperty().bind(tableView.comparatorProperty());
         tableView.setItems(sortedList);
+        tableView.setPrefHeight(100);
+        tableView.setMaxHeight(200);
 
         filterBox.initialize(filteredList, tableView); // here because filteredList is instantiated here
         filterBox.activate();
@@ -295,13 +299,13 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                     selectedSubView = model.dataModel.tradeManager.isBuyer(model.dataModel.getOffer()) ?
                             new BuyerSubView(model) : new SellerSubView(model);
 
-                    selectedSubView.setMinHeight(460);
-                    VBox.setVgrow(selectedSubView, Priority.ALWAYS);
+                    //selectedSubView.setMinHeight(460);
+                    //VBox.setVgrow(selectedSubView, Priority.SOMETIMES);
                     if (root.getChildren().size() == 2)
-                        root.getChildren().add(selectedSubView);
+                        root.getChildren().add(scrollView);
                     else if (root.getChildren().size() == 3)
-                        root.getChildren().set(2, selectedSubView);
-
+                        root.getChildren().set(2, scrollView);
+                    scrollView.setContent(selectedSubView);
                     // create and register a callback so we can be notified when the subview
                     // wants to open the chat window
                     ChatCallback chatCallback = this::openChat;

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/TradeSubView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/TradeSubView.java
@@ -61,7 +61,7 @@ public abstract class TradeSubView extends HBox {
 
     public TradeSubView(PendingTradesViewModel model) {
         this.model = model;
-
+        HBox.setHgrow(this, Priority.ALWAYS);
         setSpacing(Layout.PADDING_WINDOW);
         buildViews();
     }

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -100,8 +100,10 @@ import haveno.desktop.main.overlays.popups.Popup;
 import haveno.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import haveno.desktop.main.portfolio.pendingtrades.steps.TradeStepView;
 import haveno.desktop.util.Layout;
+import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
@@ -217,6 +219,7 @@ public class BuyerStep2View extends TradeStepView {
 
         addTradeInfoBlock();
 
+
         PaymentAccountPayload paymentAccountPayload = model.dataModel.getSellersPaymentAccountPayload();
         String paymentMethodId = paymentAccountPayload != null ? paymentAccountPayload.getPaymentMethodId() : "<missing payment account payload>";
         TitledGroupBg accountTitledGroupBg = addTitledGroupBg(gridPane, ++gridRow, 4,
@@ -227,6 +230,14 @@ public class BuyerStep2View extends TradeStepView {
                 model.getFiatVolume(),
                 Layout.COMPACT_FIRST_ROW_AND_GROUP_DISTANCE).second;
         field.setCopyWithoutCurrencyPostFix(true);
+
+        //preland: this fixes a textarea layout glitch
+        TextArea uiHack = new TextArea();
+        uiHack.setMaxHeight(1);
+        GridPane.setRowIndex(uiHack, 1);
+        GridPane.setMargin(uiHack, new Insets(0, 0, 0, 0));
+        uiHack.setVisible(false);
+        gridPane.getChildren().add(uiHack);
 
         switch (paymentMethodId) {
             case PaymentMethod.UPHOLD_ID:

--- a/desktop/src/main/java/haveno/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/haveno/desktop/util/FormBuilder.java
@@ -645,7 +645,7 @@ public class FormBuilder {
         TextArea textArea = new HavenoTextArea();
         textArea.setPromptText(prompt);
         textArea.setWrapText(true);
-
+        textArea.setPrefHeight(100);
         final Tuple2<Label, VBox> topLabelWithVBox = addTopLabelWithVBox(gridPane, rowIndex, title, textArea, top);
         GridPane.setColumnIndex(topLabelWithVBox.second, colIndex);
 
@@ -672,10 +672,10 @@ public class FormBuilder {
         //DatePicker datePicker = new JFXDatePicker();
         //
         //Temporary solution to fix issue 527; a more
-        //permanant solution would require this issue to be solved: 
+        //permanant solution would require this issue to be solved:
         //(https://github.com/sshahine/JFoenix/issues/1245)
         DatePicker datePicker = new DatePicker();
-        
+
         Tuple2<Label, VBox> topLabelWithVBox = addTopLabelWithVBox(gridPane, rowIndex, columnIndex, title, datePicker, top);
         return new Tuple2<>(topLabelWithVBox.first, datePicker);
     }


### PR DESCRIPTION
This PR is a reimplementation of the scrollbar fix for the pending trades screen. It is a lot simpler than the earlier solution, while also maintaining higher functionality. The width issue should be addressed now, such that a horizontal scrollbar should no longer be necessary (at least for Pay By Mail; if another method requires horizontal scrolling it could be added back in). The width and height of the text sections now properly scale on different screen sizes.

The only issue I can find is a minor layout issue on Pay By Mail in certain conditions:

In some conditions, it will look fine:
<img width="1308" alt="Screenshot 2024-02-04 at 8 14 53 PM" src="https://github.com/haveno-dex/haveno/assets/89992615/54a5839c-13ab-4c02-8e8c-29dadc3bf64a">

In other conditions, it will look like this: 
<img width="1308" alt="Screenshot 2024-02-04 at 8 15 01 PM" src="https://github.com/haveno-dex/haveno/assets/89992615/ec19f787-8e14-4167-bb07-47a7b0e40194">

My guess is that is has something to do with the placeholder text being one column, while the form is two columns. The issue occurs consistently when moving from a placeholder view to the form view, while moving from a two column view (in my testing i used the Zelle form) to the form resulted in no changing. The issue only consistently reverts when moving from another tab back to the form. I was also able to get the issue to fix itself ~5% of the time by using an autoclicker and switching between tabs at around 20 cps, which I am unable to explain currently.