### PR TITLE
Make offers filterable via offer ID or Node address

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -311,6 +311,9 @@ market.tabs.spreadCurrency=Offers by Currency
 market.tabs.spreadPayment=Offers by Payment Method
 market.tabs.trades=Trades
 
+# OfferBookView
+market.offerBook.filterPrompt=Offer ID, address...
+
 # OfferBookChartView
 market.offerBook.sellOffersHeaderLabel=Sell {0} to
 market.offerBook.buyOffersHeaderLabel=Buy {0} from

--- a/desktop/src/main/java/haveno/desktop/components/AutoTooltipTextField.java
+++ b/desktop/src/main/java/haveno/desktop/components/AutoTooltipTextField.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.desktop.components;
+
+import com.jfoenix.controls.JFXTextField;
+import com.jfoenix.skins.JFXTextFieldSkin;
+import javafx.scene.control.Skin;
+import javafx.scene.control.TextField;
+
+public class AutoTooltipTextField extends JFXTextField {
+
+    public AutoTooltipTextField() {
+        super();
+    }
+
+    public AutoTooltipTextField(String text) {
+        super(text);
+    }
+
+    @Override
+    protected Skin<?> createDefaultSkin() {
+        return new AutoTooltipTextFieldSkin(this);
+    }
+
+    private class AutoTooltipTextFieldSkin extends JFXTextFieldSkin {
+        public AutoTooltipTextFieldSkin(TextField textField) {
+            super(textField);
+        }
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookView.java
@@ -46,6 +46,7 @@ import haveno.desktop.components.AutoTooltipButton;
 import haveno.desktop.components.AutoTooltipLabel;
 import haveno.desktop.components.AutoTooltipSlideToggleButton;
 import haveno.desktop.components.AutoTooltipTableColumn;
+import haveno.desktop.components.AutoTooltipTextField;
 import haveno.desktop.components.AutocompleteComboBox;
 import haveno.desktop.components.ColoredDecimalPlacesWithZerosText;
 import haveno.desktop.components.HyperlinkWithIcon;
@@ -107,6 +108,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static haveno.desktop.util.FormBuilder.addTitledGroupBg;
+import static haveno.desktop.util.FormBuilder.addTopLabelAutoToolTipTextField;
 
 abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewModel> extends ActivatableViewAndModel<R, M> {
 
@@ -122,6 +124,7 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
     protected AutocompleteComboBox<TradeCurrency> currencyComboBox;
     private AutocompleteComboBox<PaymentMethod> paymentMethodComboBox;
     private AutoTooltipButton createOfferButton;
+    private AutoTooltipTextField filterInputField;
     private AutoTooltipSlideToggleButton matchingOffersToggle;
     private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> amountColumn;
     private AutoTooltipTableColumn<OfferBookListItem, OfferBookListItem> volumeColumn;
@@ -212,8 +215,13 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
 
         var createOfferButtonStack = new StackPane(createOfferButton, disabledCreateOfferButtonTooltip);
 
+        Tuple3<VBox, Label, AutoTooltipTextField> autoToolTipTextField = addTopLabelAutoToolTipTextField(Res.get("shared.filter"));
+        VBox filterBox = autoToolTipTextField.first;
+        filterInputField = autoToolTipTextField.third;
+        filterInputField.setPromptText(Res.get("market.offerBook.filterPrompt"));
+
         offerToolsBox.getChildren().addAll(currencyBoxTuple.first, paymentBoxTuple.first,
-                matchingOffersToggle, getSpacer(), createOfferButtonStack);
+                filterBox, matchingOffersToggle, getSpacer(), createOfferButtonStack);
 
         GridPane.setHgrow(offerToolsBox, Priority.ALWAYS);
         GridPane.setRowIndex(offerToolsBox, gridRow);
@@ -427,6 +435,10 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         nrOfOffersLabel.setText(Res.get("offerbook.nrOffers", model.getOfferList().size()));
 
         model.priceFeedService.updateCounterProperty().addListener(priceFeedUpdateCounterListener);
+
+        filterInputField.setOnKeyTyped(event -> {
+            model.onFilterKeyTyped(filterInputField.getText());
+        });
     }
 
     private void updatePaymentMethodComboBoxEditor() {

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -121,6 +121,7 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
     PaymentMethod selectedPaymentMethod = getShowAllEntryForPaymentMethod();
 
     boolean isTabSelected;
+    String filterText = "";
     final BooleanProperty showAllTradeCurrenciesProperty = new SimpleBooleanProperty(true);
     final BooleanProperty disableMatchToggle = new SimpleBooleanProperty();
     final IntegerProperty maxPlacesForAmount = new SimpleIntegerProperty();
@@ -267,6 +268,11 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
 
             saveSelectedCurrencyCodeInPreferences(direction, code);
         }
+    }
+
+    void onFilterKeyTyped(String filterText) {
+        this.filterText = filterText;
+        filterOffers();
     }
 
     abstract void saveSelectedCurrencyCodeInPreferences(OfferDirection direction, String code);
