### PR TITLE
Add an "extra_info" text area for PayPal

### DIFF
--- a/core/src/main/java/haveno/core/offer/Offer.java
+++ b/core/src/main/java/haveno/core/offer/Offer.java
@@ -410,6 +410,8 @@ public class Offer implements NetworkPayload, PersistablePayload {
             return getExtraDataMap().get(OfferPayload.PAY_BY_MAIL_EXTRA_INFO);
         else if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.AUSTRALIA_PAYID_EXTRA_INFO))
             return getExtraDataMap().get(OfferPayload.AUSTRALIA_PAYID_EXTRA_INFO);
+        else if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.PAYPAL_EXTRA_INFO))
+            return getExtraDataMap().get(OfferPayload.PAYPAL_EXTRA_INFO);
         else
             return "";
     }

--- a/core/src/main/java/haveno/core/offer/OfferPayload.java
+++ b/core/src/main/java/haveno/core/offer/OfferPayload.java
@@ -100,6 +100,7 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     public static final String F2F_EXTRA_INFO = "f2fExtraInfo";
     public static final String PAY_BY_MAIL_EXTRA_INFO = "payByMailExtraInfo";
     public static final String AUSTRALIA_PAYID_EXTRA_INFO = "australiaPayidExtraInfo";
+    public static final String PAYPAL_EXTRA_INFO = "paypalExtraInfo";
 
     // Comma separated list of ordinal of a haveno.common.app.Capability. E.g. ordinal of
     // Capability.SIGNED_ACCOUNT_AGE_WITNESS is 11 and Capability.MEDIATION is 12 so if we want to signal that maker

--- a/core/src/main/java/haveno/core/offer/OfferUtil.java
+++ b/core/src/main/java/haveno/core/offer/OfferUtil.java
@@ -40,6 +40,7 @@ import static haveno.core.offer.OfferPayload.CAPABILITIES;
 import static haveno.core.offer.OfferPayload.F2F_CITY;
 import static haveno.core.offer.OfferPayload.F2F_EXTRA_INFO;
 import static haveno.core.offer.OfferPayload.PAY_BY_MAIL_EXTRA_INFO;
+import static haveno.core.offer.OfferPayload.PAYPAL_EXTRA_INFO;
 import static haveno.core.offer.OfferPayload.REFERRAL_ID;
 import static haveno.core.offer.OfferPayload.XMR_AUTO_CONF;
 import static haveno.core.offer.OfferPayload.XMR_AUTO_CONF_ENABLED_VALUE;
@@ -47,6 +48,7 @@ import static haveno.core.offer.OfferPayload.XMR_AUTO_CONF_ENABLED_VALUE;
 import haveno.core.payment.AustraliaPayidAccount;
 import haveno.core.payment.F2FAccount;
 import haveno.core.payment.PayByMailAccount;
+import haveno.core.payment.PayPalAccount;
 import haveno.core.payment.PaymentAccount;
 import haveno.core.provider.price.MarketPrice;
 import haveno.core.provider.price.PriceFeedService;
