### PR TITLE
enable hidden files in cache node dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
       - name: cache nodes dependencies
         uses: actions/upload-artifact@v3
         with:
+          include-hidden-files: true
           name: cached-localnet
           path: .localnet
       - name: Install dependencies


### PR DESCRIPTION
addresses: https://github.com/haveno-dex/haveno/issues/1268

This is due to a change for upload-artifact v4, which was ported back to upload-artifact v3.
The breaking change makes hidden files not included by default, where hidden files are defined as beginning with `.`
Enabled hidden files for the cache node dependencies step to make .localnet visible
https://github.com/actions/upload-artifact/issues/602