### PR TITLE
chore: split binary artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,32 +92,24 @@ jobs:
         if: ${{ matrix.os == 'windows-latest'}}
         with:
           name: haveno-${{ env.VERSION }}-windows
-          path: |
-              ${{ github.workspace }}/release/*.exe
-              ${{ github.workspace }}/release/*.jar.SHA-256
+          path: ${{ github.workspace }}/release
       # macos
       - uses: actions/upload-artifact@v3
         name: "macOS artifacts"
         if: ${{ matrix.os == 'macos-13'  }}
         with:
           name: haveno-${{ env.VERSION }}-macos
-          path: |
-              ${{ github.workspace }}/release/*.dmg
-              ${{ github.workspace }}/release/*.jar.SHA-256
+          path: ${{ github.workspace }}/release
       # linux
       - uses: actions/upload-artifact@v3
         name: "Linux - deb artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: haveno-${{ env.VERSION }}-linux-deb
-          path: |
-              ${{ github.workspace }}/release/*.deb
-              ${{ github.workspace }}/release/*.jar.SHA-256
+          path: ${{ github.workspace }}/release
       - uses: actions/upload-artifact@v3
         name: "Linux - rpm artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: haveno-${{ env.VERSION }}-linux-rpm
-          path: |
-              ${{ github.workspace }}/release/*.rpm
-              ${{ github.workspace }}/release/*.jar.SHA-256
+          path: ${{ github.workspace }}/release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-22.04, macos-13, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -37,7 +37,7 @@ jobs:
           name: cached-localnet
           path: .localnet
       - name: Install dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           sudo apt update
           sudo apt install -y rpm
@@ -55,7 +55,7 @@ jobs:
 
       # get version from jar
       - name: Set Version Unix
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-13' }}
         run: |
           export VERSION=$(ls desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 | grep -Eo 'desktop-[0-9]+\.[0-9]+\.[0-9]+' | sed 's/desktop-//')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
@@ -67,10 +67,10 @@ jobs:
         shell: powershell
 
       - name: Move Release Files on Unix
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-13' }}
         run: |
           mkdir ${{ github.workspace }}/release
-          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+          if [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
             mv desktop/build/temp-*/binaries/haveno-*.rpm ${{ github.workspace }}/release-rpm/Haveno-x86_64.rpm
             mv desktop/build/temp-*/binaries/haveno_*.deb ${{ github.workspace }}/release-deb/Haveno-x86_64.deb
           else
@@ -104,13 +104,13 @@ jobs:
       # linux
       - uses: actions/upload-artifact@v3
         name: "Linux - deb artifact"
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         with:
           name: haveno-${{ env.VERSION }}-linux-deb
           path: ${{ github.workspace }}/release-deb
       - uses: actions/upload-artifact@v3
         name: "Linux - rpm artifact"
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         with:
           name: haveno-${{ env.VERSION }}-linux-rpm
           path: ${{ github.workspace }}/release-rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,20 +88,13 @@ jobs:
 
 
       # do all files manually and use version too
-      # win
+      # others
       - uses: actions/upload-artifact@v3
         name: "Windows - exe artifact"
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-latest' || matrix.os == 'macos-13'  }}
         with:
-          name: windows-haveno-${{ env.VERSION }}.exe
-          path: ${{ github.workspace }}/release/Haveno-*.exe
-      # macos
-      - uses: actions/upload-artifact@v3
-        name: "MacOS - dmg artifact"
-        if: ${{ matrix.os == 'macos-13' }}
-        with:
-          name: macos-haveno-${{ env.VERSION }}.dmg
-          path: ${{ github.workspace }}/release/Haveno-*.dmg
+          name: HavenoInstaller-${{ matrix.os }}
+          path: ${{ github.workspace }}/release
       # linux
       - uses: actions/upload-artifact@v3
         name: "Linux - deb artifact"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,41 @@ jobs:
           Move-Item -Path desktop\build\temp-*/binaries\Haveno-*.exe -Destination ${{ github.workspace }}/release
           Move-Item -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256 -Destination ${{ github.workspace }}/release
         shell: powershell
