### PR TITLE
chore: lock macos version back to x86

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,11 @@ jobs:
           cache: gradle
       - name: Build with Gradle
         run: ./gradlew build --stacktrace --scan
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: error-reports-${{ matrix.os }}
+          path: ${{ github.workspace }}/desktop/build/reports
       - name: cache nodes dependencies
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The failing CI tests were because of GitHub's `macos-latest` image update, which is now arm64 instead of x86-64. Setting the version to macos-13 stays with the 64-bit image, which can be used until #792 is completed.