### PR TITLE
Changes needed for external tor on seednodes

### DIFF
--- a/scripts/deployment/haveno-seednode.service
+++ b/scripts/deployment/haveno-seednode.service
@@ -10,6 +10,8 @@ SyslogIdentifier=Haveno-Seednode
 ExecStart=/bin/sh /home/haveno/haveno/haveno-seednode --baseCurrencyNetwork=XMR_STAGENET\
   --useLocalhostForP2P=false\
   --useDevPrivilegeKeys=false\
+# Uncomment the following line to use external tor
+#  --hiddenServiceAddress=example.onion:port\
   --nodePort=2002\
   --appName=haveno-XMR_STAGENET_Seed_2002\
 #  --logLevel=trace\

--- a/scripts/deployment/haveno-seednode2.service
+++ b/scripts/deployment/haveno-seednode2.service
@@ -13,7 +13,7 @@ ExecStart=/bin/sh /home/haveno/haveno/haveno-seednode --baseCurrencyNetwork=XMR_
 # Uncomment the following line to use external tor
 #  --hiddenServiceAddress=example.onion:port\
   --nodePort=2003\
-  --appName=haveno-XMR_STAGENET_Seed_3003\
+  --appName=haveno-XMR_STAGENET_Seed_2003\
 #  --logLevel=trace\
   --xmrNode=http://[::1]:38088\
   --xmrNodeUsername=admin\

--- a/scripts/deployment/haveno-seednode2.service
+++ b/scripts/deployment/haveno-seednode2.service
@@ -10,7 +10,9 @@ SyslogIdentifier=Haveno-Seednode2
 ExecStart=/bin/sh /home/haveno/haveno/haveno-seednode --baseCurrencyNetwork=XMR_STAGENET\
   --useLocalhostForP2P=false\
   --useDevPrivilegeKeys=false\
-  --nodePort=3003\
+# Uncomment the following line to use external tor
+#  --hiddenServiceAddress=example.onion:port\
+  --nodePort=2003\
   --appName=haveno-XMR_STAGENET_Seed_3003\
 #  --logLevel=trace\
   --xmrNode=http://[::1]:38088\

