### PR TITLE
chore: re-enable macos artifact uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           ./gradlew packageInstallers
         working-directory: .
       - name: Move Release Files on Unix
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
         run: |
           mkdir ${{ github.workspace }}/release
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then


### PR DESCRIPTION
Forgot to change the `macos-latest` in the conditional :sweat_smile: 