+
+      # get version from jar
+      - name: Set Version Unix
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
+        run: |
+          export VERSION=$(ls desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 | grep -oP 'desktop-\K[0-9]+\.[0-9]+\.[0-9]+')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Set Version Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          $VERSION = (Get-ChildItem -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256).Name -replace 'desktop-', '' -replace '-.*', ''
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+        shell: powershell
+
+      # do all files manually and use version too
+      # win
       - uses: actions/upload-artifact@v3
         with:
-          name: HavenoInstaller-${{ matrix.os }}
-          path: ${{ github.workspace }}/release
+          name: windows-haveno-${{ env.VERSION }}.exe
+          path: ${{ github.workspace }}/release/Haveno-*.exe
+      # macos
+      - uses: actions/upload-artifact@v3
+        with:
+          name: macos-haveno-${{ env.VERSION }}.dmg
+          path: ${{ github.workspace }}/release/Haveno-*.dmg
+      # linux
+      - uses: actions/upload-artifact@v3
+        with:
+          name: linux-haveno-${{ env.VERSION }}.deb
+          path: ${{ github.workspace }}/release/haveno_*.deb
+      - uses: actions/upload-artifact@v3
+        with:
+          name: linux-haveno-${{ env.VERSION }}.rpm
+          path: ${{ github.workspace }}/release/haveno-*.rpm
+      - uses: actions/upload-artifact@v3
+        with:
+          name: linux-haveno-${{ env.VERSION }}.flatpak
+          path: ${{ github.workspace }}/release/*.flatpak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,10 @@ jobs:
         run: |
           mkdir ${{ github.workspace }}/release
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            mv desktop/build/temp-*/binaries/haveno-*.rpm ${{ github.workspace }}/release
-            mv desktop/build/temp-*/binaries/haveno_*.deb ${{ github.workspace }}/release
+            mv desktop/build/temp-*/binaries/haveno-*.rpm ${{ github.workspace }}/release/Haveno-x86_64.rpm
+            mv desktop/build/temp-*/binaries/haveno_*.deb ${{ github.workspace }}/release/Haveno-x86_64.deb
           else
-            mv desktop/build/temp-*/binaries/Haveno-*.dmg ${{ github.workspace }}/release
+            mv desktop/build/temp-*/binaries/Haveno-*.dmg ${{ github.workspace }}/release/Haveno-x86_64.dmg
           fi
           mv desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release
         shell: bash
@@ -82,29 +82,34 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
           mkdir ${{ github.workspace }}/release
-          Move-Item -Path desktop\build\temp-*/binaries\Haveno-*.exe -Destination ${{ github.workspace }}/release
+          Move-Item -Path desktop\build\temp-*/binaries\Haveno-*.exe -Destination ${{ github.workspace }}/release/Haveno-x86_64.exe
           Move-Item -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256 -Destination ${{ github.workspace }}/release
         shell: powershell
 
-
-      # do all files manually and use version too
-      # others
+      # win
       - uses: actions/upload-artifact@v3
-        name: "Other artifacts"
-        if: ${{ matrix.os == 'windows-latest' || matrix.os == 'macos-13'  }}
+        name: "Windows artifacts"
+        if: ${{ matrix.os == 'windows-latest'}}
         with:
