### PR TITLE
Add PayPal, CashApp, and Venmo support to Haveno

### DIFF
--- a/core/src/main/java/haveno/core/api/model/PaymentAccountFormField.java
+++ b/core/src/main/java/haveno/core/api/model/PaymentAccountFormField.java
@@ -87,6 +87,7 @@ public final class PaymentAccountFormField implements PersistablePayload {
         INTERMEDIARY_SWIFT_CODE,
         MOBILE_NR,
         NATIONAL_ACCOUNT_ID,
+        NAME_OR_USERNAME_OR_EMAIL_OR_MOBILE_NR,
         PAYID,
         PIX_KEY,
         POSTAL_ADDRESS,

--- a/core/src/main/java/haveno/core/payment/CashAppAccount.java
+++ b/core/src/main/java/haveno/core/payment/CashAppAccount.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 // Removed due too high chargeback risk
 // Cannot be deleted as it would break old trade history entries
-@Deprecated
 @EqualsAndHashCode(callSuper = true)
 public final class CashAppAccount extends PaymentAccount {
 
@@ -56,11 +55,11 @@ public final class CashAppAccount extends PaymentAccount {
         throw new RuntimeException("Not implemented");
     }
 
-    public void setCashTag(String cashTag) {
-        ((CashAppAccountPayload) paymentAccountPayload).setCashTag(cashTag);
+    public void setEmailOrMobileNrOrCashtag(String emailOrMobileNrOrCashtag) {
+        ((CashAppAccountPayload) paymentAccountPayload).setEmailOrMobileNrOrCashtag(emailOrMobileNrOrCashtag);
     }
 
-    public String getCashTag() {
-        return ((CashAppAccountPayload) paymentAccountPayload).getCashTag();
+    public String getEmailOrMobileNrOrCashtag() {
+        return ((CashAppAccountPayload) paymentAccountPayload).getEmailOrMobileNrOrCashtag();
     }
 }

--- a/core/src/main/java/haveno/core/payment/PayPalAccount.java
+++ b/core/src/main/java/haveno/core/payment/PayPalAccount.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.payment;
+
+import haveno.core.api.model.PaymentAccountFormField;
+import haveno.core.locale.TraditionalCurrency;
+import haveno.core.locale.TradeCurrency;
+import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.payload.PaymentMethod;
+import haveno.core.payment.payload.PayPalAccountPayload;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+
+import java.util.List;
+
+// Removed due too high chargeback risk
+// Cannot be deleted as it would break old trade history entries
+// @Deprecated
+@EqualsAndHashCode(callSuper = true)
+public final class PayPalAccount extends PaymentAccount {
+
+    public static final List<TradeCurrency> SUPPORTED_CURRENCIES = List.of(
+            new TraditionalCurrency("AUD"), new TraditionalCurrency("BRL"), new TraditionalCurrency("CAD"),
+            new TraditionalCurrency("CNY"), new TraditionalCurrency("CZK"), new TraditionalCurrency("DKK"),
+            new TraditionalCurrency("EUR"), new TraditionalCurrency("HKD"), new TraditionalCurrency("HUF"),
+            new TraditionalCurrency("ILS"), new TraditionalCurrency("JPY"), new TraditionalCurrency("MYR"),
+            new TraditionalCurrency("MXN"), new TraditionalCurrency("TWD"), new TraditionalCurrency("NZD"),
+            new TraditionalCurrency("NOK"), new TraditionalCurrency("PHP"), new TraditionalCurrency("PLN"),
+            new TraditionalCurrency("GBP"), new TraditionalCurrency("SGD"), new TraditionalCurrency("SEK"),
+            new TraditionalCurrency("CHF"), new TraditionalCurrency("THB"), new TraditionalCurrency("USD"));
+
+    private static final List<PaymentAccountFormField.FieldId> INPUT_FIELD_IDS = List.of(
+            PaymentAccountFormField.FieldId.NAME_OR_USERNAME_OR_EMAIL_OR_MOBILE_NR,
+            PaymentAccountFormField.FieldId.SALT);
+
+    public PayPalAccount() {
+        super(PaymentMethod.PAYPAL);
+        tradeCurrencies.addAll(SUPPORTED_CURRENCIES);
+    }
+
+    @Override
+    protected PaymentAccountPayload createPayload() {
+        return new PayPalAccountPayload(paymentMethod.getId(), id);
+    }
+
+    @Override
+    public @NonNull List<TradeCurrency> getSupportedCurrencies() {
+        return SUPPORTED_CURRENCIES;
+    }
+
+    @Override
+    public @NonNull List<PaymentAccountFormField.FieldId> getInputFieldIds() {
+        return INPUT_FIELD_IDS;
+    }
+
+    public void setNameOrUsernameOrEmailOrMobileNr(String paypalNameOrUsernameOrEmailOrMobileNr) {
+        ((PayPalAccountPayload) paymentAccountPayload)
+                .setNameOrUsernameOrEmailOrMobileNr(paypalNameOrUsernameOrEmailOrMobileNr);
+    }
+
+    public String getNameOrUsernameOrEmailOrMobileNr() {
+        return ((PayPalAccountPayload) paymentAccountPayload).getNameOrUsernameOrEmailOrMobileNr();
+    }
+}

--- a/core/src/main/java/haveno/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/haveno/core/payment/PaymentAccountFactory.java
@@ -86,6 +86,8 @@ public class PaymentAccountFactory {
                 return new TransferwiseAccount();
             case PaymentMethod.TRANSFERWISE_USD_ID:
                 return new TransferwiseUsdAccount();
+            case PaymentMethod.PAYPAL_ID:
+                return new PayPalAccount();
             case PaymentMethod.PAYSERA_ID:
                 return new PayseraAccount();
             case PaymentMethod.PAXUM_ID:

--- a/core/src/main/java/haveno/core/payment/PaymentAccountUtil.java
+++ b/core/src/main/java/haveno/core/payment/PaymentAccountUtil.java
@@ -66,6 +66,7 @@ import static haveno.core.payment.payload.PaymentMethod.NATIONAL_BANK_ID;
 import static haveno.core.payment.payload.PaymentMethod.NEFT_ID;
 import static haveno.core.payment.payload.PaymentMethod.NEQUI_ID;
 import static haveno.core.payment.payload.PaymentMethod.PAXUM_ID;
+import static haveno.core.payment.payload.PaymentMethod.PAYPAL_ID;
 import static haveno.core.payment.payload.PaymentMethod.PAYSERA_ID;
 import static haveno.core.payment.payload.PaymentMethod.PAYTM_ID;
 import static haveno.core.payment.payload.PaymentMethod.PERFECT_MONEY_ID;
@@ -214,6 +215,8 @@ public class PaymentAccountUtil {
                 return USPostalMoneyOrderAccount.SUPPORTED_CURRENCIES;
             case VENMO_ID:
                 return VenmoAccount.SUPPORTED_CURRENCIES;
+            case PAYPAL_ID:
+                return PayPalAccount.SUPPORTED_CURRENCIES;
             case JAPAN_BANK_ID:
                 return JapanBankAccount.SUPPORTED_CURRENCIES;
             case WECHAT_PAY_ID:

--- a/core/src/main/java/haveno/core/payment/VenmoAccount.java
+++ b/core/src/main/java/haveno/core/payment/VenmoAccount.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 // Removed due too high chargeback risk
 // Cannot be deleted as it would break old trade history entries
-@Deprecated
+// @Deprecated
 @EqualsAndHashCode(callSuper = true)
 public final class VenmoAccount extends PaymentAccount {
 
@@ -56,19 +56,12 @@ public final class VenmoAccount extends PaymentAccount {
         throw new RuntimeException("Not implemented");
     }
 
-    public void setVenmoUserName(String venmoUserName) {
-        ((VenmoAccountPayload) paymentAccountPayload).setVenmoUserName(venmoUserName);
+    public void setNameOrUsernameOrEmailOrMobileNr(String venmoNameOrUsernameOrEmailOrMobileNr) {
+        ((VenmoAccountPayload) paymentAccountPayload)
+                .setNameOrUsernameOrEmailOrMobileNr(venmoNameOrUsernameOrEmailOrMobileNr);
     }
 
-    public String getVenmoUserName() {
-        return ((VenmoAccountPayload) paymentAccountPayload).getVenmoUserName();
-    }
-
-    public void setHolderName(String holderName) {
-        ((VenmoAccountPayload) paymentAccountPayload).setHolderName(holderName);
-    }
-
-    public String getHolderName() {
-        return ((VenmoAccountPayload) paymentAccountPayload).getHolderName();
+    public String getNameOrUsernameOrEmailOrMobileNr() {
+        return ((VenmoAccountPayload) paymentAccountPayload).getNameOrUsernameOrEmailOrMobileNr();
     }
 }

--- a/core/src/main/java/haveno/core/payment/payload/CashAppAccountPayload.java
+++ b/core/src/main/java/haveno/core/payment/payload/CashAppAccountPayload.java
@@ -31,19 +31,17 @@ import java.util.Map;
 
 // Cannot be deleted as it would break old trade history entries
 // Removed due too high chargeback risk
-@Deprecated
 @EqualsAndHashCode(callSuper = true)
 @ToString
 @Setter
 @Getter
 @Slf4j
 public final class CashAppAccountPayload extends PaymentAccountPayload {
-    private String cashTag = "";
+    private String emailOrMobileNrOrCashtag = "";
 
     public CashAppAccountPayload(String paymentMethod, String id) {
         super(paymentMethod, id);
     }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
@@ -51,7 +49,7 @@ public final class CashAppAccountPayload extends PaymentAccountPayload {
 
     private CashAppAccountPayload(String paymentMethod,
                                   String id,
-                                  String cashTag,
+                                  String emailOrMobileNrOrCashtag,
                                   long maxTradePeriod,
                                   Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
@@ -59,21 +57,21 @@ public final class CashAppAccountPayload extends PaymentAccountPayload {
                 maxTradePeriod,
                 excludeFromJsonDataMap);
 
-        this.cashTag = cashTag;
+        this.emailOrMobileNrOrCashtag = emailOrMobileNrOrCashtag;
     }
 
     @Override
     public Message toProtoMessage() {
         return getPaymentAccountPayloadBuilder()
                 .setCashAppAccountPayload(protobuf.CashAppAccountPayload.newBuilder()
-                        .setCashTag(cashTag))
+                        .setEmailOrMobileNrOrCashtag(emailOrMobileNrOrCashtag))
                 .build();
     }
 
     public static CashAppAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
         return new CashAppAccountPayload(proto.getPaymentMethodId(),
                 proto.getId(),
-                proto.getCashAppAccountPayload().getCashTag(),
+                proto.getCashAppAccountPayload().getEmailOrMobileNrOrCashtag(),
                 proto.getMaxTradePeriod(),
                 new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
@@ -85,7 +83,7 @@ public final class CashAppAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.account") + " " + cashTag;
+        return Res.get(paymentMethodId) + " - " + Res.getWithCol("payment.email.mobile.cashtag") + " " + emailOrMobileNrOrCashtag;
     }
 
     @Override
@@ -95,6 +93,6 @@ public final class CashAppAccountPayload extends PaymentAccountPayload {
 
     @Override
     public byte[] getAgeWitnessInputData() {
-        return super.getAgeWitnessInputData(cashTag.getBytes(StandardCharsets.UTF_8));
+        return super.getAgeWitnessInputData(emailOrMobileNrOrCashtag.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/core/src/main/java/haveno/core/payment/payload/PayPalAccountPayload.java
+++ b/core/src/main/java/haveno/core/payment/payload/PayPalAccountPayload.java
@@ -37,23 +37,22 @@ import java.util.Map;
 @Setter
 @Getter
 @Slf4j
-public final class VenmoAccountPayload extends PaymentAccountPayload {
+public final class PayPalAccountPayload extends PaymentAccountPayload {
     private String nameOrUsernameOrEmailOrMobileNr = "";
 
-    public VenmoAccountPayload(String paymentMethod, String id) {
+    public PayPalAccountPayload(String paymentMethod, String id) {
         super(paymentMethod, id);
     }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // PROTO BUFFER
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    private VenmoAccountPayload(String paymentMethod,
-                                String id,
-                                String nameOrUsernameOrEmailOrMobileNr,
-                                long maxTradePeriod,
-                                Map<String, String> excludeFromJsonDataMap) {
+    private PayPalAccountPayload(String paymentMethod,
+            String id,
+            String nameOrUsernameOrEmailOrMobileNr,
+            long maxTradePeriod,
+            Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
                 id,
                 maxTradePeriod,
@@ -65,19 +64,18 @@ public final class VenmoAccountPayload extends PaymentAccountPayload {
     @Override
     public Message toProtoMessage() {
         return getPaymentAccountPayloadBuilder()
-                .setVenmoAccountPayload(protobuf.VenmoAccountPayload.newBuilder()
+                .setPaypalAccountPayload(protobuf.PayPalAccountPayload.newBuilder()
                         .setNameOrUsernameOrEmailOrMobileNr(nameOrUsernameOrEmailOrMobileNr))
                 .build();
     }
 
-    public static VenmoAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
-        return new VenmoAccountPayload(proto.getPaymentMethodId(),
+    public static PayPalAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
+        return new PayPalAccountPayload(proto.getPaymentMethodId(),
                 proto.getId(),
-                proto.getVenmoAccountPayload().getNameOrUsernameOrEmailOrMobileNr(),
+                proto.getPaypalAccountPayload().getNameOrUsernameOrEmailOrMobileNr(),
                 proto.getMaxTradePeriod(),
                 new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // API
@@ -85,7 +83,7 @@ public final class VenmoAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.getWithCol("payment.venmo.NameOrUsernameOrEmailOrMobileNr") + " "
+        return Res.getWithCol("payment.paypal.paypalNameOrUsernameOrEmailOrMobileNr") + " "
                 + nameOrUsernameOrEmailOrMobileNr;
     }
 

--- a/core/src/main/java/haveno/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/haveno/core/payment/payload/PaymentMethod.java
@@ -47,8 +47,10 @@ import haveno.core.payment.AmazonGiftCardAccount;
 import haveno.core.payment.AustraliaPayidAccount;
 import haveno.core.payment.BizumAccount;
 import haveno.core.payment.CapitualAccount;
+import haveno.core.payment.CashAppAccount;
 import haveno.core.payment.CashAtAtmAccount;
 import haveno.core.payment.PayByMailAccount;
+import haveno.core.payment.PayPalAccount;
 import haveno.core.payment.CashDepositAccount;
 import haveno.core.payment.CelPayAccount;
 import haveno.core.payment.ZelleAccount;
@@ -89,6 +91,7 @@ import haveno.core.payment.TransferwiseUsdAccount;
 import haveno.core.payment.USPostalMoneyOrderAccount;
 import haveno.core.payment.UpholdAccount;
 import haveno.core.payment.UpiAccount;
+import haveno.core.payment.VenmoAccount;
 import haveno.core.payment.VerseAccount;
 import haveno.core.payment.WeChatPayAccount;
 import haveno.core.payment.WesternUnionAccount;
@@ -194,10 +197,11 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     // Cannot be deleted as it would break old trade history entries
     @Deprecated
     public static final String OK_PAY_ID = "OK_PAY";
-    @Deprecated
+    // @Deprecated
     public static final String CASH_APP_ID = "CASH_APP"; // Removed due too high chargeback risk
-    @Deprecated
-    public static final String VENMO_ID = "VENMO";  // Removed due too high chargeback risk
+    // @Deprecated
+    public static final String VENMO_ID = "VENMO"; // Removed due too high chargeback risk
+    public static final String PAYPAL_ID = "PAYPAL";
 
     public static PaymentMethod UPHOLD;
     public static PaymentMethod MONEY_BEAM;
@@ -254,17 +258,24 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static PaymentMethod ACH_TRANSFER;
     public static PaymentMethod DOMESTIC_WIRE_TRANSFER;
     public static PaymentMethod BSQ_SWAP;
+    public static PaymentMethod PAYPAL;
+    public static PaymentMethod CASH_APP;
+    public static PaymentMethod VENMO;
 
     // Cannot be deleted as it would break old trade history entries
     @Deprecated
     public static PaymentMethod OK_PAY = getDummyPaymentMethod(OK_PAY_ID);
-    @Deprecated
-    public static PaymentMethod CASH_APP = getDummyPaymentMethod(CASH_APP_ID); // Removed due too high chargeback risk
-    @Deprecated
-    public static PaymentMethod VENMO = getDummyPaymentMethod(VENMO_ID); // Removed due too high chargeback risk
+    // @Deprecated
+    // public static PaymentMethod CASH_APP = getDummyPaymentMethod(CASH_APP_ID); //
+    // Removed due too high chargeback risk
+    // @Deprecated
+    // public static PaymentMethod VENMO = getDummyPaymentMethod(VENMO_ID); //
+    // Removed due too high chargeback risk
 
-    // The limit and duration assignment must not be changed as that could break old offers (if amount would be higher
-    // than new trade limit) and violate the maker expectation when he created the offer (duration).
+    // The limit and duration assignment must not be changed as that could break old
+    // offers (if amount would be higher
+    // than new trade limit) and violate the maker expectation when he created the
+    // offer (duration).
     public final static List<PaymentMethod> paymentMethods = Arrays.asList(
             // EUR
             HAL_CASH = new PaymentMethod(HAL_CASH_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK, getAssetCodes(HalCashAccount.SUPPORTED_CURRENCIES)),
@@ -343,7 +354,10 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
             // Cryptos
             BLOCK_CHAINS = new PaymentMethod(BLOCK_CHAINS_ID, DAY, DEFAULT_TRADE_LIMIT_VERY_LOW_RISK, Arrays.asList()),
             // Cryptos with 1 hour trade period
-            BLOCK_CHAINS_INSTANT = new PaymentMethod(BLOCK_CHAINS_INSTANT_ID, TimeUnit.HOURS.toMillis(1), DEFAULT_TRADE_LIMIT_VERY_LOW_RISK, Arrays.asList())
+            BLOCK_CHAINS_INSTANT = new PaymentMethod(BLOCK_CHAINS_INSTANT_ID, TimeUnit.HOURS.toMillis(1), DEFAULT_TRADE_LIMIT_VERY_LOW_RISK, Arrays.asList()),
+            PAYPAL = new PaymentMethod(PAYPAL_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(PayPalAccount.SUPPORTED_CURRENCIES)),
+            VENMO = new PaymentMethod(VENMO_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(VenmoAccount.SUPPORTED_CURRENCIES)),
+            CASH_APP = new PaymentMethod(CASH_APP_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(CashAppAccount.SUPPORTED_CURRENCIES))
     );
 
     // TODO: delete this override method, which overrides the paymentMethods variable, when all payment methods supported using structured form api, and make paymentMethods private

--- a/core/src/main/java/haveno/core/payment/validation/EmailOrMobileNrOrCashtagValidator.java
+++ b/core/src/main/java/haveno/core/payment/validation/EmailOrMobileNrOrCashtagValidator.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.payment.validation;
+
+import haveno.core.util.validation.InputValidator;
+
+public final class EmailOrMobileNrOrCashtagValidator extends InputValidator {
+
+    private final EmailOrMobileNrValidator emailOrMobileNrValidator;
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Public methods
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public EmailOrMobileNrOrCashtagValidator() {
+        emailOrMobileNrValidator = new EmailOrMobileNrValidator();
+    }
+
+    @Override
+    public ValidationResult validate(String input) {
+        ValidationResult result = validateIfNotEmpty(input);
+        if (!result.isValid) {
+            return result;
+        } else {
+            ValidationResult emailOrMobileResult = emailOrMobileNrValidator.validate(input);
+            if (emailOrMobileResult.isValid)
+                return emailOrMobileResult;
+            else
+                return validateCashtag(input);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Private methods
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    // TODO not impl yet -> see InteracETransferValidator
+    private ValidationResult validateCashtag(String input) {
+        return super.validate(input);
+    }
+}

--- a/core/src/main/java/haveno/core/payment/validation/NameOrUsernameOrEmailOrMobileNrValidator.java
+++ b/core/src/main/java/haveno/core/payment/validation/NameOrUsernameOrEmailOrMobileNrValidator.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.payment.validation;
+
+import haveno.core.util.validation.InputValidator;
+
+public final class NameOrUsernameOrEmailOrMobileNrValidator extends InputValidator {
+
+    private final EmailOrMobileNrValidator emailOrMobileNrValidator;
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Public methods
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public NameOrUsernameOrEmailOrMobileNrValidator() {
+        emailOrMobileNrValidator = new EmailOrMobileNrValidator();
+    }
+
+    @Override
+    public ValidationResult validate(String input) {
+        ValidationResult result = validateIfNotEmpty(input);
+        if (!result.isValid) {
+            return result;
+        } else {
+            ValidationResult emailOrMobileResult = emailOrMobileNrValidator.validate(input);
+            if (emailOrMobileResult.isValid)
+                return emailOrMobileResult;
+            else
+                return validateName(input);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Private methods
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    // TODO: properly implement name/username validation
+    private ValidationResult validateName(String input) {
+        return super.validate(input);
+    }
+}

--- a/core/src/main/java/haveno/core/proto/CoreProtoResolver.java
+++ b/core/src/main/java/haveno/core/proto/CoreProtoResolver.java
@@ -54,6 +54,7 @@ import haveno.core.payment.payload.NequiAccountPayload;
 import haveno.core.payment.payload.OKPayAccountPayload;
 import haveno.core.payment.payload.PaxumAccountPayload;
 import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.payload.PayPalAccountPayload;
 import haveno.core.payment.payload.PayseraAccountPayload;
 import haveno.core.payment.payload.PaytmAccountPayload;
 import haveno.core.payment.payload.PerfectMoneyAccountPayload;
@@ -236,6 +237,8 @@ public class CoreProtoResolver implements ProtoResolver {
                     return CashAppAccountPayload.fromProto(proto);
                 case VENMO_ACCOUNT_PAYLOAD:
                     return VenmoAccountPayload.fromProto(proto);
+                case PAYPAL_ACCOUNT_PAYLOAD:
+                    return PayPalAccountPayload.fromProto(proto);
 
                 default:
                     throw new ProtobufferRuntimeException("Unknown proto message case(PB.PaymentAccountPayload). messageCase=" + messageCase);

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2500,6 +2500,8 @@ payment.email=Email
 payment.country=Country
 payment.extras=Extra requirements
 payment.email.mobile=Email or mobile no.
+payment.email.mobile.cashtag=Email, mobile number, or Cashtag
+payment.name.username.email.mobile=Full name, username, email, or mobile no.
 payment.crypto.address=Cryptocurrency address
 payment.crypto.tradeInstantCheckbox=Trade instant (within 1 hour) with this Cryptocurrency
 payment.crypto.tradeInstant.popup=For instant trading it is required that both trading peers are online to be able \
@@ -3159,7 +3161,7 @@ OK_PAY=OKPay
 CASH_APP=Cash App
 # suppress inspection "UnusedProperty"
 VENMO=Venmo
-
+PAYPAL=PayPal
 
 # suppress inspection "UnusedProperty"
 UPHOLD_SHORT=Uphold
@@ -3255,6 +3257,7 @@ OK_PAY_SHORT=OKPay
 CASH_APP_SHORT=Cash App
 # suppress inspection "UnusedProperty"
 VENMO_SHORT=Venmo
+PAYPAL_SHORT=PayPal
 
 
 ####################################################################

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/CashAppForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/CashAppForm.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.desktop.components.paymentmethods;
+
+import haveno.core.account.witness.AccountAgeWitnessService;
+import haveno.core.locale.Res;
+import haveno.core.locale.TradeCurrency;
+import haveno.core.payment.CashAppAccount;
+import haveno.core.payment.PaymentAccount;
+import haveno.core.payment.payload.CashAppAccountPayload;
+import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.validation.EmailOrMobileNrOrCashtagValidator;
+import haveno.core.util.coin.CoinFormatter;
+import haveno.core.util.validation.InputValidator;
+import haveno.desktop.components.InputTextField;
+import haveno.desktop.util.FormBuilder;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
+import static haveno.desktop.util.FormBuilder.addTopLabelTextField;
+
+public class CashAppForm extends PaymentMethodForm {
+    private final CashAppAccount cashAppAccount;
+    private final EmailOrMobileNrOrCashtagValidator cashAppValidator;
+
+    public static int addFormForBuyer(GridPane gridPane, int gridRow, PaymentAccountPayload paymentAccountPayload) {
+        addCompactTopLabelTextFieldWithCopyIcon(gridPane, gridRow, 1, Res.get("payment.email.mobile.cashtag"),
+                ((CashAppAccountPayload) paymentAccountPayload).getEmailOrMobileNrOrCashtag());
+        return gridRow;
+    }
+
+    public CashAppForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService,
+            EmailOrMobileNrOrCashtagValidator cashAppValidator, InputValidator inputValidator, GridPane gridPane,
+            int gridRow,
+            CoinFormatter formatter) {
+        super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
+        this.cashAppAccount = (CashAppAccount) paymentAccount;
+        this.cashAppValidator = cashAppValidator;
+    }
+
+    @Override
+    public void addFormForAddAccount() {
+        gridRowFrom = gridRow + 1;
+
+        InputTextField mobileNrInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow,
+                Res.get("payment.email.mobile.cashtag"));
+        mobileNrInputTextField.setValidator(cashAppValidator);
+        mobileNrInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            cashAppAccount.setEmailOrMobileNrOrCashtag(newValue.trim());
+            updateFromInputs();
+        });
+        final TradeCurrency singleTradeCurrency = cashAppAccount.getSingleTradeCurrency();
+        final String nameAndCode = singleTradeCurrency != null ? singleTradeCurrency.getNameAndCode() : "";
+        addTopLabelTextField(gridPane, ++gridRow, Res.get("shared.currency"),
+                nameAndCode);
+        addLimitations(false);
+        addAccountNameTextFieldWithAutoFillToggleButton();
+    }
+
+    @Override
+    protected void autoFillNameTextField() {
+        setAccountNameWithString(cashAppAccount.getEmailOrMobileNrOrCashtag());
+    }
+
+    @Override
+    public void addFormForEditAccount() {
+        gridRowFrom = gridRow;
+        TextField field = addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("payment.email.mobile.cashtag"),
+                cashAppAccount.getEmailOrMobileNrOrCashtag()).second;
+        field.setMouseTransparent(false);
+        final TradeCurrency singleTradeCurrency = cashAppAccount.getSingleTradeCurrency();
+        final String nameAndCode = singleTradeCurrency != null ? singleTradeCurrency.getNameAndCode() : "";
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.currency"),
+                nameAndCode);
+        addLimitations(true);
+    }
+
+    @Override
+    public void updateAllInputsValid() {
+        allInputsValid.set(isAccountNameValid()
+                && cashAppValidator.validate(cashAppAccount.getEmailOrMobileNrOrCashtag()).isValid
+                && cashAppAccount.getTradeCurrencies().size() > 0);
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.desktop.components.paymentmethods;
+
+import haveno.core.account.witness.AccountAgeWitnessService;
+import haveno.core.locale.Res;
+import haveno.core.locale.TradeCurrency;
+import haveno.core.payment.PayPalAccount;
+import haveno.core.payment.PaymentAccount;
+import haveno.core.payment.payload.PayPalAccountPayload;
+import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.validation.NameOrUsernameOrEmailOrMobileNrValidator;
+import haveno.core.util.coin.CoinFormatter;
+import haveno.core.util.validation.InputValidator;
+import haveno.desktop.components.InputTextField;
+import haveno.desktop.util.FormBuilder;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
+
+public class PayPalForm extends PaymentMethodForm {
+    private final PayPalAccount paypalAccount;
+    private final NameOrUsernameOrEmailOrMobileNrValidator paypalValidator;
+
+    public static int addFormForBuyer(GridPane gridPane, int gridRow, PaymentAccountPayload paymentAccountPayload) {
+        addCompactTopLabelTextFieldWithCopyIcon(gridPane, gridRow, 1, Res.get("payment.name.username.email.mobile"),
+                ((PayPalAccountPayload) paymentAccountPayload).getNameOrUsernameOrEmailOrMobileNr());
+        return gridRow;
+    }
+
+    public PayPalForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService,
+            NameOrUsernameOrEmailOrMobileNrValidator paypalValidator, InputValidator inputValidator, GridPane gridPane,
+            int gridRow,
+            CoinFormatter formatter) {
+        super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
+        this.paypalAccount = (PayPalAccount) paymentAccount;
+        this.paypalValidator = paypalValidator;
+    }
+
+    @Override
+    public void addFormForAddAccount() {
+        gridRowFrom = gridRow + 1;
+
+        InputTextField mobileNrInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow,
+                Res.get("payment.name.username.email.mobile"));
+        mobileNrInputTextField.setValidator(paypalValidator);
+        mobileNrInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            paypalAccount.setNameOrUsernameOrEmailOrMobileNr(newValue.trim());
+            updateFromInputs();
+        });
+        addLimitations(false);
+        addAccountNameTextFieldWithAutoFillToggleButton();
+    }
+
+    @Override
+    protected void autoFillNameTextField() {
+        setAccountNameWithString(paypalAccount.getNameOrUsernameOrEmailOrMobileNr());
+    }
+
+    @Override
+    public void addFormForEditAccount() {
+        gridRowFrom = gridRow;
+        addAccountNameTextFieldWithAutoFillToggleButton();
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.paymentMethod"),
+                Res.get(paypalAccount.getPaymentMethod().getId()));
+        TextField field = addCompactTopLabelTextField(gridPane, ++gridRow,
+                Res.get("payment.name.username.email.mobile"),
+                paypalAccount.getNameOrUsernameOrEmailOrMobileNr()).second;
+        field.setMouseTransparent(false);
+        final TradeCurrency singleTradeCurrency = paypalAccount.getSingleTradeCurrency();
+        final String nameAndCode = singleTradeCurrency != null ? singleTradeCurrency.getNameAndCode() : "";
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.currency"),
+                nameAndCode);
+        addLimitations(true);
+    }
+
+    @Override
+    public void updateAllInputsValid() {
+        allInputsValid.set(isAccountNameValid()
+                && paypalValidator.validate(paypalAccount.getNameOrUsernameOrEmailOrMobileNr()).isValid
+                && paypalAccount.getTradeCurrencies().size() > 0);
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/VenmoForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/VenmoForm.java
@@ -1,0 +1,91 @@
+/**This file is part of Bisq.**Bisq is free software:you can redistribute it and/or modify it*under the terms of the GNU Affero General Public License as published by*the Free Software Foundation,either version 3 of the License,or(at*your option)any later version.**Bisq is distributed in the hope that it will be useful,but WITHOUT*ANY WARRANTY;without even the implied warranty of MERCHANTABILITY or*FITNESS FOR A PARTICULAR PURPOSE.See the GNU Affero General Public*License for more details.**You should have received a copy of the GNU Affero General Public License*along with Bisq.If not,see<http://www.gnu.org/licenses/>.
+*/
+
+package haveno.desktop.components.paymentmethods;
+
+import haveno.core.account.witness.AccountAgeWitnessService;
+import haveno.core.locale.Res;
+import haveno.core.locale.TradeCurrency;
+import haveno.core.payment.VenmoAccount;
+import haveno.core.payment.PaymentAccount;
+import haveno.core.payment.payload.VenmoAccountPayload;
+import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.validation.NameOrUsernameOrEmailOrMobileNrValidator;
+import haveno.core.util.coin.CoinFormatter;
+import haveno.core.util.validation.InputValidator;
+import haveno.desktop.components.InputTextField;
+import haveno.desktop.util.FormBuilder;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
+import static haveno.desktop.util.FormBuilder.addTopLabelTextField;
+
+public class VenmoForm extends PaymentMethodForm {
+    private final VenmoAccount venmoAccount;
+    private final NameOrUsernameOrEmailOrMobileNrValidator venmoValidator;
+
+    public static int addFormForBuyer(GridPane gridPane, int gridRow, PaymentAccountPayload paymentAccountPayload) {
+        addCompactTopLabelTextFieldWithCopyIcon(gridPane, gridRow, 1, Res.get("payment.name.username.email.mobile"),
+                ((VenmoAccountPayload) paymentAccountPayload).getNameOrUsernameOrEmailOrMobileNr());
+        return gridRow;
+    }
+
+    public VenmoForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService,
+            NameOrUsernameOrEmailOrMobileNrValidator venmoValidator, InputValidator inputValidator, GridPane gridPane,
+            int gridRow,
+            CoinFormatter formatter) {
+        super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
+        this.venmoAccount = (VenmoAccount) paymentAccount;
+        this.venmoValidator = venmoValidator;
+    }
+
+    @Override
+    public void addFormForAddAccount() {
+        gridRowFrom = gridRow + 1;
+
+        InputTextField mobileNrInputTextField = FormBuilder.addInputTextField(gridPane, ++gridRow,
+                Res.get("payment.name.username.email.mobile"));
+        mobileNrInputTextField.setValidator(venmoValidator);
+        mobileNrInputTextField.textProperty().addListener((ov, oldValue, newValue) -> {
+            venmoAccount.setNameOrUsernameOrEmailOrMobileNr(newValue.trim());
+            updateFromInputs();
+        });
+        final TradeCurrency singleTradeCurrency = venmoAccount.getSingleTradeCurrency();
+        final String nameAndCode = singleTradeCurrency != null ? singleTradeCurrency.getNameAndCode() : "";
+        addTopLabelTextField(gridPane, ++gridRow, Res.get("shared.currency"),
+                nameAndCode);
+        addLimitations(false);
+        addAccountNameTextFieldWithAutoFillToggleButton();
+    }
+
+    @Override
+    protected void autoFillNameTextField() {
+        setAccountNameWithString(venmoAccount.getNameOrUsernameOrEmailOrMobileNr());
+    }
+
+    @Override
+    public void addFormForEditAccount() {
+        gridRowFrom = gridRow;
+        addAccountNameTextFieldWithAutoFillToggleButton();
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.paymentMethod"),
+                Res.get(venmoAccount.getPaymentMethod().getId()));
+        TextField field = addCompactTopLabelTextField(gridPane, ++gridRow,
+                Res.get("payment.name.username.email.mobile"),
+                venmoAccount.getNameOrUsernameOrEmailOrMobileNr()).second;
+        field.setMouseTransparent(false);
+        final TradeCurrency singleTradeCurrency = venmoAccount.getSingleTradeCurrency();
+        final String nameAndCode = singleTradeCurrency != null ? singleTradeCurrency.getNameAndCode() : "";
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.currency"),
+                nameAndCode);
+        addLimitations(true);
+    }
+
+    @Override
+    public void updateAllInputsValid() {
+        allInputsValid.set(isAccountNameValid()
+                && venmoValidator.validate(venmoAccount.getNameOrUsernameOrEmailOrMobileNr()).isValid
+                && venmoAccount.getTradeCurrencies().size() > 0);
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/main/account/content/traditionalaccounts/TraditionalAccountsView.java
+++ b/desktop/src/main/java/haveno/desktop/main/account/content/traditionalaccounts/TraditionalAccountsView.java
@@ -48,12 +48,14 @@ import haveno.core.payment.validation.BICValidator;
 import haveno.core.payment.validation.CapitualValidator;
 import haveno.core.payment.validation.ChaseQuickPayValidator;
 import haveno.core.payment.validation.EmailOrMobileNrValidator;
+import haveno.core.payment.validation.EmailOrMobileNrOrCashtagValidator;
 import haveno.core.payment.validation.F2FValidator;
 import haveno.core.payment.validation.HalCashValidator;
 import haveno.core.payment.validation.InteracETransferValidator;
 import haveno.core.payment.validation.JapanBankTransferValidator;
 import haveno.core.payment.validation.LengthValidator;
 import haveno.core.payment.validation.MoneyBeamValidator;
+import haveno.core.payment.validation.NameOrUsernameOrEmailOrMobileNrValidator;
 import haveno.core.payment.validation.PerfectMoneyValidator;
 import haveno.core.payment.validation.PopmoneyValidator;
 import haveno.core.payment.validation.PromptPayValidator;
@@ -75,6 +77,7 @@ import haveno.desktop.components.paymentmethods.AmazonGiftCardForm;
 import haveno.desktop.components.paymentmethods.AustraliaPayidForm;
 import haveno.desktop.components.paymentmethods.BizumForm;
 import haveno.desktop.components.paymentmethods.CapitualForm;
+import haveno.desktop.components.paymentmethods.CashAppForm;
 import haveno.desktop.components.paymentmethods.CashAtAtmForm;
 import haveno.desktop.components.paymentmethods.CashDepositForm;
 import haveno.desktop.components.paymentmethods.CelPayForm;
@@ -94,6 +97,7 @@ import haveno.desktop.components.paymentmethods.NeftForm;
 import haveno.desktop.components.paymentmethods.NequiForm;
 import haveno.desktop.components.paymentmethods.PaxumForm;
 import haveno.desktop.components.paymentmethods.PayByMailForm;
+import haveno.desktop.components.paymentmethods.PayPalForm;
 import haveno.desktop.components.paymentmethods.PaymentMethodForm;
 import haveno.desktop.components.paymentmethods.PayseraForm;
 import haveno.desktop.components.paymentmethods.PaytmForm;
@@ -117,6 +121,7 @@ import haveno.desktop.components.paymentmethods.TransferwiseUsdForm;
 import haveno.desktop.components.paymentmethods.USPostalMoneyOrderForm;
 import haveno.desktop.components.paymentmethods.UpholdForm;
 import haveno.desktop.components.paymentmethods.UpiForm;
+import haveno.desktop.components.paymentmethods.VenmoForm;
 import haveno.desktop.components.paymentmethods.VerseForm;
 import haveno.desktop.components.paymentmethods.WeChatPayForm;
 import haveno.desktop.components.paymentmethods.WesternUnionForm;
@@ -158,6 +163,9 @@ public class TraditionalAccountsView extends PaymentAccountsView<GridPane, Tradi
     private final PerfectMoneyValidator perfectMoneyValidator;
     private final SwishValidator swishValidator;
     private final EmailOrMobileNrValidator zelleValidator;
+    private final NameOrUsernameOrEmailOrMobileNrValidator paypalValidator;
+    private final NameOrUsernameOrEmailOrMobileNrValidator venmoValidator;
+    private final EmailOrMobileNrOrCashtagValidator cashAppValidator;
     private final ChaseQuickPayValidator chaseQuickPayValidator;
     private final InteracETransferValidator interacETransferValidator;
     private final JapanBankTransferValidator japanBankTransferValidator;
@@ -189,6 +197,8 @@ public class TraditionalAccountsView extends PaymentAccountsView<GridPane, Tradi
                             PerfectMoneyValidator perfectMoneyValidator,
                             SwishValidator swishValidator,
                             EmailOrMobileNrValidator zelleValidator,
+                            EmailOrMobileNrOrCashtagValidator cashAppValidator,
+                            NameOrUsernameOrEmailOrMobileNrValidator nuemValidator,
                             ChaseQuickPayValidator chaseQuickPayValidator,
                             InteracETransferValidator interacETransferValidator,
                             JapanBankTransferValidator japanBankTransferValidator,
@@ -217,6 +227,9 @@ public class TraditionalAccountsView extends PaymentAccountsView<GridPane, Tradi
         this.perfectMoneyValidator = perfectMoneyValidator;
         this.swishValidator = swishValidator;
         this.zelleValidator = zelleValidator;
+        this.paypalValidator = nuemValidator;
+        this.venmoValidator = nuemValidator;
+        this.cashAppValidator = cashAppValidator;
         this.chaseQuickPayValidator = chaseQuickPayValidator;
         this.interacETransferValidator = interacETransferValidator;
         this.japanBankTransferValidator = japanBankTransferValidator;
@@ -624,6 +637,12 @@ public class TraditionalAccountsView extends PaymentAccountsView<GridPane, Tradi
                 return new AchTransferForm(paymentAccount, accountAgeWitnessService, inputValidator, root, gridRow, formatter);
             case PaymentMethod.DOMESTIC_WIRE_TRANSFER_ID:
                 return new DomesticWireTransferForm(paymentAccount, accountAgeWitnessService, inputValidator, root, gridRow, formatter);
+            case PaymentMethod.PAYPAL_ID:
+                return new PayPalForm(paymentAccount, accountAgeWitnessService, paypalValidator, inputValidator, root, gridRow, formatter);
+            case PaymentMethod.VENMO_ID:
+                return new VenmoForm(paymentAccount, accountAgeWitnessService, venmoValidator, inputValidator, root, gridRow, formatter);
+            case PaymentMethod.CASH_APP_ID:
+                return new CashAppForm(paymentAccount, accountAgeWitnessService, cashAppValidator, inputValidator, root, gridRow, formatter);
             default:
                 log.error("Not supported PaymentMethod: " + paymentMethod);
                 return null;
@@ -669,4 +688,3 @@ public class TraditionalAccountsView extends PaymentAccountsView<GridPane, Tradi
     }
 
 }
-

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -856,9 +856,9 @@ message PaymentAccountPayload {
         SwishAccountPayload swish_account_payload = 14;
         USPostalMoneyOrderAccountPayload u_s_postal_money_order_account_payload = 15;
         UpholdAccountPayload uphold_account_payload = 16;
-        CashAppAccountPayload cash_app_account_payload = 17 [deprecated = true];
+        CashAppAccountPayload cash_app_account_payload = 17;
         MoneyBeamAccountPayload money_beam_account_payload = 18;
-        VenmoAccountPayload venmo_account_payload = 19 [deprecated = true];
+        VenmoAccountPayload venmo_account_payload = 19;
         PopmoneyAccountPayload popmoney_account_payload = 20;
         RevolutAccountPayload revolut_account_payload = 21;
         WeChatPayAccountPayload we_chat_pay_account_payload = 22;
@@ -880,6 +880,7 @@ message PaymentAccountPayload {
         MoneseAccountPayload monese_account_payload = 38;
         VerseAccountPayload verse_account_payload = 39;
         CashAtAtmAccountPayload cash_at_atm_account_payload = 40;
+        PayPalAccountPayload paypal_account_payload = 41;
     }
 }
 
@@ -1057,19 +1058,19 @@ message UpholdAccountPayload {
     string account_owner = 2;
 }
 
-// Deprecated, not used anymore
 message CashAppAccountPayload {
-    string cash_tag = 1;
+    string email_or_mobile_nr_or_cashtag = 1;
 }
 
 message MoneyBeamAccountPayload {
     string account_id = 1;
 }
 
-// Deprecated, not used anymore
 message VenmoAccountPayload {
-    string venmo_user_name = 1;
-    string holder_name = 2;
+    string name_or_username_or_email_or_mobile_nr = 1;
+}
+message PayPalAccountPayload {
+    string name_or_username_or_email_or_mobile_nr = 1;
 }
 
 message PopmoneyAccountPayload {
@@ -1331,8 +1332,8 @@ message XmrAddressEntry {
         TRADE_PAYOUT = 5;
     }
 
-	int32 subaddress_index = 7;
-	string address_string = 8;
+        int32 subaddress_index = 7;
+        string address_string = 8;
     string offer_id = 9;
     Context context = 10;
     int64 coin_locked_in_multi_sig = 11;
@@ -1543,7 +1544,7 @@ message SellerAsTakerTrade {
 }
 
 message ArbitratorTrade {
-	Trade trade = 1;
+        Trade trade = 1;
 }
 
 message ProcessModel {
@@ -1935,6 +1936,8 @@ message PaymentAccountFormField {
         STATE = 55;
         TRADE_CURRENCIES = 56;
         USER_NAME = 57;
+        NAME_OR_USERNAME_OR_EMAIL_OR_MOBILE_NR = 58;
+        EMAIL_OR_MOBILE_NR_OR_CASHTAG = 59;
     }
     enum Component {
         TEXT = 0;


### PR DESCRIPTION
This PR addresses #948 and #685 by adding PayPal and CashApp as payment methods to Haveno. Venmo is also added, as it had some pre-existing code alongside CashApp from Bisq.