--- a/seednode/externalTorDirectBind3.patch
+++ b/seednode/externalTorDirectBind3.patch
@@ -1,0 +1,324 @@
+diff --git a/common/src/main/java/haveno/common/config/Config.java b/common/src/main/java/haveno/common/config/Config.java
+index 9147d535..71f5436e 100644
+--- a/common/src/main/java/haveno/common/config/Config.java
++++ b/common/src/main/java/haveno/common/config/Config.java
+@@ -77,6 +77,7 @@ public class Config {
+     public static final String SEED_NODES = "seedNodes";
+     public static final String BAN_LIST = "banList";
+     public static final String NODE_PORT = "nodePort";
++    public static final String HIDDEN_SERVICE_ADDRESS = "hiddenServiceAddress";
+     public static final String USE_LOCALHOST_FOR_P2P = "useLocalhostForP2P";
+     public static final String MAX_CONNECTIONS = "maxConnections";
+     public static final String SOCKS_5_PROXY_XMR_ADDRESS = "socks5ProxyXmrAddress";
+@@ -151,6 +152,7 @@ public class Config {
+     public final File appDataDir;
+     public final int walletRpcBindPort;
+     public final int nodePort;
++    public final String  hiddenServiceAddress;
+     public final int maxMemory;
+     public final String logLevel;
+     public final List<String> bannedXmrNodes;
+@@ -286,6 +288,12 @@ public class Config {
+                         .ofType(Integer.class)
+                         .defaultsTo(9999);
+
++        ArgumentAcceptingOptionSpec<String> hiddenServiceAddressOpt =
++                parser.accepts(HIDDEN_SERVICE_ADDRESS, "Hidden Service Address to listen on")
++                        .withRequiredArg()
++                        .ofType(String.class)
++                        .defaultsTo("placeholder.onion");
++
+         ArgumentAcceptingOptionSpec<Integer> walletRpcBindPortOpt =
+                 parser.accepts(WALLET_RPC_BIND_PORT, "Port to bind the wallet RPC on")
+                         .withRequiredArg()
+@@ -670,6 +678,7 @@ public class Config {
+             this.helpRequested = options.has(helpOpt);
+             this.configFile = configFile;
+             this.nodePort = options.valueOf(nodePortOpt);
++            this.hiddenServiceAddress = options.valueOf(hiddenServiceAddressOpt);
+             this.walletRpcBindPort = options.valueOf(walletRpcBindPortOpt);
+             this.maxMemory = options.valueOf(maxMemoryOpt);
+             this.logLevel = options.valueOf(logLevelOpt);
+diff --git a/p2p/src/main/java/haveno/network/p2p/NetworkNodeProvider.java b/p2p/src/main/java/haveno/network/p2p/NetworkNodeProvider.java
+index 676db83f..a0548b6d 100644
+--- a/p2p/src/main/java/haveno/network/p2p/NetworkNodeProvider.java
++++ b/p2p/src/main/java/haveno/network/p2p/NetworkNodeProvider.java
+@@ -44,6 +44,7 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
+             @Named(Config.MAX_CONNECTIONS) int maxConnections,
+             @Named(Config.USE_LOCALHOST_FOR_P2P) boolean useLocalhostForP2P,
+             @Named(Config.NODE_PORT) int port,
++            @Named(Config.HIDDEN_SERVICE_ADDRESS) String hiddenServiceAddress,
+             @Named(Config.TOR_DIR) File torDir,
+             @Nullable @Named(Config.TORRC_FILE) File torrcFile,
+             @Named(Config.TORRC_OPTIONS) String torrcOptions,
+@@ -65,7 +66,7 @@ public class NetworkNodeProvider implements Provider<NetworkNode> {
+                     password,
+                     cookieFile,
+                     useSafeCookieAuthentication);
+-            networkNode = new TorNetworkNode(port, networkProtoResolver, streamIsolation, torMode, banFilter, maxConnections, controlHost);
++            networkNode = new TorNetworkNode(hiddenServiceAddress, port, networkProtoResolver, streamIsolation, torMode, banFilter, maxConnections, controlHost);
+         }
+     }
+
+diff --git a/p2p/src/main/java/haveno/network/p2p/P2PModule.java b/p2p/src/main/java/haveno/network/p2p/P2PModule.java
+index 50ce7d56..b13c2ccb 100644
+--- a/p2p/src/main/java/haveno/network/p2p/P2PModule.java
++++ b/p2p/src/main/java/haveno/network/p2p/P2PModule.java
+@@ -26,6 +26,7 @@ import haveno.common.config.Config;
+ import static haveno.common.config.Config.BAN_LIST;
+ import static haveno.common.config.Config.MAX_CONNECTIONS;
+ import static haveno.common.config.Config.NODE_PORT;
++import static haveno.common.config.Config.HIDDEN_SERVICE_ADDRESS;
+ import static haveno.common.config.Config.REPUBLISH_MAILBOX_ENTRIES;
+ import static haveno.common.config.Config.SOCKS_5_PROXY_HTTP_ADDRESS;
+ import static haveno.common.config.Config.SOCKS_5_PROXY_XMR_ADDRESS;
+@@ -87,6 +88,7 @@ public class P2PModule extends AppModule {
+         bind(File.class).annotatedWith(named(TOR_DIR)).toInstance(config.torDir);
+
+         bind(int.class).annotatedWith(named(NODE_PORT)).toInstance(config.nodePort);
++        bind(String.class).annotatedWith(named(HIDDEN_SERVICE_ADDRESS)).toInstance(config.hiddenServiceAddress);
+
+         bindConstant().annotatedWith(named(MAX_CONNECTIONS)).to(config.maxConnections);
+
+diff --git a/p2p/src/main/java/haveno/network/p2p/network/TorNetworkNode.java b/p2p/src/main/java/haveno/network/p2p/network/TorNetworkNode.java
+index 58842ed1..5d4b2703 100644
+--- a/p2p/src/main/java/haveno/network/p2p/network/TorNetworkNode.java
++++ b/p2p/src/main/java/haveno/network/p2p/network/TorNetworkNode.java
+@@ -17,28 +17,23 @@
+
+ package haveno.network.p2p.network;
+
++import haveno.common.util.Hex;
+ import haveno.network.p2p.NodeAddress;
+-import haveno.network.utils.Utils;
+
+ import haveno.common.Timer;
+ import haveno.common.UserThread;
+ import haveno.common.proto.network.NetworkProtoResolver;
+ import haveno.common.util.SingleThreadExecutorUtils;
+
+-import org.berndpruenster.netlayer.tor.HiddenServiceSocket;
+-import org.berndpruenster.netlayer.tor.Tor;
+-import org.berndpruenster.netlayer.tor.TorCtlException;
+-import org.berndpruenster.netlayer.tor.TorSocket;
+-
+ import com.runjva.sourceforge.jsocks.protocol.Socks5Proxy;
+
+-import java.security.SecureRandom;
+-
+ import java.net.Socket;
++import java.net.InetAddress;
++import java.net.ServerSocket;
+
+ import java.io.IOException;
+
+-import java.util.Base64;
++import java.nio.charset.StandardCharsets;
+ import java.util.concurrent.ExecutorService;
+
+ import lombok.extern.slf4j.Slf4j;
+@@ -52,13 +47,11 @@ public class TorNetworkNode extends NetworkNode {
+     private static final long SHUT_DOWN_TIMEOUT = 2;
+
+     private final String torControlHost;
++    private final String serviceAddress;
+
+-    private HiddenServiceSocket hiddenServiceSocket;
+     private Timer shutDownTimeoutTimer;
+-    private Tor tor;
+     private TorMode torMode;
+     private boolean streamIsolation;
+-    private Socks5Proxy socksProxy;
+     private boolean shutDownInProgress;
+     private boolean shutDownComplete;
+     private final ExecutorService executor;
+@@ -67,13 +60,14 @@ public class TorNetworkNode extends NetworkNode {
+     // Constructor
+     ///////////////////////////////////////////////////////////////////////////////////////////
+
+-    public TorNetworkNode(int servicePort,
++    public TorNetworkNode(String hiddenServiceAddress, int servicePort,
+             NetworkProtoResolver networkProtoResolver,
+             boolean useStreamIsolation,
+             TorMode torMode,
+             @Nullable BanFilter banFilter,
+             int maxConnections, String torControlHost) {
+         super(servicePort, networkProtoResolver, banFilter, maxConnections);
++        this.serviceAddress = hiddenServiceAddress;
+         this.torMode = torMode;
+         this.streamIsolation = useStreamIsolation;
+         this.torControlHost = torControlHost;
+@@ -92,33 +86,50 @@ public class TorNetworkNode extends NetworkNode {
+         if (setupListener != null)
+             addSetupListener(setupListener);
+
+-        createTorAndHiddenService(Utils.findFreeSystemPort(), servicePort);
++        createTorAndHiddenService(servicePort);
+     }
+
+     @Override
+     protected Socket createSocket(NodeAddress peerNodeAddress) throws IOException {
+-        checkArgument(peerNodeAddress.getHostName().endsWith(".onion"), "PeerAddress is not an onion address");
+-        // If streamId is null stream isolation gets deactivated.
+-        // Hidden services use stream isolation by default, so we pass null.
+-        return new TorSocket(peerNodeAddress.getHostName(), peerNodeAddress.getPort(), torControlHost, null);
++        // https://www.ietf.org/rfc1928.txt SOCKS5 Protocol
++        try {
++            checkArgument(peerNodeAddress.getHostName().endsWith(".onion"), "PeerAddress is not an onion address");
++            Socket sock = new Socket(InetAddress.getLoopbackAddress(), 9050);
++            sock.getOutputStream().write(Hex.decode("050100"));
++            String response = Hex.encode(sock.getInputStream().readNBytes(2));
++            if (!response.equalsIgnoreCase("0500")) {
++                return null;
++            }
++            String connect_details = "050100033E" + Hex.encode(peerNodeAddress.getHostName().getBytes(StandardCharsets.UTF_8));
++            StringBuilder connect_port = new StringBuilder(Integer.toHexString(peerNodeAddress.getPort()));
++            while (connect_port.length() < 4) connect_port.insert(0, "0");
++            connect_details = connect_details + connect_port;
++            sock.getOutputStream().write(Hex.decode(connect_details));
++            response = Hex.encode(sock.getInputStream().readNBytes(10));
++            if (response.substring(0, 2).equalsIgnoreCase("05") && response.substring(2, 4).equalsIgnoreCase("00")) {
++                return sock;    // success
++            }
++            if (response.substring(2, 4).equalsIgnoreCase("04")) {
++                log.warn("Host unreachable: {}", peerNodeAddress);
++            } else {
++                log.warn("SOCKS error code received {} expected 00", response.substring(2, 4));
++            }
++            if (!response.substring(0, 2).equalsIgnoreCase("05")) {
++                log.warn("unexpected response, this isn't a SOCKS5 proxy?: {} {}", response, response.substring(0, 2));
++            }
++        } catch (Exception e) {
++            log.warn(e.toString());
++        }
++        throw new IOException("createSocket failed");
+     }
+
+     public Socks5Proxy getSocksProxy() {
+         try {
+-            String stream = null;
+-            if (streamIsolation) {
+-                byte[] bytes = new byte[512]; // tor.getProxy creates a Sha256 hash
+-                new SecureRandom().nextBytes(bytes);
+-                stream = Base64.getEncoder().encodeToString(bytes);
+-            }
+-
+-            if (socksProxy == null || streamIsolation) {
+-                tor = Tor.getDefault();
+-                socksProxy = tor != null ? tor.getProxy(torControlHost, stream) : null;
+-            }
+-            return socksProxy;
+-        } catch (Throwable t) {
+-            log.error("Error at getSocksProxy", t);
++            Socks5Proxy prox = new Socks5Proxy(InetAddress.getLoopbackAddress(), 9050);
++            prox.resolveAddrLocally(false);
++            return prox;
++        } catch (Exception e) {
++            log.warn(e.toString());
+             return null;
+         }
+     }
+@@ -145,12 +156,6 @@ public class TorNetworkNode extends NetworkNode {
+
+         super.shutDown(() -> {
+             try {
+-                tor = Tor.getDefault();
+-                if (tor != null) {
+-                    tor.shutdown();
+-                    tor = null;
+-                    log.info("Tor shutdown completed");
+-                }
+                 executor.shutdownNow();
+             } catch (Throwable e) {
+                 log.error("Shutdown torNetworkNode failed with exception", e);
+@@ -166,36 +171,23 @@ public class TorNetworkNode extends NetworkNode {
+     // Create tor and hidden service
+     ///////////////////////////////////////////////////////////////////////////////////////////
+
+-    private void createTorAndHiddenService(int localPort, int servicePort) {
++    private void createTorAndHiddenService(int servicePort) {
+         executor.submit(() -> {
+             try {
+-                Tor.setDefault(torMode.getTor());
+-                long ts = System.currentTimeMillis();
+-                hiddenServiceSocket = new HiddenServiceSocket(localPort, torMode.getHiddenServiceDirectory(), servicePort);
+-                nodeAddressProperty.set(new NodeAddress(hiddenServiceSocket.getServiceName() + ":" + hiddenServiceSocket.getHiddenServicePort()));
++                // listener for incoming messages at the hidden service
++                ServerSocket socket = new ServerSocket(servicePort);
++                nodeAddressProperty.set(new NodeAddress(serviceAddress + ":" + servicePort));
++                log.info("\n################################################################\n" +
++                                "Tor hidden service published: {} Port: {}\n" +
++                                "################################################################",
++                        serviceAddress, servicePort);
+                 UserThread.execute(() -> setupListeners.forEach(SetupListener::onTorNodeReady));
+-                hiddenServiceSocket.addReadyListener(socket -> {
+-                    log.info("\n################################################################\n" +
+-                            "Tor hidden service published after {} ms. Socket={}\n" +
+-                            "################################################################",
+-                            System.currentTimeMillis() - ts, socket);
+-                    UserThread.execute(() -> {
+-                        nodeAddressProperty.set(new NodeAddress(hiddenServiceSocket.getServiceName() + ":"
+-                                + hiddenServiceSocket.getHiddenServicePort()));
+-                        startServer(socket);
+-                        setupListeners.forEach(SetupListener::onHiddenServicePublished);
+-                    });
+-                    return null;
+-                });
+-            } catch (TorCtlException e) {
+-                log.error("Starting tor node failed", e);
+-                if (e.getCause() instanceof IOException) {
+-                    UserThread.execute(() -> setupListeners.forEach(s -> s.onSetupFailed(new RuntimeException(e.getMessage()))));
+-                } else {
+-                    UserThread.execute(() -> setupListeners.forEach(SetupListener::onRequestCustomBridges));
+-                    log.warn("We shutdown as starting tor with the default bridges failed. We request user to add custom bridges.");
+-                    shutDown(null);
+-                }
++                UserThread.runAfter(() -> {
++                    nodeAddressProperty.set(new NodeAddress(serviceAddress + ":" + servicePort));
++                    startServer(socket);
++                    setupListeners.forEach(SetupListener::onHiddenServicePublished);
++                }, 3);
++                return null;
+             } catch (IOException e) {
+                 log.error("Could not connect to running Tor", e);
+                 UserThread.execute(() -> setupListeners.forEach(s -> s.onSetupFailed(new RuntimeException(e.getMessage()))));
+diff --git a/p2p/src/test/java/haveno/network/p2p/network/TorNetworkNodeTest.java b/p2p/src/test/java/haveno/network/p2p/network/TorNetworkNodeTest.java
+index f74a9d34..fda93464 100644
+--- a/p2p/src/test/java/haveno/network/p2p/network/TorNetworkNodeTest.java
++++ b/p2p/src/test/java/haveno/network/p2p/network/TorNetworkNodeTest.java
+@@ -50,7 +50,7 @@ public class TorNetworkNodeTest {
+     public void testTorNodeBeforeSecondReady() throws InterruptedException, IOException {
+         latch = new CountDownLatch(1);
+         int port = 9001;
+-        TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(), false,
++        TorNetworkNode node1 = new TorNetworkNode("serviceAddress", port, TestUtils.getNetworkProtoResolver(), false,
+                 new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null, 12, "127.0.0.1");
+         node1.start(new SetupListener() {
+             @Override
+@@ -77,7 +77,7 @@ public class TorNetworkNodeTest {
+
+         latch = new CountDownLatch(1);
+         int port2 = 9002;
+-        TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(), false,
++        TorNetworkNode node2 = new TorNetworkNode("serviceAddress", port2, TestUtils.getNetworkProtoResolver(), false,
+                 new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null, 12, "127.0.0.1");
+         node2.start(new SetupListener() {
+             @Override
+@@ -135,7 +135,7 @@ public class TorNetworkNodeTest {
+     public void testTorNodeAfterBothReady() throws InterruptedException, IOException {
+         latch = new CountDownLatch(2);
+         int port = 9001;
+-        TorNetworkNode node1 = new TorNetworkNode(port, TestUtils.getNetworkProtoResolver(), false,
++        TorNetworkNode node1 = new TorNetworkNode("serviceAddress", port, TestUtils.getNetworkProtoResolver(), false,
+                 new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null, 12, "127.0.0.1");
+         node1.start(new SetupListener() {
+             @Override
+@@ -161,7 +161,7 @@ public class TorNetworkNodeTest {
+         });
+
+         int port2 = 9002;
+-        TorNetworkNode node2 = new TorNetworkNode(port2, TestUtils.getNetworkProtoResolver(), false,
++        TorNetworkNode node2 = new TorNetworkNode("serviceAddress", port2, TestUtils.getNetworkProtoResolver(), false,
+                 new NewTor(new File("torNode_" + port), null, "", this::getBridgeAddresses), null, 12, "127.0.0.1");
+         node2.start(new SetupListener() {
+             @Override

--- a/seednode/haveno-seednode.service
+++ b/seednode/haveno-seednode.service
@@ -11,6 +11,8 @@ SyslogIdentifier=Haveno-Seednode
 ExecStart=/bin/sh $PATH/haveno-seednode --baseCurrencyNetwork=XMR_STAGENET\
   --useLocalhostForP2P=false\
   --useDevPrivilegeKeys=false\
+# Uncomment the following line to use external tor
+#  --hiddenServiceAddress=example.onion:port\
   --nodePort=2002\
   --appName=haveno-XMR_STAGENET_Seed_2002
   --xmrNode=http://[::1]:38088

--- a/seednode/torrc
+++ b/seednode/torrc
@@ -1,18 +1,144 @@
-RunAsDaemon 1
-SOCKSPort 9050
-ControlPort 9051
-Log notice syslog
+## Configuration file for Haveno Seednode
+##
+## To start/reload/etc this instance, run "systemctl start tor" (or reload, or..).
+## This instance will run as user debian-tor; its data directory is /var/lib/tor.
+##
+## This file is configured via:
+## /usr/share/tor/tor-service-defaults-torrc
+##
+## See 'man tor', for more options you can use in this file.
 
-CookieAuthentication 0
-CookieAuthFileGroupReadable 1
-DataDirectoryGroupReadable 1
+## Tor opens a socks proxy on port 9050 by default -- even if you don't
+## configure one below. Set "SocksPort 0" if you plan to run Tor only
+## as a relay, and not make any local application connections yourself.
+#SocksPort 9050 # Default: Bind to localhost:9050 for local connections.
+# ### SocksPort flag: OnionTrafficOnly ###
+## Tell the tor client to only connect to .onion addresses in response to SOCKS5 requests on this connection.
+## This is equivalent to NoDNSRequest, NoIPv4Traffic, NoIPv6Traffic.
+# ### SocksPort flag: ExtendedErrors ###
+## Return extended error code in the SOCKS reply. So far, the possible errors are:
+# X'F0' Onion Service Descriptor Can Not be Found
+# X'F1' Onion Service Descriptor Is Invalid
+# X'F2' Onion Service Introduction Failed
+# X'F3' Onion Service Rendezvous Failed
+# X'F4' Onion Service Missing Client Authorization
+# X'F5' Onion Service Wrong Client Authorization
+# X'F6' Onion Service Invalid Address
+# X'F7' Onion Service Introduction Timed Out
+SocksPort 9050 OnionTrafficOnly ExtendedErrors
 
-SafeSocks 0
-HiddenServiceStatistics 0
+## Entry policies to allow/deny SOCKS requests based on IP address.
+## First entry that matches wins. If no SocksPolicy is set, we accept
+## all (and only) requests that reach a SocksPort. Untrusted users who
+## can access your SocksPort may be able to learn about the connections
+## you make.
+SocksPolicy accept 127.0.0.1
+SocksPolicy accept6 [::1]
+SocksPolicy reject *
+
+## Tor will reject application connections that use unsafe variants of the socks protocol
+## — ones that only provide an IP address, meaning the application is doing a DNS resolve first.
+## Specifically, these are socks4 and socks5 when not doing remote DNS. (Default: 0)
+#SafeSocks 1
+
+## Tor will make a notice-level log entry for each connection to the Socks port indicating
+## whether the request used a safe socks protocol or an unsafe one (see above entry on SafeSocks).
+## This helps to determine whether an application using Tor is possibly leaking DNS requests. (Default: 0)
+TestSocks 1
+
+## Logs go to stdout at level "notice" unless redirected by something
+## else, like one of the below lines. You can have as many Log lines as
+## you want.
+##
+## We advise using "notice" in most cases, since anything more verbose
+## may provide sensitive information to an attacker who obtains the logs.
+##
+## Send all messages of level 'notice' or higher to /var/log/tor/notices.log
+#Log notice file /var/log/tor/notices.log
+## Send every possible message to /var/log/tor/debug.log
+#Log debug file /var/log/tor/debug.log
+## Use the system log instead of Tor's logfiles (This is default)
+#Log notice syslog
+## To send all messages to stderr:
+#Log debug stderr
+
+# Try to write to disk less frequently than we would otherwise. This is useful when running on flash memory.
 AvoidDiskWrites 1
 
-#MaxClientCircuitsPending 64
-#KeepalivePeriod 2
-#CircuitBuildTimeout 5
-#NewCircuitPeriod 15
-#NumEntryGuards 8
+## TODO: This option has no effect. Bisq/Haveno is tor client &/or hidden service.
+## Relays and bridges only. When this option is enabled, a Tor relay writes obfuscated statistics on its
+## role as hidden-service directory, introduction point, or rendezvous point to disk every 24 hours.
+## If ExtraInfoStatistics is enabled, it will be published as part of the extra-info document. (Default: 1)
+HiddenServiceStatistics 0
+
+## The port on which Tor will listen for local connections from Tor
+## controller applications, as documented in control-spec.txt.
+#ControlPort 9051
+## If you enable the controlport, be sure to enable one of these
+## authentication methods, to prevent attackers from accessing it.
+##
+## Compute the hash of a password with "tor --hash-password password".
+#HashedControlPassword 16:872860B76453A77D60CA2BB8C1A7042072093276A3D701AD684053EC4C
+CookieAuthentication 0       # (Default: 1)
+
+## MetricsPort provides an interface to the underlying Tor relay metrics.
+## Exposing publicly is dangerous, set a very strict access policy.
+## Retrieve the metrics with:  curl http://127.0.0.1:9035/metrics
+MetricsPort 127.0.0.1:9035
+MetricsPortPolicy accept 127.0.0.1
+MetricsPortPolicy accept [::1]
+
+############### This section is just for location-hidden services ###
+
+## Once you have configured a hidden service, you can look at the
+## contents of the file ".../hidden_service/hostname" for the address
+## to tell people. e.g.: 'sudo cat /var/lib/tor/haveno_seednode/hostname'
+##
+## HiddenServicePort x y:z says to redirect requests on port x to the
+## address y:z.
+
+## Haveno seednode incoming anonymity connections
+HiddenServiceDir /var/lib/tor/haveno_seednode
+HiddenServicePort 2002 127.0.0.1:2002
+HiddenServicePort 2002 [::1]:2002
+
+## HiddenService options are per onion service:
+## https://community.torproject.org/onion-services/advanced/dos/
+##
+## Rate limiting at the Introduction Points
+## Intropoint protections prevents onion service DoS from becoming a DoS for the entire machine and its guard.
+HiddenServiceEnableIntroDoSDefense 1
+#HiddenServiceEnableIntroDoSRatePerSec 25       # (Default: 25)
+#HiddenServiceEnableIntroDoSBurstPerSec 200     # (Default: 200)
+
+## https://community.torproject.org/onion-services/ecosystem/technology/pow/#configuring-an-onion-service-with-the-pow-protection
+## Proof of Work (PoW) before establishing Rendezvous Circuits
+## The lower the queue and burst rates, the higher the puzzle effort tends to be for users.
+HiddenServicePoWDefensesEnabled 1
+HiddenServicePoWQueueRate 200          # (Default: 250)
+HiddenServicePoWQueueBurst 1000        # (Default: 2500)
+
+## Stream limits in the established Rendezvous Circuits
+HiddenServiceMaxStreams 25
+#HiddenServiceMaxStreamsCloseCircuit 1
+
+## Haveno seednode2 incoming anonymity connections
+HiddenServiceDir /var/lib/tor/haveno_seednode2
+HiddenServicePort 2003 127.0.0.1:2003
+HiddenServicePort 2003 [::1]:2003
+
+HiddenServiceEnableIntroDoSDefense 1
+#HiddenServiceEnableIntroDoSRatePerSec 25       # (Default: 25)
+#HiddenServiceEnableIntroDoSBurstPerSec 200     # (Default: 200)
+
+HiddenServicePoWDefensesEnabled 1
+HiddenServicePoWQueueRate 200          # (Default: 250)
+HiddenServicePoWQueueBurst 1000        # (Default: 2500)
+
+HiddenServiceMaxStreams 25
+#HiddenServiceMaxStreamsCloseCircuit 1
+
+#####################################################################
+
+LongLivedPorts 2002,2003
+## Default: 21, 22, 706, 1863, 5050, 5190, 5222, 5223, 6523, 6667, 6697, 8300


### PR DESCRIPTION
This PR adds the `externalTorDirectBind3` and `torrc` files required by #1170 to `seednode/` and adds the `hiddenServiceAddress=` line to all `haveno-seednode*.service` files