-          name: HavenoInstaller-${{ matrix.os }}
-          path: ${{ github.workspace }}/release
+          name: haveno-${{ env.VERSION }}-windows.zip
+          path: ${{ github.workspace }}/release/*.exe
+      # macos
+      - uses: actions/upload-artifact@v3
+        name: "macOS artifacts"
+        if: ${{ matrix.os == 'macos-13'  }}
+        with:
+          name: haveno-${{ env.VERSION }}-macos.zip
+          path: ${{ github.workspace }}/release/*.dmg
       # linux
       - uses: actions/upload-artifact@v3
         name: "Linux - deb artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
-          name: linux-haveno-${{ env.VERSION }}.deb
-          path: ${{ github.workspace }}/release/haveno_*.deb
+          name: haveno-${{ env.VERSION }}-linux-deb.deb
+          path: ${{ github.workspace }}/release/*.deb
       - uses: actions/upload-artifact@v3
         name: "Linux - rpm artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
-          name: linux-haveno-${{ env.VERSION }}.rpm
-          path: ${{ github.workspace }}/release/haveno-*.rpm
+          name: haveno-${{ env.VERSION }}-linux-rpm.rpm
+          path: ${{ github.workspace }}/release/*.rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,24 +92,32 @@ jobs:
         if: ${{ matrix.os == 'windows-latest'}}
         with:
           name: haveno-${{ env.VERSION }}-windows
-          path: ${{ github.workspace }}/release/*.exe
+          path: |
+              ${{ github.workspace }}/release/*.exe
+              desktop/build/temp-*/binaries/*.jar.SHA-256
       # macos
       - uses: actions/upload-artifact@v3
         name: "macOS artifacts"
         if: ${{ matrix.os == 'macos-13'  }}
         with:
           name: haveno-${{ env.VERSION }}-macos
-          path: ${{ github.workspace }}/release/*.dmg
+          path: |
+              ${{ github.workspace }}/release/*.dmg
+              desktop/build/temp-*/binaries/*.jar.SHA-256
       # linux
       - uses: actions/upload-artifact@v3
         name: "Linux - deb artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: haveno-${{ env.VERSION }}-linux-deb
-          path: ${{ github.workspace }}/release/*.deb
+          path: |
+              ${{ github.workspace }}/release/*.deb
+              desktop/build/temp-*/binaries/*.jar.SHA-256
       - uses: actions/upload-artifact@v3
         name: "Linux - rpm artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: haveno-${{ env.VERSION }}-linux-rpm
-          path: ${{ github.workspace }}/release/*.rpm
+          path: |
+              ${{ github.workspace }}/release/*.rpm
+              desktop/build/temp-*/binaries/*.jar.SHA-256

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,20 @@ jobs:
           ./gradlew clean build --refresh-keys --refresh-dependencies
           ./gradlew packageInstallers
         working-directory: .
+
+      # get version from jar
+      - name: Set Version Unix
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
+        run: |
+          export VERSION=$(ls desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 | grep -oP 'desktop-\K[0-9]+\.[0-9]+\.[0-9]+')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Set Version Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          $VERSION = (Get-ChildItem -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256).Name -replace 'desktop-', '' -replace '-.*', ''
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+        shell: powershell
+        
       - name: Move Release Files on Unix
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
         run: |
@@ -72,18 +86,6 @@ jobs:
           Move-Item -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256 -Destination ${{ github.workspace }}/release
         shell: powershell
 
-      # get version from jar
-      - name: Set Version Unix
-        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
-        run: |
-          export VERSION=$(ls desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 | grep -oP 'desktop-\K[0-9]+\.[0-9]+\.[0-9]+')
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-      - name: Set Version Windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-          $VERSION = (Get-ChildItem -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256).Name -replace 'desktop-', '' -replace '-.*', ''
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-        shell: powershell
 
       # do all files manually and use version too
       # win

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,24 +90,29 @@ jobs:
       # do all files manually and use version too
       # win
       - uses: actions/upload-artifact@v3
+        name: "Windows - exe artifact"
         with:
           name: windows-haveno-${{ env.VERSION }}.exe
           path: ${{ github.workspace }}/release/Haveno-*.exe
       # macos
       - uses: actions/upload-artifact@v3
+        name: "MacOS - dmg artifact"
         with:
           name: macos-haveno-${{ env.VERSION }}.dmg
           path: ${{ github.workspace }}/release/Haveno-*.dmg
       # linux
       - uses: actions/upload-artifact@v3
+        name: "Linux - deb artifact"
         with:
           name: linux-haveno-${{ env.VERSION }}.deb
           path: ${{ github.workspace }}/release/haveno_*.deb
       - uses: actions/upload-artifact@v3
+        name: "Linux - rpm artifact"
         with:
           name: linux-haveno-${{ env.VERSION }}.rpm
           path: ${{ github.workspace }}/release/haveno-*.rpm
       - uses: actions/upload-artifact@v3
+        name: "Linux - flatpak artifact"
         with:
           name: linux-haveno-${{ env.VERSION }}.flatpak
           path: ${{ github.workspace }}/release/*.flatpak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,8 @@ jobs:
         run: |
           mkdir ${{ github.workspace }}/release
           if [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
+            mkdir ${{ github.workspace }}/release-rpm
+            mkdir ${{ github.workspace }}/release-deb
             mv desktop/build/temp-*/binaries/haveno-*.rpm ${{ github.workspace }}/release-rpm/Haveno-x86_64.rpm
             mv desktop/build/temp-*/binaries/haveno_*.deb ${{ github.workspace }}/release-deb/Haveno-x86_64.deb
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,25 +91,25 @@ jobs:
         name: "Windows artifacts"
         if: ${{ matrix.os == 'windows-latest'}}
         with:
