### PR TITLE
Remove coloring of log.info messages

### DIFF
--- a/common/src/main/java/haveno/common/app/LogHighlighter.java
+++ b/common/src/main/java/haveno/common/app/LogHighlighter.java
@@ -1,0 +1,34 @@
+/* Derived from https://logback.qos.ch/xref/ch/qos/logback/classic/pattern/color/HighlightingCompositeConverter.html */
+
+package haveno.common.app;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import static ch.qos.logback.core.pattern.color.ANSIConstants.*;
+import ch.qos.logback.core.pattern.color.ForegroundCompositeConverterBase;
+
+/**
+ * Highlights inner-text depending on the level, in bold red for events of level
+ * ERROR, in red for WARN, in the default color for INFO, and in the default color for other
+ * levels.
+ */
+
+public class LogHighlighter extends ForegroundCompositeConverterBase<ILoggingEvent> {
+
+	@Override
+	protected String getForegroundColorCode(ILoggingEvent event) {
+		Level level = event.getLevel();
+		switch (level.toInt()) {
+		case Level.ERROR_INT:
+			return BOLD + RED_FG;
+		case Level.WARN_INT:
+			return RED_FG;
+		case Level.INFO_INT:
+			return DEFAULT_FG;
+		default:
+			return DEFAULT_FG;
+		}
+
+	}
+}
+

--- a/desktop/src/main/resources/logback.xml
+++ b/desktop/src/main/resources/logback.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
+    <conversionRule conversionWord="hl2" converterClass="haveno.common.app.LogHighlighter" />
+
     <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%highlight(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{30}: %msg %xEx%n)</pattern>
+            <pattern>%hl2(%d{MMM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{30}: %msg %xEx%n)</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
As described in [Haveno issue #798](https://github.com/haveno-dex/haveno/issues/798)