### PR TITLE
Increase seed node connections to 30

### DIFF
--- a/scripts/deployment/haveno-seednode.service
+++ b/scripts/deployment/haveno-seednode.service
@@ -13,6 +13,7 @@ ExecStart=/bin/sh /home/haveno/haveno/haveno-seednode --baseCurrencyNetwork=XMR_
   --nodePort=2002\
   --appName=haveno-XMR_STAGENET_Seed_2002\
 #  --logLevel=trace\
+  --maxConnections=30\
   --xmrNode=http://[::1]:38088\
   --xmrNodeUsername=admin\
   --xmrNodePassword=password

--- a/scripts/deployment/haveno-seednode2.service
+++ b/scripts/deployment/haveno-seednode2.service
@@ -13,6 +13,7 @@ ExecStart=/bin/sh /home/haveno/haveno/haveno-seednode --baseCurrencyNetwork=XMR_
   --nodePort=3003\
   --appName=haveno-XMR_STAGENET_Seed_3003\
 #  --logLevel=trace\
+  --maxConnections=30\
   --xmrNode=http://[::1]:38088\
   --xmrNodeUsername=admin\
   --xmrNodePassword=password

--- a/seednode/haveno-seednode.service
+++ b/seednode/haveno-seednode.service
@@ -13,6 +13,7 @@ ExecStart=/bin/sh $PATH/haveno-seednode --baseCurrencyNetwork=XMR_STAGENET\
   --useDevPrivilegeKeys=false\
   --nodePort=2002\
   --appName=haveno-XMR_STAGENET_Seed_2002
+  --maxConnections=30\
   --xmrNode=[::1]:38088
 
 ExecStop=/bin/kill ${MAINPID}


### PR DESCRIPTION
this PR seeks to increase the maximum number of connections on a seed node to 30. I am currently running my node in this configuration and it is working fine. I normally see 20-25 connections in the logs.