-          name: haveno-${{ env.VERSION }}-windows.zip
+          name: haveno-${{ env.VERSION }}-windows
           path: ${{ github.workspace }}/release/*.exe
       # macos
       - uses: actions/upload-artifact@v3
         name: "macOS artifacts"
         if: ${{ matrix.os == 'macos-13'  }}
         with:
-          name: haveno-${{ env.VERSION }}-macos.zip
+          name: haveno-${{ env.VERSION }}-macos
           path: ${{ github.workspace }}/release/*.dmg
       # linux
       - uses: actions/upload-artifact@v3
         name: "Linux - deb artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
-          name: haveno-${{ env.VERSION }}-linux-deb.deb
+          name: haveno-${{ env.VERSION }}-linux-deb
           path: ${{ github.workspace }}/release/*.deb
       - uses: actions/upload-artifact@v3
         name: "Linux - rpm artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
-          name: haveno-${{ env.VERSION }}-linux-rpm.rpm
+          name: haveno-${{ env.VERSION }}-linux-rpm
           path: ${{ github.workspace }}/release/*.rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           $VERSION = (Get-ChildItem -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256).Name -replace 'desktop-', '' -replace '-.*', ''
           "VERSION=$VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
         shell: powershell
-        
+
       - name: Move Release Files on Unix
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
         run: |
@@ -91,23 +91,27 @@ jobs:
       # win
       - uses: actions/upload-artifact@v3
         name: "Windows - exe artifact"
+        if: ${{ matrix.os == 'windows-latest' }}
         with:
           name: windows-haveno-${{ env.VERSION }}.exe
           path: ${{ github.workspace }}/release/Haveno-*.exe
       # macos
       - uses: actions/upload-artifact@v3
         name: "MacOS - dmg artifact"
+        if: ${{ matrix.os == 'macos-13' }}
         with:
           name: macos-haveno-${{ env.VERSION }}.dmg
           path: ${{ github.workspace }}/release/Haveno-*.dmg
       # linux
       - uses: actions/upload-artifact@v3
         name: "Linux - deb artifact"
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: linux-haveno-${{ env.VERSION }}.deb
           path: ${{ github.workspace }}/release/haveno_*.deb
       - uses: actions/upload-artifact@v3
         name: "Linux - rpm artifact"
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: linux-haveno-${{ env.VERSION }}.rpm
           path: ${{ github.workspace }}/release/haveno-*.rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Set Version Unix
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-13' }}
         run: |
-          export VERSION=$(ls desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 | grep -oP 'desktop-\K[0-9]+\.[0-9]+\.[0-9]+')
+          export VERSION=$(ls desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 | grep -Eo 'desktop-[0-9]+\.[0-9]+\.[0-9]+' | sed 's/desktop-//')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Set Version Windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
           $VERSION = (Get-ChildItem -Path desktop\build\temp-*/binaries\desktop-*.jar.SHA-256).Name -replace 'desktop-', '' -replace '-.*', ''
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          "VERSION=$VERSION" | Out-File -FilePath $env:GITHUB_ENV -Append
         shell: powershell
         
       - name: Move Release Files on Unix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,8 +111,3 @@ jobs:
         with:
           name: linux-haveno-${{ env.VERSION }}.rpm
           path: ${{ github.workspace }}/release/haveno-*.rpm
