### PR TITLE
chore: add installer builds to artifacts w/ GH action

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,99 @@
+name: Build Haveno Installers
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y rpm
+
+      - name: Build Haveno Installer for Linux
+        run: |
+          ./gradlew clean build --refresh-keys --refresh-dependencies
+          ./gradlew packageInstallers
+        working-directory: .
+
+      - name: Copy Installer
+        run: |
+          cp installer.deb ${{ github.workspace }}/HavenoInstaller.deb
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Build Haveno Installer for macOS
+        run: |
+          ./gradlew clean build --refresh-keys --refresh-dependencies
+          ./gradlew packageInstallers
+        working-directory: .
+
+      - name: Copy Installer
+        run: |
+          cp installer.dmg ${{ github.workspace }}/HavenoInstaller.dmg
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Install WiX Toolset
+        run: |
+          Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314.exe' -OutFile wix314.exe
+          .\wix314.exe /quiet /norestart
+          del wix314.exe
+        shell: powershell
+
+      - name: Build Haveno Installer for Windows
+        run: |
+          ./gradlew clean build --refresh-keys --refresh-dependencies
+          ./gradlew packageInstallers
+        working-directory: .
+
+      - name: Copy Installer
+        run: |
+          cp installer.exe ${{ github.workspace }}/HavenoInstaller.exe
+
+  copy-artifacts:
+    runs-on: ubuntu-latest
+    needs: [build-linux, build-macos, build-windows]
+    steps:
+      - name: Copy Installers
+        run: |
+          cp ${{ github.workspace }}/HavenoInstaller.* /path/to/your/safe/location/
+        shell: bash
+
+      - name: Rebuild Haveno Binaries
+        run: |
+          make clean && make
+        working-directory: .

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -98,8 +98,8 @@ jobs:
       - name: Move Release Files
         run: |
           mkdir ${{ github.workspace }}/release
-          $source = Get-ChildItem -Path ${{ github.workspace }}\desktop\build -Recurse -File
-          $destination = ${{ github.workspace }}\release
+          $source = Get-ChildItem -Path "${{ github.workspace }}\desktop\build" -Recurse -File
+          $destination = "${{ github.workspace }}\release"
           Move-Item -Path $source -Destination $destination
         shell: powershell
         

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -3,7 +3,7 @@ name: Build Haveno Installers
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-linux:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -98,11 +98,10 @@ jobs:
       - name: Move Release Files
         run: |
           mkdir ${{ github.workspace }}/release
-          $source = Get-ChildItem -Path "${{ github.workspace }}\desktop\build" -Recurse -File
-          $destination = "${{ github.workspace }}\release"
-          Move-Item -Path $source -Destination $destination
+          Move-Item -Path desktop\build\temp-*/binaries\Haveno-*.exe -Destination ${{ github.workspace }}/release
+          Move-Item -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256 -Destination ${{ github.workspace }}/release
         shell: powershell
-        
+
       - uses: actions/upload-artifact@v2
         with:
           name: HavenoInstaller-windows

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -29,9 +29,18 @@ jobs:
           ./gradlew packageInstallers
         working-directory: .
 
-      - name: Copy Installer
+      - name: Move Release Files
         run: |
-          cp installer.deb ${{ github.workspace }}/HavenoInstaller.deb
+          mkdir ${{ github.workspace }}/release
+          mv desktop/build/temp-*/binaries/haveno-*.rpm ${{ github.workspace }}/release
+          mv desktop/build/temp-*/binaries/haveno_*.deb ${{ github.workspace }}/release
+          mv desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: HavenoInstaller-linux
+          path: ${{ github.workspace }}/release
+
 
   build-macos:
     runs-on: macos-latest
@@ -51,9 +60,16 @@ jobs:
           ./gradlew packageInstallers
         working-directory: .
 
-      - name: Copy Installer
+      - name: Move Release Files
         run: |
-          cp installer.dmg ${{ github.workspace }}/HavenoInstaller.dmg
+          mkdir ${{ github.workspace }}/release
+          mv desktop/build/temp-*/binaries/Haveno-*.dmg ${{ github.workspace }}/release
+          mv desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: HavenoInstaller-macos
+          path: ${{ github.workspace }}/release
 
   build-windows:
     runs-on: windows-latest
@@ -79,20 +95,15 @@ jobs:
           ./gradlew packageInstallers
         working-directory: .
 
-      - name: Copy Installer
+      - name: Move Release Files
         run: |
