### PR TITLE
enable proof of work dos protection in torrc

### DIFF
--- a/relay/torrc
+++ b/relay/torrc
@@ -1,2 +1,3 @@
 HiddenServiceDir build/tor-hidden-service
 HiddenServicePort 80 127.0.0.1:8080
+HiddenServicePoWDefensesEnabled 1


### PR DESCRIPTION
This PR addresses #1000 by enabling PoW DOS protection in torrc, as described [here](https://community.torproject.org/onion-services/ecosystem/technology/pow/#configuring-an-onion-service-with-the-pow-protection).