### PR TITLE
Add an additional "details" text area for PayPal

### DIFF
--- a/core/src/main/java/haveno/core/payment/PayPalAccount.java
+++ b/core/src/main/java/haveno/core/payment/PayPalAccount.java
@@ -84,6 +84,10 @@ public final class PayPalAccount extends PaymentAccount {
         return INPUT_FIELD_IDS;
     }
 
+    public void setDetails(String details) {
+        ((PayPalAccountPayload) paymentAccountPayload).setDetails(details);
+    }
+
     public void setEmailOrMobileNrOrUsername(String emailOrMobileNrOrUsername) {
         ((PayPalAccountPayload) paymentAccountPayload)
                 .setEmailOrMobileNrOrUsername(emailOrMobileNrOrUsername);

--- a/core/src/main/java/haveno/core/payment/payload/PayPalAccountPayload.java
+++ b/core/src/main/java/haveno/core/payment/payload/PayPalAccountPayload.java
@@ -36,6 +36,7 @@ import java.util.Map;
 @Slf4j
 public final class PayPalAccountPayload extends PaymentAccountPayload {
     private String emailOrMobileNrOrUsername = "";
+    private String details = "";
 
     public PayPalAccountPayload(String paymentMethod, String id) {
         super(paymentMethod, id);
@@ -48,6 +49,7 @@ public final class PayPalAccountPayload extends PaymentAccountPayload {
     private PayPalAccountPayload(String paymentMethod,
             String id,
             String emailOrMobileNrOrUsername,
+            String details,
             long maxTradePeriod,
             Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
@@ -56,12 +58,14 @@ public final class PayPalAccountPayload extends PaymentAccountPayload {
                 excludeFromJsonDataMap);
 
         this.emailOrMobileNrOrUsername = emailOrMobileNrOrUsername;
+        this.details = details;
     }
 
     @Override
     public Message toProtoMessage() {
         return getPaymentAccountPayloadBuilder()
                 .setPaypalAccountPayload(protobuf.PayPalAccountPayload.newBuilder()
+                        .setDetails(details)
                         .setEmailOrMobileNrOrUsername(emailOrMobileNrOrUsername))
                 .build();
     }
@@ -70,6 +74,7 @@ public final class PayPalAccountPayload extends PaymentAccountPayload {
         return new PayPalAccountPayload(proto.getPaymentMethodId(),
                 proto.getId(),
                 proto.getPaypalAccountPayload().getEmailOrMobileNrOrUsername(),
+                proto.getPaypalAccountPayload().getDetails(),
                 proto.getMaxTradePeriod(),
                 new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
@@ -81,7 +86,9 @@ public final class PayPalAccountPayload extends PaymentAccountPayload {
     @Override
     public String getPaymentDetails() {
         return Res.getWithCol("payment.email.mobile.username") + " "
-                + emailOrMobileNrOrUsername;
+                + emailOrMobileNrOrUsername
+                + Res.getWithCol("shared.details") + " "
+                + details;
     }
 
     @Override

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
@@ -29,17 +29,17 @@ import haveno.core.util.validation.InputValidator;
 import haveno.desktop.components.InputTextField;
 import haveno.desktop.util.FormBuilder;
 import haveno.desktop.util.Layout;
+import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
 
-import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
-import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
-import static haveno.desktop.util.FormBuilder.addTopLabelFlowPane;
+import static haveno.desktop.util.FormBuilder.*;
 
 public class PayPalForm extends PaymentMethodForm {
     private final PayPalAccount paypalAccount;
     private final EmailOrMobileNrOrUsernameValidator paypalValidator;
+    private TextArea sharedDetailsTextArea;
 
     public static int addFormForBuyer(GridPane gridPane, int gridRow, PaymentAccountPayload paymentAccountPayload) {
         addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.email.mobile.username"), ((PayPalAccountPayload) paymentAccountPayload).getEmailOrMobileNrOrUsername());
@@ -66,6 +66,15 @@ public class PayPalForm extends PaymentMethodForm {
             paypalAccount.setEmailOrMobileNrOrUsername(newValue.trim());
             updateFromInputs();
         });
+
+        sharedDetailsTextArea = addTopLabelTextArea(gridPane, ++gridRow,
+                Res.get("shared.details"), "").second;
+        sharedDetailsTextArea.setMinHeight(70);
+        sharedDetailsTextArea.textProperty().addListener((ov, oldValue, newValue) -> {
+            paypalAccount.setDetails(newValue);
+            updateFromInputs();
+        });
+
         addCurrenciesGrid(true);
         addLimitations(false);
         addAccountNameTextFieldWithAutoFillToggleButton();
@@ -99,6 +108,15 @@ public class PayPalForm extends PaymentMethodForm {
         TextField field = addCompactTopLabelTextField(gridPane, ++gridRow,
                 Res.get("payment.email.mobile.username"),
                 paypalAccount.getEmailOrMobileNrOrUsername()).second;
+
+        sharedDetailsTextArea = addTopLabelTextArea(gridPane, ++gridRow,
+                Res.get("shared.details"), "").second;
+        sharedDetailsTextArea.setMinHeight(70);
+        sharedDetailsTextArea.textProperty().addListener((ov, oldValue, newValue) -> {
+            paypalAccount.setDetails(newValue);
+            updateFromInputs();
+        });
+
         field.setMouseTransparent(false);
         addLimitations(true);
         addCurrenciesGrid(false);
@@ -108,6 +126,6 @@ public class PayPalForm extends PaymentMethodForm {
     public void updateAllInputsValid() {
         allInputsValid.set(isAccountNameValid()
                 && paypalValidator.validate(paypalAccount.getEmailOrMobileNrOrUsername()).isValid
-                && paypalAccount.getTradeCurrencies().size() > 0);
+                && !paypalAccount.getTradeCurrencies().isEmpty());
     }
 }

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
@@ -34,7 +34,12 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
 
-import static haveno.desktop.util.FormBuilder.*;
+
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
+import static haveno.desktop.util.FormBuilder.addTopLabelFlowPane;
+import static haveno.desktop.util.FormBuilder.addTopLabelTextArea;
+
 
 public class PayPalForm extends PaymentMethodForm {
     private final PayPalAccount paypalAccount;

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
@@ -113,6 +113,7 @@ public class PayPalForm extends PaymentMethodForm {
         TextField field = addCompactTopLabelTextField(gridPane, ++gridRow,
                 Res.get("payment.email.mobile.username"),
                 paypalAccount.getEmailOrMobileNrOrUsername()).second;
+        field.setMouseTransparent(false);
 
         sharedDetailsTextArea = addTopLabelTextArea(gridPane, ++gridRow,
                 Res.get("shared.details"), "").second;
@@ -121,8 +122,7 @@ public class PayPalForm extends PaymentMethodForm {
             paypalAccount.setDetails(newValue);
             updateFromInputs();
         });
-
-        field.setMouseTransparent(false);
+        
         addLimitations(true);
         addCurrenciesGrid(false);
     }

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1072,6 +1072,7 @@ message VenmoAccountPayload {
 }
 message PayPalAccountPayload {
     string email_or_mobile_nr_or_username = 1;
+    string details = 2;
 }
 
 message PopmoneyAccountPayload {


### PR DESCRIPTION
#1021 

This is only for Paypal accounts only. Probably need to do it for CashApp accounts as well.

Tested and verified on 1.0.7