-          cp installer.exe ${{ github.workspace }}/HavenoInstaller.exe
-
-  copy-artifacts:
-    runs-on: ubuntu-latest
-    needs: [build-linux, build-macos, build-windows]
-    steps:
-      - name: Copy Installers
-        run: |
-          cp ${{ github.workspace }}/HavenoInstaller.* /path/to/your/safe/location/
-        shell: bash
-
-      - name: Rebuild Haveno Binaries
-        run: |
-          make clean && make
-        working-directory: .
+          mkdir ${{ github.workspace }}/release
+          $source = Get-ChildItem -Path ${{ github.workspace }}\desktop\build -Recurse -File
+          $destination = ${{ github.workspace }}\release
+          Move-Item -Path $source -Destination $destination
+        shell: powershell
+        
+      - uses: actions/upload-artifact@v2
+        with:
+          name: HavenoInstaller-windows
+          path: ${{ github.workspace }}/release

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '21'
 
       - name: Install dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '21'
 
       - name: Build Haveno Installer for macOS
         run: |
@@ -65,13 +65,12 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '21'
 
       - name: Install WiX Toolset
         run: |
           Invoke-WebRequest -Uri 'https://github.com/wixtoolset/wix3/releases/download/wix314rtm/wix314.exe' -OutFile wix314.exe
           .\wix314.exe /quiet /norestart
-          del wix314.exe
         shell: powershell
 
       - name: Build Haveno Installer for Windows

--- a/desktop/package/package.gradle
+++ b/desktop/package/package.gradle
@@ -6,33 +6,40 @@ task jpackageSanityChecks {
     description 'Interactive sanity checks on the version of the code that will be packaged'
 
     doLast {
-        executeCmd("git --no-pager log -5 --oneline")
-        ant.input(message: "Above you see the current HEAD and its recent history.\n" +
-                "Is this the right commit for packaging? (y=continue, n=abort)",
-                addproperty: "sanity-check-1",
-                validargs: "y,n")
-        if (ant.properties['sanity-check-1'] == 'n') {
-            ant.fail('Aborting')
-        }
+        if (!System.getenv("CI")) {
+            executeCmd("git --no-pager log -5 --oneline")
+            ant.input(message: "Above you see the current HEAD and its recent history.\n" +
+                    "Is this the right commit for packaging? (y=continue, n=abort)",
+                    addproperty: "sanity-check-1",
+                    validargs: "y,n")
+            if (ant.properties['sanity-check-1'] == 'n') {
+                ant.fail('Aborting')
+            }
 
-        executeCmd("git status --short --branch")
-        ant.input(message: "Above you see any local changes that are not in the remote branch.\n" +
-                "If you have any local changes, please abort, get them merged, get the latest branch and try again.\n" +
-                "Continue with packaging? (y=continue, n=abort)",
-                addproperty: "sanity-check-2",
-                validargs: "y,n")
-        if (ant.properties['sanity-check-2'] == 'n') {
-            ant.fail('Aborting')
-        }
+            executeCmd("git status --short --branch")
+            ant.input(message: "Above you see any local changes that are not in the remote branch.\n" +
+                    "If you have any local changes, please abort, get them merged, get the latest branch and try again.\n" +
+                    "Continue with packaging? (y=continue, n=abort)",
+                    addproperty: "sanity-check-2",
+                    validargs: "y,n")
+            if (ant.properties['sanity-check-2'] == 'n') {
+                ant.fail('Aborting')
+            }
 
-        // TODO Evtl check programmatically in gradle (i.e. fail if below v11)
-        executeCmd("java --version")
-        ant.input(message: "Above you see the installed java version, which will be used to compile and build Haveno.\n" +
-                "Is this java version ok for that? (y=continue, n=abort)",
-                addproperty: "sanity-check-3",
-                validargs: "y,n")
-        if (ant.properties['sanity-check-3'] == 'n') {
-            ant.fail('Aborting')
+            // TODO Evtl check programmatically in gradle (i.e. fail if below v11)
+            executeCmd("java --version")
+            ant.input(message: "Above you see the installed java version, which will be used to compile and build Haveno.\n" +
+                    "Is this java version ok for that? (y=continue, n=abort)",
+                    addproperty: "sanity-check-3",
+                    validargs: "y,n")
+            if (ant.properties['sanity-check-3'] == 'n') {
+                ant.fail('Aborting')
+            }
+        } else {
+            println "CI environment detected, skipping interactive sanity checks"
+            executeCmd("git --no-pager log -5 --oneline")
+            executeCmd("git status --short --branch")
+            executeCmd("java --version")
         }
     }
 }


### PR DESCRIPTION
The action runs whenever commits are pushed, and will create installers for the three main platforms (all 64-bit) and attach them to the workflow run (see https://github.com/Jabster28/haveno/actions/runs/8649608495 for an example)

Closes #862 

I've only tested the macOS installer and the binaries in the Linux installer, so I'd appreciate it if someone could test the windows installer. For now, I'll try it in wine and see what happens.

Most of the CI stuff should be good, but let me know if you'd rather not zip all of the files or maybe attach them to releases when they're created.