### PR TITLE
Enable DoS defense at the intropoint level.

### DIFF
--- a/relay/torrc
+++ b/relay/torrc
@@ -1,3 +1,4 @@
 HiddenServiceDir build/tor-hidden-service
 HiddenServicePort 80 127.0.0.1:8080
 HiddenServicePoWDefensesEnabled 1
+HiddenServiceEnableIntroDoSDefense 1


### PR DESCRIPTION
The rate and burst parameter (see below) will be sent to the intro point which will then use them to apply rate limiting for introduction request to this service. The introduction point honors the directory consensus parameters except if this is specifically set by the service operator using this option. (Defaults:)
```
HiddenServiceEnableIntroDoSBurstPerSec 200
HiddenServiceEnableIntroDoSRatePerSec 25
```