-      - uses: actions/upload-artifact@v3
-        name: "Linux - flatpak artifact"
-        with:
-          name: linux-haveno-${{ env.VERSION }}.flatpak
-          path: ${{ github.workspace }}/release/*.flatpak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
           name: haveno-${{ env.VERSION }}-windows
           path: |
               ${{ github.workspace }}/release/*.exe
-              desktop/build/temp-*/binaries/*.jar.SHA-256
+              ${{ github.workspace }}/release/*.jar.SHA-256
       # macos
       - uses: actions/upload-artifact@v3
         name: "macOS artifacts"
@@ -103,7 +103,7 @@ jobs:
           name: haveno-${{ env.VERSION }}-macos
           path: |
               ${{ github.workspace }}/release/*.dmg
-              desktop/build/temp-*/binaries/*.jar.SHA-256
+              ${{ github.workspace }}/release/*.jar.SHA-256
       # linux
       - uses: actions/upload-artifact@v3
         name: "Linux - deb artifact"
@@ -112,7 +112,7 @@ jobs:
           name: haveno-${{ env.VERSION }}-linux-deb
           path: |
               ${{ github.workspace }}/release/*.deb
-              desktop/build/temp-*/binaries/*.jar.SHA-256
+              ${{ github.workspace }}/release/*.jar.SHA-256
       - uses: actions/upload-artifact@v3
         name: "Linux - rpm artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -120,4 +120,4 @@ jobs:
           name: haveno-${{ env.VERSION }}-linux-rpm
           path: |
               ${{ github.workspace }}/release/*.rpm
-              desktop/build/temp-*/binaries/*.jar.SHA-256
+              ${{ github.workspace }}/release/*.jar.SHA-256

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,12 +71,13 @@ jobs:
         run: |
           mkdir ${{ github.workspace }}/release
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            mv desktop/build/temp-*/binaries/haveno-*.rpm ${{ github.workspace }}/release/Haveno-x86_64.rpm
-            mv desktop/build/temp-*/binaries/haveno_*.deb ${{ github.workspace }}/release/Haveno-x86_64.deb
+            mv desktop/build/temp-*/binaries/haveno-*.rpm ${{ github.workspace }}/release-rpm/Haveno-x86_64.rpm
+            mv desktop/build/temp-*/binaries/haveno_*.deb ${{ github.workspace }}/release-deb/Haveno-x86_64.deb
           else
             mv desktop/build/temp-*/binaries/Haveno-*.dmg ${{ github.workspace }}/release/Haveno-x86_64.dmg
           fi
-          mv desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release
+          cp desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release-deb
+          cp desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release-rpm
         shell: bash
       - name: Move Release Files on Windows
         if: ${{ matrix.os == 'windows-latest' }}
@@ -106,10 +107,10 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: haveno-${{ env.VERSION }}-linux-deb
-          path: ${{ github.workspace }}/release
+          path: ${{ github.workspace }}/release-deb
       - uses: actions/upload-artifact@v3
         name: "Linux - rpm artifact"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: haveno-${{ env.VERSION }}-linux-rpm
-          path: ${{ github.workspace }}/release
+          path: ${{ github.workspace }}/release-rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
           else
             mv desktop/build/temp-*/binaries/Haveno-*.dmg ${{ github.workspace }}/release/Haveno-x86_64.dmg
           fi
+          cp desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release
           cp desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release-deb
           cp desktop/build/temp-*/binaries/desktop-*.jar.SHA-256 ${{ github.workspace }}/release-rpm
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
       # do all files manually and use version too
       # others
       - uses: actions/upload-artifact@v3
-        name: "Windows - exe artifact"
+        name: "Other artifacts"
         if: ${{ matrix.os == 'windows-latest' || matrix.os == 'macos-13'  }}
         with:
           name: HavenoInstaller-${{ matrix.os }}


### PR DESCRIPTION
This keeps the version string for now.