@@ -198,6 +200,10 @@ public class OfferUtil {
 
         if (paymentAccount instanceof PayByMailAccount) {
             extraDataMap.put(PAY_BY_MAIL_EXTRA_INFO, ((PayByMailAccount) paymentAccount).getExtraInfo());
+        }
+
+        if (paymentAccount instanceof PayPalAccount) {
+            extraDataMap.put(PAYPAL_EXTRA_INFO, ((PayPalAccount) paymentAccount).getExtraInfo());
         }
 
         if (paymentAccount instanceof AustraliaPayidAccount) {

--- a/core/src/main/java/haveno/core/payment/PayPalAccount.java
+++ b/core/src/main/java/haveno/core/payment/PayPalAccount.java
@@ -62,6 +62,7 @@ public final class PayPalAccount extends PaymentAccount {
             PaymentAccountFormField.FieldId.EMAIL_OR_MOBILE_NR_OR_USERNAME,
             PaymentAccountFormField.FieldId.TRADE_CURRENCIES,
             PaymentAccountFormField.FieldId.ACCOUNT_NAME,
+            PaymentAccountFormField.FieldId.EXTRA_INFO,
             PaymentAccountFormField.FieldId.SALT);
 
     public PayPalAccount() {
@@ -91,5 +92,13 @@ public final class PayPalAccount extends PaymentAccount {
 
     public String getEmailOrMobileNrOrUsername() {
         return ((PayPalAccountPayload) paymentAccountPayload).getEmailOrMobileNrOrUsername();
+    }
+
+    public void setExtraInfo(String extraInfo) {
+        ((PayPalAccountPayload) paymentAccountPayload).setExtraInfo(extraInfo);
+    }
+
+    public String getExtraInfo() {
+        return ((PayPalAccountPayload) paymentAccountPayload).getExtraInfo();
     }
 }

--- a/core/src/main/java/haveno/core/payment/payload/PayPalAccountPayload.java
+++ b/core/src/main/java/haveno/core/payment/payload/PayPalAccountPayload.java
@@ -36,6 +36,7 @@ import java.util.Map;
 @Slf4j
 public final class PayPalAccountPayload extends PaymentAccountPayload {
     private String emailOrMobileNrOrUsername = "";
+    private String extraInfo = "";
 
     public PayPalAccountPayload(String paymentMethod, String id) {
         super(paymentMethod, id);
@@ -48,6 +49,7 @@ public final class PayPalAccountPayload extends PaymentAccountPayload {
     private PayPalAccountPayload(String paymentMethod,
             String id,
             String emailOrMobileNrOrUsername,
+            String extraInfo,
             long maxTradePeriod,
             Map<String, String> excludeFromJsonDataMap) {
         super(paymentMethod,
@@ -56,13 +58,15 @@ public final class PayPalAccountPayload extends PaymentAccountPayload {
                 excludeFromJsonDataMap);
 
         this.emailOrMobileNrOrUsername = emailOrMobileNrOrUsername;
+        this.extraInfo = extraInfo;
     }
 
     @Override
     public Message toProtoMessage() {
         return getPaymentAccountPayloadBuilder()
                 .setPaypalAccountPayload(protobuf.PayPalAccountPayload.newBuilder()
-                        .setEmailOrMobileNrOrUsername(emailOrMobileNrOrUsername))
+                .setExtraInfo(extraInfo)
+                .setEmailOrMobileNrOrUsername(emailOrMobileNrOrUsername))
                 .build();
     }
 
@@ -70,6 +74,7 @@ public final class PayPalAccountPayload extends PaymentAccountPayload {
         return new PayPalAccountPayload(proto.getPaymentMethodId(),
                 proto.getId(),
                 proto.getPaypalAccountPayload().getEmailOrMobileNrOrUsername(),
+                proto.getPaypalAccountPayload().getExtraInfo(),
                 proto.getMaxTradePeriod(),
                 new HashMap<>(proto.getExcludeFromJsonDataMap()));
     }
@@ -80,8 +85,8 @@ public final class PayPalAccountPayload extends PaymentAccountPayload {
 
     @Override
     public String getPaymentDetails() {
-        return Res.getWithCol("payment.email.mobile.username") + " "
-                + emailOrMobileNrOrUsername;
+        return Res.getWithCol("payment.email.mobile.username") + " "+ emailOrMobileNrOrUsername + "\n" +
+                Res.getWithCol("payment.shared.extraInfo") + " " + extraInfo+ "\n";
     }
 
     @Override

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PayPalForm.java
@@ -17,6 +17,7 @@
 
 package haveno.desktop.components.paymentmethods;
 
+import com.jfoenix.controls.JFXTextArea;
 import haveno.core.account.witness.AccountAgeWitnessService;
 import haveno.core.locale.Res;
 import haveno.core.payment.PayPalAccount;
@@ -29,13 +30,16 @@ import haveno.core.util.validation.InputValidator;
 import haveno.desktop.components.InputTextField;
 import haveno.desktop.util.FormBuilder;
 import haveno.desktop.util.Layout;
+import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.GridPane;
 
-import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
 import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextArea;
+import static haveno.desktop.util.FormBuilder.addTopLabelTextArea;
 import static haveno.desktop.util.FormBuilder.addTopLabelFlowPane;
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
 
 public class PayPalForm extends PaymentMethodForm {
     private final PayPalAccount paypalAccount;
@@ -43,6 +47,13 @@ public class PayPalForm extends PaymentMethodForm {
 
     public static int addFormForBuyer(GridPane gridPane, int gridRow, PaymentAccountPayload paymentAccountPayload) {
         addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.email.mobile.username"), ((PayPalAccountPayload) paymentAccountPayload).getEmailOrMobileNrOrUsername());
+
+        PayPalAccountPayload payId = (PayPalAccountPayload) paymentAccountPayload;
+        TextArea textExtraInfo = addCompactTopLabelTextArea(gridPane, gridRow, 1, Res.get("payment.shared.extraInfo"), "").second;
+        textExtraInfo.setMinHeight(70);
+        textExtraInfo.setEditable(false);
+        textExtraInfo.setText(payId.getExtraInfo());
+
         return gridRow;
     }
 
@@ -66,6 +77,16 @@ public class PayPalForm extends PaymentMethodForm {
             paypalAccount.setEmailOrMobileNrOrUsername(newValue.trim());
             updateFromInputs();
         });
+
+        TextArea extraTextArea = addTopLabelTextArea(gridPane, ++gridRow,
+                Res.get("payment.shared.optionalExtra"), Res.get("payment.shared.extraInfo.prompt")).second;
+        extraTextArea.setMinHeight(70);
+        ((JFXTextArea) extraTextArea).setLabelFloat(false);
+        extraTextArea.textProperty().addListener((ov, oldValue, newValue) -> {
+            paypalAccount.setExtraInfo(newValue);
+            updateFromInputs();
+        });
+
         addCurrenciesGrid(true);
         addLimitations(false);
         addAccountNameTextFieldWithAutoFillToggleButton();
@@ -99,6 +120,12 @@ public class PayPalForm extends PaymentMethodForm {
         TextField field = addCompactTopLabelTextField(gridPane, ++gridRow,
                 Res.get("payment.email.mobile.username"),
                 paypalAccount.getEmailOrMobileNrOrUsername()).second;
+
+        TextArea textAreaExtra = addCompactTopLabelTextArea(gridPane, ++gridRow, Res.get("payment.shared.extraInfo"), "").second;
+        textAreaExtra.setText(paypalAccount.getExtraInfo());
+        textAreaExtra.setMinHeight(70);
+        textAreaExtra.setEditable(false);
+
         field.setMouseTransparent(false);
         addLimitations(true);
         addCurrenciesGrid(false);

--- a/desktop/src/main/java/haveno/desktop/main/offer/takeoffer/TakeOfferView.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/takeoffer/TakeOfferView.java
@@ -158,7 +158,8 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
     private int gridRow = 0;
     private final HashMap<String, Boolean> paymentAccountWarningDisplayed = new HashMap<>();
     private boolean offerDetailsWindowDisplayed, zelleWarningDisplayed, fasterPaymentsWarningDisplayed,
-            takeOfferFromUnsignedAccountWarningDisplayed, payByMailWarningDisplayed, cashAtAtmWarningDisplayed, australiaPayidWarningDisplayed;
+            takeOfferFromUnsignedAccountWarningDisplayed, payByMailWarningDisplayed, cashAtAtmWarningDisplayed,
+            australiaPayidWarningDisplayed, paypalWarningDisplayed;
     private SimpleBooleanProperty errorPopupDisplayed;
     private ChangeListener<Boolean> amountFocusedListener, getShowWalletFundedNotificationListener;
 
@@ -268,6 +269,7 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         maybeShowPayByMailWarning(lastPaymentAccount, model.dataModel.getOffer());
         maybeShowCashAtAtmWarning(lastPaymentAccount, model.dataModel.getOffer());
         maybeShowAustraliaPayidWarning(lastPaymentAccount, model.dataModel.getOffer());
+        maybeShowPaypalWarning(lastPaymentAccount, model.dataModel.getOffer());
 
         if (!model.isRange()) {
             nextButton.setVisible(false);
@@ -1144,6 +1146,23 @@ public class TakeOfferView extends ActivatableViewAndModel<AnchorPane, TakeOffer
         if (paymentAccount.getPaymentMethod().getId().equals(PaymentMethod.AUSTRALIA_PAYID_ID) &&
                 !australiaPayidWarningDisplayed && !offer.getExtraInfo().isEmpty()) {
             australiaPayidWarningDisplayed = true;
+            UserThread.runAfter(() -> {
+                new GenericMessageWindow()
+                        .preamble(Res.get("payment.tradingRestrictions"))
+                        .instruction(offer.getExtraInfo())
+                        .actionButtonText(Res.get("shared.iConfirm"))
+                        .closeButtonText(Res.get("shared.close"))
+                        .width(Layout.INITIAL_WINDOW_WIDTH)
+                        .onClose(() -> close(false))
+                        .show();
+            }, 500, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void maybeShowPaypalWarning(PaymentAccount paymentAccount, Offer offer) {
+        if (paymentAccount.getPaymentMethod().getId().equals(PaymentMethod.PAYPAL_ID) &&
+                !paypalWarningDisplayed && !offer.getExtraInfo().isEmpty()) {
+            paypalWarningDisplayed = true;
             UserThread.runAfter(() -> {
                 new GenericMessageWindow()
                         .preamble(Res.get("payment.tradingRestrictions"))

--- a/desktop/src/main/java/haveno/desktop/main/overlays/windows/OfferDetailsWindow.java
+++ b/desktop/src/main/java/haveno/desktop/main/overlays/windows/OfferDetailsWindow.java
@@ -174,7 +174,10 @@ public class OfferDetailsWindow extends Overlay<OfferDetailsWindow> {
         List<String> acceptedCountryCodes = offer.getAcceptedCountryCodes();
         boolean showAcceptedCountryCodes = acceptedCountryCodes != null && !acceptedCountryCodes.isEmpty();
         boolean isF2F = offer.getPaymentMethod().equals(PaymentMethod.F2F);
-        boolean showExtraInfo = offer.getPaymentMethod().equals(PaymentMethod.F2F) || offer.getPaymentMethod().equals(PaymentMethod.PAY_BY_MAIL) || offer.getPaymentMethod().equals(PaymentMethod.AUSTRALIA_PAYID);
+        boolean showExtraInfo = offer.getPaymentMethod().equals(PaymentMethod.F2F) ||
+                offer.getPaymentMethod().equals(PaymentMethod.PAY_BY_MAIL) ||
+                offer.getPaymentMethod().equals(PaymentMethod.AUSTRALIA_PAYID)||
+                offer.getPaymentMethod().equals(PaymentMethod.PAYPAL_ID);
         if (!takeOfferHandlerOptional.isPresent())
             rows++;
         if (showAcceptedBanks)

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1072,6 +1072,7 @@ message VenmoAccountPayload {
 }
 message PayPalAccountPayload {
     string email_or_mobile_nr_or_username = 1;
+    string extra_info = 2;
 }
 
 message PopmoneyAccountPayload {


### PR DESCRIPTION
This pull request is a redo of #1032.

Overview:
- I ran a full end-to-end test to complete a new Paypal trade on testnet and verified everything working.
- I ran the test `Can validate payment account forms`

PASS  src/HavenoClient.test.ts (25.389 s)
  ✓ Can validate payment account forms (CI, sanity check) (2255 ms)
  ○ skipped Can get the version (CI)
  ○ skipped Can convert between XMR and atomic units (CI)
  ○ skipped Can manage an account (CI)
  ○ skipped Can manage Monero daemon connections (CI)
  ○ skipped Can start and stop a local Monero node (CI)
  ○ skipped Has a Monero wallet (CI)
  ○ skipped Can get balances (CI, sanity check)
  ○ skipped Can send and receive push notifications (CI, sanity check)
  ○ skipped Can get asset codes with prices and their payment methods (CI, sanity check)
  ○ skipped Can get market prices (CI, sanity check)
  ○ skipped Can get market depth (CI, sanity check)
  ○ skipped Can register as an arbitrator (CI)
  ○ skipped Can get offers (CI)
  ○ skipped Can get my offers (CI)
  ○ skipped Can get payment methods (CI)
  ○ skipped Can get payment accounts (CI)
  ○ skipped Can create fiat payment accounts (CI)
  ○ skipped Can create crypto payment accounts (CI)
  ○ skipped Can prepare for trading (CI)
  ○ skipped Can post and remove an offer (CI, sanity check)
  ○ skipped Can schedule offers with locked funds (CI)
  ○ skipped Can reserve exact amount needed for offer (CI)
  ○ skipped Cannot post offer exceeding trade limit (CI, sanity check)
  ○ skipped Can complete a trade within a range
  ○ skipped Can complete trades at the same time (CI, sanity check)
  ○ skipped Can complete all trade combinations (stress)
  ○ skipped Can go offline while completing a trade (CI, sanity check)
  ○ skipped Can resolve a dispute (CI)
  ○ skipped Can resolve disputes (CI)
  ○ skipped Can go offline while resolving a dispute (CI)
  ○ skipped Cannot make or take offer with insufficient unlocked funds (CI, sanity check)
  ○ skipped Invalidates offers when reserved funds are spent (CI)
  ○ skipped Can handle unexpected errors during trade initialization
  ○ skipped Selects arbitrators which are online, registered, and least used

Test Suites: 1 passed, 1 total
Tests:       34 skipped, 1 passed, 35 total
Snapshots:   0 total
Time:        25.86 s
Ran all test suites with tests matching "Can validate payment account forms".