### PR TITLE
chore: don't run codacy tests if on a fork

### DIFF
--- a/.github/workflows/codacy-code-reporter.yml
+++ b/.github/workflows/codacy-code-reporter.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'haveno-dex/haveno'
     name: Publish coverage
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Skips the coverage tests if the repo isn't `haveno-dex/haveno` (if the workflow is run on a fork). This seems to be the preferred way to skip tests on forks (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository).

You can see that the commit https://github.com/Jabster28/haveno/commit/f3266e007102aeab7e270e75d81c8d80eec43afb had a skipped run: https://github.com/Jabster28/haveno/actions/runs/8665816426/job/23765283878. Assuming the test still runs after merging, this should work fine.

Should close #865 when checked. 