### PR TITLE
Follow-up for https://github.com/haveno-dex/haveno/pull/1030

### DIFF
--- a/core/src/main/java/haveno/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/haveno/core/locale/CurrencyUtil.java
@@ -150,6 +150,12 @@ public class CurrencyUtil {
         list.add(new TraditionalCurrency("RUB"));
         list.add(new TraditionalCurrency("INR"));
         list.add(new TraditionalCurrency("NGN"));
+        list.add(new TraditionalCurrency("CNY"));
+        list.add(new TraditionalCurrency("JPY"));
+        list.add(new TraditionalCurrency("BRL"));
+        list.add(new TraditionalCurrency("THB"));
+        list.add(new TraditionalCurrency("SEK"));
+        list.add(new TraditionalCurrency("DKK"));
         postProcessTraditionalCurrenciesList(list);
         return list;
     }
@@ -271,7 +277,7 @@ public class CurrencyUtil {
 
     public static boolean isPricePrecise(String currencyCode) {
         return isCryptoCurrency(currencyCode) ||
-            "XAU".equals(currencyCode.toUpperCase()) || 
+            "XAU".equals(currencyCode.toUpperCase()) ||
             "XAG".equals(currencyCode.toUpperCase());
     }
 

--- a/core/src/main/java/haveno/core/locale/TradeCurrency.java
+++ b/core/src/main/java/haveno/core/locale/TradeCurrency.java
@@ -21,6 +21,7 @@ import haveno.common.proto.ProtobufferRuntimeException;
 import haveno.common.proto.persistable.PersistablePayload;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -33,10 +34,21 @@ public abstract class TradeCurrency implements PersistablePayload, Comparable<Tr
     protected final String code;
     @EqualsAndHashCode.Exclude
     protected final String name;
+    @EqualsAndHashCode.Exclude
+    @Getter
+    @Setter
+    protected Boolean selected;
+
+    public TradeCurrency(String code, String name, @NotNull Boolean selected) {
+        this.code = code;
+        this.name = name;
+        this.selected = selected;
+    }
 
     public TradeCurrency(String code, String name) {
         this.code = code;
         this.name = name;
+        this.selected = false;
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -57,7 +69,8 @@ public abstract class TradeCurrency implements PersistablePayload, Comparable<Tr
     public protobuf.TradeCurrency.Builder getTradeCurrencyBuilder() {
         return protobuf.TradeCurrency.newBuilder()
                 .setCode(code)
-                .setName(name);
+                .setName(name)
+                .setSelected(selected);
     }
 
 

--- a/core/src/main/java/haveno/core/locale/TraditionalCurrency.java
+++ b/core/src/main/java/haveno/core/locale/TraditionalCurrency.java
@@ -55,17 +55,29 @@ public final class TraditionalCurrency extends TradeCurrency {
         this(Currency.getInstance(currencyCode), getLocale());
     }
 
+    public TraditionalCurrency(String currencyCode, Boolean selected) {
+        this(Currency.getInstance(currencyCode), getLocale(), selected);
+    }
+
+    public TraditionalCurrency(String currencyCode, String name, Boolean selected) {
+        super(currencyCode, name, selected);
+    }
+
     public TraditionalCurrency(String currencyCode, String name) {
         super(currencyCode, name);
     }
 
     public TraditionalCurrency(TraditionalCurrency currency) {
-        this(currency.getCode(), currency.getName());
+        this(currency.getCode(), currency.getName(), currency.getSelected());
     }
 
     @SuppressWarnings("WeakerAccess")
     public TraditionalCurrency(Currency currency) {
         this(currency, getLocale());
+    }
+
+    public TraditionalCurrency(Currency currency, Locale locale, Boolean selected) {
+        super(currency.getCurrencyCode(), currency.getDisplayName(locale), selected);
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -83,12 +95,13 @@ public final class TraditionalCurrency extends TradeCurrency {
         return getTradeCurrencyBuilder()
                 .setCode(code)
                 .setName(name)
+                .setSelected(getSelected())
                 .setTraditionalCurrency(protobuf.TraditionalCurrency.newBuilder())
                 .build();
     }
 
     public static TraditionalCurrency fromProto(protobuf.TradeCurrency proto) {
-        return new TraditionalCurrency(proto.getCode(), proto.getName());
+        return new TraditionalCurrency(proto.getCode(), proto.getName(), proto.getSelected());
     }
 
 

--- a/core/src/main/java/haveno/core/payment/PaymentAccount.java
+++ b/core/src/main/java/haveno/core/payment/PaymentAccount.java
@@ -224,7 +224,7 @@ public abstract class PaymentAccount implements PersistablePayload {
     }
 
     public boolean hasMultipleCurrencies() {
-        return tradeCurrencies.size() > 1;
+        return getSelectedTradeCurrencies().size() > 1;
     }
 
     public void setSingleTradeCurrency(TradeCurrency tradeCurrency) {
@@ -235,7 +235,10 @@ public abstract class PaymentAccount implements PersistablePayload {
 
     @Nullable
     public TradeCurrency getSingleTradeCurrency() {
-        if (tradeCurrencies.size() == 1)
+        List<TradeCurrency> currencies = getSelectedTradeCurrencies();
+        if (currencies.size() == 1)
+            return currencies.get(0);
+        else if (tradeCurrencies.size() == 1)
             return tradeCurrencies.get(0);
         else
             return null;
@@ -275,6 +278,18 @@ public abstract class PaymentAccount implements PersistablePayload {
         return this.getPaymentMethod().getId().equals(paymentMethodId);
     }
 
+    public TradeCurrency getTradeCurrencyByCode(String code) {
+        return tradeCurrencies.stream()
+                .filter(o1 -> o1.getCode().equals(code))
+                .findFirst()
+                .orElse(null); // This should never be null.
+    }
+
+    private List<TradeCurrency> getSelectedTradeCurrencies() {
+        return tradeCurrencies.stream()
+                .filter(TradeCurrency::getSelected)
+                .toList();
+    }
     /**
      * Return an Optional of the trade currency for this payment account, or
      * Optional.empty() if none is found.  If this payment account has a selected
@@ -285,12 +300,13 @@ public abstract class PaymentAccount implements PersistablePayload {
      * @return Optional of the trade currency for the given payment account
      */
     public Optional<TradeCurrency> getTradeCurrency() {
+        List<TradeCurrency> currencies = getSelectedTradeCurrencies();
         if (this.getSelectedTradeCurrency() != null)
             return Optional.of(this.getSelectedTradeCurrency());
         else if (this.getSingleTradeCurrency() != null)
             return Optional.of(this.getSingleTradeCurrency());
         else if (!this.getTradeCurrencies().isEmpty())
-            return Optional.of(this.getTradeCurrencies().get(0));
+            return Optional.of(currencies.get(0));
         else
             return Optional.empty();
     }

--- a/core/src/main/java/haveno/core/user/Preferences.java
+++ b/core/src/main/java/haveno/core/user/Preferences.java
@@ -214,6 +214,27 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         setupPreferences();
     }
 
+    public void onSinglePaymentAccountCurrienciesSelected(TraditionalCurrency currency) {
+        prefPayload.setBuyScreenCurrencyCode(currency.getCode());
+        prefPayload.setSellScreenCurrencyCode(currency.getCode());
+        setPreferredTradeCurrency(currency);
+    }
+
+    public void onPaymentAccountCurrienciesSelected(List<TradeCurrency> currencies) {
+        List<TraditionalCurrency> availableCurrencies = currencies.stream()
+                .filter(o1 -> o1 instanceof TraditionalCurrency)
+                .map(o1 -> (TraditionalCurrency) o1)
+                .distinct()
+                .sorted((o1, o2) -> {   // Give priority to selected currencies.
+                    if (o1.getSelected() && !o2.getSelected()) return -1;
+                    else if (!o1.getSelected() && o2.getSelected()) return 1;
+                    else return 0;
+                })
+                .collect(Collectors.toList());
+        setTraditionalCurrencies(availableCurrencies);
+        onSinglePaymentAccountCurrienciesSelected(availableCurrencies.get(0));
+    }
+
     private void initNewPreferences() {
         prefPayload = new PreferencesPayload();
         prefPayload.setUserLanguage(GlobalSettings.getLocale().getLanguage());

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -293,11 +293,14 @@ public abstract class PaymentMethodForm {
                                       TradeCurrency e, PaymentAccount paymentAccount) {
         CheckBox checkBox = new AutoTooltipCheckBox(e.getCode());
         checkBox.setMouseTransparent(!isEditable);
-        checkBox.setSelected(paymentAccount.getTradeCurrencies().contains(e));
+        checkBox.setSelected(paymentAccount.getTradeCurrencies().contains(e)
+                && paymentAccount.getTradeCurrencyByCode(e.getCode()).getSelected());
         checkBox.setMinWidth(60);
         checkBox.setMaxWidth(checkBox.getMinWidth());
         checkBox.setTooltip(new Tooltip(e.getName()));
         checkBox.setOnAction(event -> {
+            e.setSelected(checkBox.isSelected());
+
             if (checkBox.isSelected())
                 paymentAccount.addCurrency(e);
             else

--- a/desktop/src/main/java/haveno/desktop/main/account/content/traditionalaccounts/TraditionalAccountsDataModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/account/content/traditionalaccounts/TraditionalAccountsDataModel.java
@@ -108,11 +108,14 @@ class TraditionalAccountsDataModel extends ActivatableDataModel {
         TradeCurrency singleTradeCurrency = paymentAccount.getSingleTradeCurrency();
         List<TradeCurrency> tradeCurrencies = paymentAccount.getTradeCurrencies();
         if (singleTradeCurrency != null) {
-            if (singleTradeCurrency instanceof TraditionalCurrency)
+            if (singleTradeCurrency instanceof TraditionalCurrency) {
                 preferences.addTraditionalCurrency((TraditionalCurrency) singleTradeCurrency);
+                preferences.onSinglePaymentAccountCurrienciesSelected((TraditionalCurrency) singleTradeCurrency);
+            }
             else
                 preferences.addCryptoCurrency((CryptoCurrency) singleTradeCurrency);
         } else if (tradeCurrencies != null && !tradeCurrencies.isEmpty()) {
+            singleTradeCurrency = tradeCurrencies.getFirst();
             if (tradeCurrencies.contains(CurrencyUtil.getDefaultTradeCurrency()))
                 paymentAccount.setSelectedTradeCurrency(CurrencyUtil.getDefaultTradeCurrency());
             else
@@ -124,6 +127,9 @@ class TraditionalAccountsDataModel extends ActivatableDataModel {
                 else
                     preferences.addCryptoCurrency((CryptoCurrency) tradeCurrency);
             });
+
+            if (singleTradeCurrency instanceof TraditionalCurrency) // Assuming Traditional and Crypto currencies are never mixed
+                preferences.onPaymentAccountCurrienciesSelected(tradeCurrencies);
         }
 
         user.addPaymentAccount(paymentAccount);

--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferDataModel.java
@@ -26,6 +26,7 @@ import haveno.common.util.Utilities;
 import haveno.core.account.witness.AccountAgeWitnessService;
 import haveno.core.locale.CurrencyUtil;
 import haveno.core.locale.TradeCurrency;
+import haveno.core.locale.TraditionalCurrency;
 import haveno.core.monetary.Price;
 import haveno.core.monetary.Volume;
 import haveno.core.offer.CreateOfferService;
@@ -303,6 +304,14 @@ public abstract class MutableOfferDataModel extends OfferDataModel {
     void onPaymentAccountSelected(PaymentAccount paymentAccount) {
         if (paymentAccount != null && !this.paymentAccount.equals(paymentAccount)) {
             preferences.setSelectedPaymentAccountForCreateOffer(paymentAccount);
+
+            TradeCurrency singleTradeCurrency = paymentAccount.getTradeCurrencies().getFirst();
+            if (singleTradeCurrency instanceof TraditionalCurrency) {
+                preferences.onPaymentAccountCurrienciesSelected(paymentAccount.getSupportedCurrencies());
+                user.requestPersistence();
+                paymentAccount.onPersistChanges();
+            }
+
             this.paymentAccount = paymentAccount;
 
             setTradeCurrencyFromPaymentAccount(paymentAccount);

--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferView.java
@@ -101,6 +101,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static haveno.desktop.main.offer.OfferViewUtil.addPayInfoEntry;
 import static haveno.desktop.util.FormBuilder.add2ButtonsAfterGroup;
@@ -499,7 +500,9 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             model.onCurrencySelected(model.getTradeCurrency());
 
             if (paymentAccount.hasMultipleCurrencies()) {
-                final List<TradeCurrency> tradeCurrencies = paymentAccount.getTradeCurrencies();
+                final List<TradeCurrency> tradeCurrencies = paymentAccount.getTradeCurrencies().stream()
+                    .filter(TradeCurrency::getSelected)
+                    .collect(Collectors.toList());
                 currencyComboBox.setItems(FXCollections.observableArrayList(tradeCurrencies));
                 currencyComboBox.getSelectionModel().select(model.getTradeCurrency());
             } else {

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/XmrOfferBookViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/XmrOfferBookViewModel.java
@@ -143,7 +143,10 @@ public class XmrOfferBookViewModel extends OfferBookViewModel {
         } else {
             return CurrencyUtil.getMainTraditionalCurrencies().stream().sorted((o1, o2) ->
                     Boolean.compare(!hasPaymentAccountForCurrency(o1),
-                            !hasPaymentAccountForCurrency(o2))).collect(Collectors.toList()).get(0);
+                            !hasPaymentAccountForCurrency(o2)))
+                    .filter(TradeCurrency::getSelected) // This assumes there will ALWAYS be a default "selected" currency
+                    .collect(Collectors.toList())
+                    .get(0);
         }
     }
 

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1807,9 +1807,10 @@ message Currency {
 message TradeCurrency {
     string code = 1;
     string name = 2;
+    bool selected = 3;
     oneof message {
-        CryptoCurrency crypto_currency = 3;
-        TraditionalCurrency traditional_currency = 4;
+        CryptoCurrency crypto_currency = 4;
+        TraditionalCurrency traditional_currency = 5;
     }
 }
 


### PR DESCRIPTION
This is an initial "follow-up" for https://github.com/haveno-dex/haveno/pull/1030.

I, very "sillily", thought this was a one-line code change but it turns out I was very foolish.

Anyhow, I ran many different kinds of test cases on this one for about 10 mins. That included:
1. Creating payment accounts.
2. Creating multiple payment accounts.
3. Making sure payments persisted selected currencies.
4. Making sure after "SELL" or "BUY" buttons are pressed, UI reflects selected currencies particularly for the drop-down box.  NOTE: There is one small bug where sometimes during the same session or after a restart, the selected currency for a multi-currency account when trying to create a "SELL" or "BUY" offer will be blank. In that case, all you need to do is select you desired currency and that change will persist until you add a new payment account or reboot (in some cases). But this is not a functional issue and does not effect the application in any meaningful way (although it would be nice to fix it)
5. Making sure everything is still configured correct after a restart.
6. Restarting multiple times with different payment accounts (new added / some deleted).
7. Deleting an existing payment account then recreating the same payment account but with different currencies.
8. Running through the above cases randomly.

The only thing I have not tested is whether this works on the stage net. From what I can tell, although some values are persisted it is only on the user side and does not effect any other users on the network.

Keep in mind that these changes only affect most of the Traditional Currency accounts. It does not effect Crypto Currency account no other non-standard accounts   Vecho "HISTSIZE=500" >> ~/.bashrc