@@ -566,7 +572,17 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
         Predicate<OfferBookListItem> predicate = useOffersMatchingMyAccountsFilter ?
                 getCurrencyAndMethodPredicate(direction, selectedTradeCurrency).and(getOffersMatchingMyAccountsPredicate()) :
                 getCurrencyAndMethodPredicate(direction, selectedTradeCurrency);
-        filteredItems.setPredicate(predicate);
+
+        if (!filterText.isEmpty()) {
+            Predicate<OfferBookListItem> nextPredicate=offerBookListItem ->
+                    offerBookListItem.getOffer().getOfferPayload().getOwnerNodeAddress().getFullAddress().contains(filterText);
+            nextPredicate=nextPredicate.or(offerBookListItem ->
+                    offerBookListItem.getOffer().getId().contains(filterText));
+
+            filteredItems.setPredicate(predicate.and(nextPredicate));
+        } else {
+            filteredItems.setPredicate(predicate);
+        }
     }
 
     abstract Predicate<OfferBookListItem> getCurrencyAndMethodPredicate(OfferDirection direction,

--- a/desktop/src/main/java/haveno/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/haveno/desktop/util/FormBuilder.java
@@ -36,6 +36,7 @@ import haveno.desktop.components.AutoTooltipCheckBox;
 import haveno.desktop.components.AutoTooltipLabel;
 import haveno.desktop.components.AutoTooltipRadioButton;
 import haveno.desktop.components.AutoTooltipSlideToggleButton;
+import haveno.desktop.components.AutoTooltipTextField;
 import haveno.desktop.components.AutocompleteComboBox;
 import haveno.desktop.components.BalanceTextField;
 import haveno.desktop.components.BusyAnimation;
@@ -1261,6 +1262,20 @@ public class FormBuilder {
         vBox.getChildren().addAll(label, comboBox);
 
         return new Tuple3<>(vBox, label, comboBox);
+    }
+
+    public static Tuple3<VBox, Label, AutoTooltipTextField> addTopLabelAutoToolTipTextField(String title) {
+        return addTopLabelAutoToolTipTextField(title, 0);
+    }
+
+    public static Tuple3<VBox, Label, AutoTooltipTextField> addTopLabelAutoToolTipTextField(String title, int top) {
+        Label label = getTopLabel(title);
+        VBox vBox = getTopLabelVBox(top);
+
+        final AutoTooltipTextField textField = new AutoTooltipTextField();
+        vBox.getChildren().addAll(label, textField);
+
+        return new Tuple3<>(vBox, label, textField);
     }
 
     @NotNull


### PR DESCRIPTION
#1094 

![image](https://github.com/haveno-dex/haveno/assets/15681329/9815d7b0-7ded-465c-ba2d-0470f41a7715)


I tested it using custom search of ID or node address by itself and in addition to combining it with other filter criteria such as "Choose Currency" and "Choose payment method" and seems to work correctly.