### PR TITLE
Unselect payment method currencies by default #1021

### DIFF
--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -297,6 +297,7 @@ public abstract class PaymentMethodForm {
         checkBox.setMinWidth(60);
         checkBox.setMaxWidth(checkBox.getMinWidth());
         checkBox.setTooltip(new Tooltip(e.getName()));
+        checkBox.setSelected(false);
         checkBox.setOnAction(event -> {
             if (checkBox.isSelected())
                 paymentAccount.addCurrency(e);


### PR DESCRIPTION
#1021

This fixes the issue where all of the currencies are checked by default.
Compiled and verified on 1.0.7

Do we really want add in an additional area to enter trade details like OP is requesting?