### PR TITLE
Fixing some words displayStrings_cs.properties

### DIFF
--- a/core/src/main/resources/i18n/displayStrings_cs.properties
+++ b/core/src/main/resources/i18n/displayStrings_cs.properties
@@ -105,7 +105,7 @@ shared.nextStep=Další krok
 shared.selectTradingAccount=Vyberte obchodní účet
 shared.fundFromSavingsWalletButton=Použít prostředky z peněženky Haveno
 shared.fundFromExternalWalletButton=Otevřít vaši externí peněženku pro financování
-shared.openDefaultWalletFailed=Nepodařilo se otevřít aplikaci moneroové peněženky. Jste si jisti, že máte nějakou nainstalovanou?
+shared.openDefaultWalletFailed=Nepodařilo se otevřít aplikaci peněženky Monero. Jste si jisti, že máte nějakou nainstalovanou?
 shared.belowInPercent=% pod tržní cenou
 shared.aboveInPercent=% nad tržní cenou
 shared.enterPercentageValue=Zadejte % hodnotu
@@ -124,7 +124,7 @@ shared.noDetailsAvailable=Detaily nejsou k dispozici
 shared.notUsedYet=Ještě nepoužito
 shared.date=Datum
 # suppress inspection "TrailingSpacesInProperty"
-shared.sendFundsDetailsDust=Haveno zjistil, že tato transakce by vytvořila drobné mince, které jsou pod limitem drobných mincí (a není to povoleno pravidly pro moneroový konsenzus). Místo toho budou tyto drobné mince ({0} satoshi {1}) přidány k poplatku za těžbu.\n\n\n
+shared.sendFundsDetailsDust=Haveno zjistil, že tato transakce by vytvořila drobné mince, které jsou pod limitem drobných mincí (a není to povoleno pravidly pro konsenzus Monero). Místo toho budou tyto drobné mince ({0} satoshi {1}) přidány k poplatku za těžbu.\n\n\n
 shared.copyToClipboard=Kopírovat do schránky
 shared.language=Jazyk
 shared.country=Země
@@ -258,19 +258,19 @@ mainView.footer.xmrInfo.synchronizingWalletWith=Synchronizace peněženky s {0} 
 mainView.footer.xmrInfo.syncedWith=Synchronizováno s {0} na bloku {1}
 mainView.footer.xmrInfo.connectingTo=Připojování
 mainView.footer.xmrInfo.connectionFailed=Připojení se nezdařilo
-mainView.footer.xmrPeers=Monero síťové nody: {0}
-mainView.footer.p2pPeers=Haveno síťové nody: {0}
+mainView.footer.xmrPeers=Monero síťové uzly: {0}
+mainView.footer.p2pPeers=Haveno síťové uzly: {0}
 
 mainView.bootstrapState.connectionToTorNetwork=(1/4) Připojování do sítě Tor...
-mainView.bootstrapState.torNodeCreated=(2/4) Tor node vytvořen
+mainView.bootstrapState.torNodeCreated=(2/4) Tor uzel vytvořen
 mainView.bootstrapState.hiddenServicePublished=(3/4) Skrytá služba publikována
 mainView.bootstrapState.initialDataReceived=(4/4) Iniciační data přijata
 
-mainView.bootstrapWarning.noSeedNodesAvailable=Žádné seed nody nejsou k dispozici
-mainView.bootstrapWarning.noNodesAvailable=Žádné seed ani peer nody k dispozici
+mainView.bootstrapWarning.noSeedNodesAvailable=Žádné seed uzly nejsou k dispozici
+mainView.bootstrapWarning.noNodesAvailable=Žádné seed ani peer uzly k dispozici
 mainView.bootstrapWarning.bootstrappingToP2PFailed=Zavádění do sítě Haveno se nezdařilo
 
-mainView.p2pNetworkWarnMsg.noNodesAvailable=Pro vyžádání dat nejsou k dispozici žádné seed ani peer nody.\nZkontrolujte připojení k internetu nebo zkuste aplikaci restartovat.
+mainView.p2pNetworkWarnMsg.noNodesAvailable=Pro vyžádání dat nejsou k dispozici žádné seed ani peer uzly.\nZkontrolujte připojení k internetu nebo zkuste aplikaci restartovat.
 mainView.p2pNetworkWarnMsg.connectionToP2PFailed=Připojení k síti Haveno selhalo (nahlášená chyba: {0}).\nZkontrolujte připojení k internetu nebo zkuste aplikaci restartovat.
 
 mainView.walletServiceErrorMsg.timeout=Připojení k síti Monero selhalo kvůli vypršení časového limitu.
@@ -278,8 +278,8 @@ mainView.walletServiceErrorMsg.connectionError=Připojení k síti Monero selhal
 
 mainView.walletServiceErrorMsg.rejectedTxException=Transakce byla ze sítě zamítnuta.\n\n{0}
 
-mainView.networkWarning.allConnectionsLost=Ztratili jste připojení ke všem {0} síťovým peer nodům.\nMožná jste ztratili připojení k internetu nebo byl váš počítač v pohotovostním režimu.
-mainView.networkWarning.localhostMoneroLost=Ztratili jste připojení k Moneroovému localhost nodu.\nRestartujte aplikaci Haveno a připojte se k jiným Moneroovým nodům nebo restartujte Moneroový localhost node.
+mainView.networkWarning.allConnectionsLost=Ztratili jste připojení ke všem {0} síťovým peer uzlům.\nMožná jste ztratili připojení k internetu nebo byl váš počítač v pohotovostním režimu.
+mainView.networkWarning.localhostMoneroLost=Ztratili jste připojení k localhost uzlu Monero.\nRestartujte aplikaci Haveno a připojte se k jiným uzlům Monero nebo restartujte localhost Monero uzel.
 mainView.version.update=(Dostupná aktualizace)
 
 
@@ -360,7 +360,7 @@ offerbook.timeSinceSigning.notSigned.noNeed=N/A
 shared.notSigned=Tento účet ještě nebyl podepsán a byl vytvořen před {0} dny
 shared.notSigned.noNeed=Tento typ účtu nevyžaduje podepisování
 shared.notSigned.noNeedDays=Tento typ účtu nevyžaduje podepisování a byl vytvořen před {0} dny
-shared.notSigned.noNeedAlts=Cryptoové účty neprocházejí kontrolou podpisu a stáří
+shared.notSigned.noNeedAlts=Kryptoměnové účty neprocházejí kontrolou podpisu a stáří
 
 offerbook.nrOffers=Počet nabídek: {0}
 offerbook.volume={0} (min - max)
@@ -747,7 +747,7 @@ portfolio.pending.step5_buyer.alreadyWithdrawn=Vaše finanční prostředky již
 portfolio.pending.step5_buyer.confirmWithdrawal=Potvrďte žádost o výběr
 portfolio.pending.step5_buyer.amountTooLow=Částka k převodu je nižší než transakční poplatek a min. možná hodnota tx (drobné).
 portfolio.pending.step5_buyer.withdrawalCompleted.headline=Výběr byl dokončen
-portfolio.pending.step5_buyer.withdrawalCompleted.msg=Vaše dokončené obchody jsou uloženy na \"Portfolio/Historie\".\nVšechny své moneroové transakce si můžete prohlédnout v sekci \"Prostředky/Transakce\"
+portfolio.pending.step5_buyer.withdrawalCompleted.msg=Vaše dokončené obchody jsou uloženy na \"Portfolio/Historie\".\nVšechny své transakce Monero si můžete prohlédnout v sekci \"Finance/Transakce\"
 portfolio.pending.step5_buyer.bought=Koupili jste
 portfolio.pending.step5_buyer.paid=Zaplatili jste
 
@@ -1015,8 +1015,8 @@ setting.preferences.prefCurrency=Preferovaná měna
 setting.preferences.displayTraditional=Zobrazit národní měny
 setting.preferences.noTraditional=Nejsou vybrány žádné národní měny
 setting.preferences.cannotRemovePrefCurrency=Vybranou zobrazovanou měnu nelze odebrat.
-setting.preferences.displayCryptos=Zobrazit cryptoy
-setting.preferences.noCryptos=Nejsou vybrány žádné cryptoy
+setting.preferences.displayCryptos=Zobrazit kryptoměny
+setting.preferences.noCryptos=Nejsou vybrány žádné kryptoměny
 setting.preferences.addTraditional=Přidejte národní měnu
 setting.preferences.addCrypto=Přidejte crypto
 setting.preferences.displayOptions=Zobrazit možnosti
@@ -1038,24 +1038,24 @@ settings.preferences.editCustomExplorer.name=Jméno
 settings.preferences.editCustomExplorer.txUrl=Transakční URL
 settings.preferences.editCustomExplorer.addressUrl=Adresa URL
 
-settings.net.xmrHeader=Moneroová síť
+settings.net.xmrHeader=Síť Monero
 settings.net.p2pHeader=Síť Haveno
 settings.net.onionAddressLabel=Moje onion adresa
-settings.net.xmrNodesLabel=Použijte vlastní Monero node
+settings.net.xmrNodesLabel=Použijte vlastní Monero uzel
 settings.net.moneroPeersLabel=Připojené peer uzly
 settings.net.connection=Připojení
 settings.net.connected=Připojeno
 settings.net.useTorForXmrJLabel=Použít Tor pro Monero síť
-settings.net.moneroNodesLabel=Monero nody, pro připojení
-settings.net.useProvidedNodesRadio=Použijte nabízené Monero Core nody
-settings.net.usePublicNodesRadio=Použít veřejnou Moneroovou síť
-settings.net.useCustomNodesRadio=Použijte vlastní Monero Core node
-settings.net.warn.usePublicNodes=Pokud používáte veřejné Monero nody, jste vystaveni riziku spojenému s používáním nedůvěryhodných vzdálených nodů.\n\nProsím, přečtěte si více podrobností na [HYPERLINK:https://www.getmonero.org/resources/moneropedia/remote-node.html].\n\nJste si jistí, že chcete použít veřejné nody?
-settings.net.warn.usePublicNodes.useProvided=Ne, použijte nabízené nody
+settings.net.moneroNodesLabel=Monero uzly, pro připojení
+settings.net.useProvidedNodesRadio=Použijte nabízené Monero Core uzly
+settings.net.usePublicNodesRadio=Použít veřejnou síť Monero
+settings.net.useCustomNodesRadio=Použijte vlastní Monero Core uzel
+settings.net.warn.usePublicNodes=Pokud používáte veřejné Monero uzly, jste vystaveni riziku spojenému s používáním nedůvěryhodných vzdálených uzlů.\n\nProsím, přečtěte si více podrobností na [HYPERLINK:https://www.getmonero.org/resources/moneropedia/remote-node.html].\n\nJste si jistí, že chcete použít veřejné uzly?
+settings.net.warn.usePublicNodes.useProvided=Ne, použijte nabízené uzly
 settings.net.warn.usePublicNodes.usePublic=Ano, použít veřejnou síť
-settings.net.warn.useCustomNodes.B2XWarning=Ujistěte se, že váš moneroový node je důvěryhodný Monero Core node!\n\nPřipojení k nodům, které nedodržují pravidla konsensu Monero Core, může poškodit vaši peněženku a způsobit problémy v obchodním procesu.\n\nUživatelé, kteří se připojují k nodům, které porušují pravidla konsensu, odpovídají za případné škody, které z toho vyplývají. Jakékoli výsledné spory budou rozhodnuty ve prospěch druhého obchodníka. Uživatelům, kteří ignorují tyto varovné a ochranné mechanismy, nebude poskytována technická podpora!
-settings.net.warn.invalidXmrConfig=Připojení k moneroové síti selhalo, protože je vaše konfigurace  neplatná.\n\nVaše konfigurace byla resetována, aby se místo toho použily poskytnuté moneroové uzly. Budete muset restartovat aplikaci.
-settings.net.localhostXmrNodeInfo=Základní informace: Haveno při spuštění hledá místní Moneroový uzel. Pokud je nalezen, Haveno bude komunikovat se sítí Monero výhradně skrze něj.
+settings.net.warn.useCustomNodes.B2XWarning=Ujistěte se, že váš Monero uzel je důvěryhodný Monero Core uzel!\n\nPřipojení k uzlům, které nedodržují pravidla konsensu Monero Core, může poškodit vaši peněženku a způsobit problémy v obchodním procesu.\n\nUživatelé, kteří se připojují k uzlům, které porušují pravidla konsensu, odpovídají za případné škody, které z toho vyplývají. Jakékoli výsledné spory budou rozhodnuty ve prospěch druhého obchodníka. Uživatelům, kteří ignorují tyto varovné a ochranné mechanismy, nebude poskytována technická podpora!
+settings.net.warn.invalidXmrConfig=Připojení k síti Monero selhalo, protože je vaše konfigurace neplatná.\n\nVaše konfigurace byla resetována, aby byly místo toho použity poskytnuté uzly Monero. Budete muset restartovat aplikaci.
+settings.net.localhostXmrNodeInfo=Základní informace: Haveno při spuštění hledá místní Monero uzel. Pokud je nalezen, Haveno bude komunikovat se sítí Monero výhradně skrze něj.
 settings.net.p2PPeersLabel=Připojené uzly
 settings.net.onionAddressColumn=Onion adresa
 settings.net.creationDateColumn=Založeno
@@ -1079,7 +1079,7 @@ settings.net.sentData=Odeslaná data: {0}, {1} zprávy, {2} zprávy/sekundu
 settings.net.receivedData=Přijatá data: {0}, {1} zprávy, {2} zprávy/sekundu
 settings.net.chainHeight=Monero Peers: {0}
 settings.net.ips=[IP adresa:port | název hostitele:port | onion adresa:port] (oddělené čárkou). Pokud je použit výchozí port (8333), lze port vynechat.
-settings.net.seedNode=Seed node
+settings.net.seedNode=Seed uzel
 settings.net.directPeer=Peer uzel (přímý)
 settings.net.initialDataExchange={0} [Bootstrapping]
 settings.net.peer=Peer
@@ -1158,10 +1158,10 @@ account.tab.mediatorRegistration=Registrace mediátora
 account.tab.refundAgentRegistration=Registrace rozhodce pro vrácení peněz
 account.tab.signing=Podepisování
 account.info.headline=Vítejte ve vašem účtu Haveno
-account.info.msg=Zde můžete přidat obchodní účty pro národní měny & cryptoy a vytvořit zálohu dat vaší peněženky a účtu.\n\nPři prvním spuštění Haveno byla vytvořena nová moneroová peněženka.\n\nDůrazně doporučujeme zapsat si seed slova moneroových peněženek (viz záložka nahoře) a před financováním zvážit přidání hesla. Vklady a výběry moneroů jsou spravovány v sekci \ "Finance \".\n\nOchrana osobních údajů a zabezpečení: protože Haveno je decentralizovaná směnárna, všechna data jsou uložena ve vašem počítači. Neexistují žádné servery, takže nemáme přístup k vašim osobním informacím, vašim finančním prostředkům ani vaší IP adrese. Údaje, jako jsou čísla bankovních účtů, adresy cryptoů a monerou atd., jsou sdíleny pouze s obchodním partnerem za účelem uskutečnění obchodů, které zahájíte (v případě sporu uvidí Prostředník nebo Rozhodce stejná data jako váš obchodní partner).
+account.info.msg=Zde můžete přidat obchodní účty pro národní měny & kryptoměny a vytvořit zálohu dat vaší peněženky a účtu.\n\nPři prvním spuštění Haveno byla vytvořena nová peněženka Monero.\n\nDůrazně doporučujeme zapsat si seed slova peněženek (viz záložka nahoře) a před financováním zvážit přidání hesla. Vklady a výběry moneroů jsou spravovány v sekci \ "Finance \".\n\nOchrana osobních údajů a zabezpečení: protože Haveno je decentralizovaná směnárna, všechna data jsou uložena ve vašem počítači. Neexistují žádné servery, takže nemáme přístup k vašim osobním informacím, vašim finančním prostředkům ani vaší IP adrese. Údaje, jako jsou čísla bankovních účtů, adresy cryptoů a monerou atd., jsou sdíleny pouze s obchodním partnerem za účelem uskutečnění obchodů, které zahájíte (v případě sporu uvidí Prostředník nebo Rozhodce stejná data jako váš obchodní partner).
 
 account.menu.paymentAccount=Účty v národní měně
-account.menu.altCoinsAccountView=Cryptoové účty
+account.menu.altCoinsAccountView=Kryptoměnové účty
 account.menu.password=Heslo peněženky
 account.menu.seedWords=Seed peněženky
 account.menu.walletInfo=Info o peněžence
@@ -1190,7 +1190,7 @@ account.arbitratorRegistration.removedFailed=Registraci se nepodařilo odebrat. 
 account.arbitratorRegistration.registerSuccess=Úspěšně jste se zaregistrovali do sítě Haveno.
 account.arbitratorRegistration.registerFailed=Registraci se nepodařilo dokončit. {0}
 
-account.crypto.yourCryptoAccounts=Vaše cryptoové účty
+account.crypto.yourCryptoAccounts=Vaše kryptoměnové účty
 account.crypto.popup.wallet.msg=Ujistěte se, že dodržujete požadavky na používání peněženek {0}, jak je popsáno na webové stránce {1}.\nPoužití peněženek z centralizovaných směnáren, kde (a) nevlastníte své soukromé klíče nebo (b) které nepoužívají kompatibilní software peněženky, je riskantní: může to vést ke ztrátě obchodovaných prostředků!\nMediátor nebo rozhodce není specialista {2} a v takových případech nemůže pomoci.
 account.crypto.popup.wallet.confirm=Rozumím a potvrzuji, že vím, jakou peněženku musím použít.
 # suppress inspection "UnusedProperty"
@@ -1244,7 +1244,7 @@ account.password.removePw.button=Odstraňte heslo
 account.password.removePw.headline=Odstraňte ochranu peněženky pomocí hesla
 account.password.setPw.button=Nastavit heslo
 account.password.setPw.headline=Nastavte ochranu peněženky pomocí hesla
-account.password.info=S ochranou pomocí hesla budete muset zadat heslo při spuštění aplikace, při výběru monera z vaší peněženky a při zobrazení vašich slov z klíčového základu.
+account.password.info=S ochranou pomocí hesla budete muset zadat heslo při spuštění aplikace, při výběru monera z vaší peněženky a při zobrazení slov seedu peněženky.
 
 account.seed.backup.title=Zálohujte svá klíčová slova peněženky.
 account.seed.info=Prosím, zapište si jak klíčová slova peněženky, tak datum. Kdykoliv můžete obnovit svou peněženku pomocí klíčových slov a data.\n\nKlíčová slova byste měli zapsat na kus papíru. Neukládejte je na počítač.\n\nVezměte prosím na vědomí, že klíčová slova NEJSOU náhradou za zálohu.\nMusíte vytvořit zálohu celého adresáře aplikace z obrazovky "Účet/Záloha", abyste mohli obnovit stav a data aplikace.
@@ -1252,7 +1252,7 @@ account.seed.backup.warning=Prosím, poznamenejte si, že klíčová slova nejso
 account.seed.warn.noPw.msg=Nenastavili jste si heslo k peněžence, které by chránilo zobrazení seed slov.\n\nChcete zobrazit seed slova?
 account.seed.warn.noPw.yes=Ano, a už se mě znovu nezeptat
 account.seed.enterPw=Chcete-li zobrazit seed slova, zadejte heslo
-account.seed.restore.info=Před použitím obnovení ze seed slov si vytvořte zálohu. Uvědomte si, že obnova peněženky je pouze pro naléhavé případy a může způsobit problémy s interní databází peněženky.\nNení to způsob, jak použít zálohu! K obnovení předchozího stavu aplikace použijte zálohu z adresáře dat aplikace.\n\nPo obnovení se aplikace automaticky vypne. Po restartování aplikace se bude znovu synchronizovat s moneroovou sítí. To může chvíli trvat a může spotřebovat hodně CPU, zejména pokud byla peněženka starší a měla mnoho transakcí. Vyhněte se přerušování tohoto procesu, jinak budete možná muset znovu odstranit soubor řetězu SPV nebo opakovat proces obnovy.
+account.seed.restore.info=Před použitím obnovení ze seed slov si vytvořte zálohu. Uvědomte si, že obnova peněženky je pouze pro naléhavé případy a může způsobit problémy s interní databází peněženky.\nNení to způsob, jak použít zálohu! K obnovení předchozího stavu aplikace použijte zálohu z adresáře dat aplikace.\n\nPo obnovení se aplikace automaticky vypne. Po restartování aplikace se bude znovu synchronizovat se sítí Monero. To může chvíli trvat a může spotřebovat hodně CPU, zejména pokud byla peněženka starší a měla mnoho transakcí. Vyhněte se přerušování tohoto procesu, jinak budete možná muset znovu odstranit soubor řetězu SPV nebo opakovat proces obnovy.
 account.seed.restore.ok=Dobře, proveďte obnovu a vypněte Haveno
 
 
@@ -1323,7 +1323,7 @@ inputControlWindow.balanceLabel=Dostupný zůstatek
 
 contractWindow.title=Podrobnosti o sporu
 contractWindow.dates=Datum nabídky / Datum obchodu
-contractWindow.xmrAddresses=Moneroová adresa kupujícího XMR / prodávajícího XMR
+contractWindow.xmrAddresses=Monero adresa kupujícího XMR / prodávajícího XMR
 contractWindow.onions=Síťová adresa kupující XMR / prodávající XMR
 contractWindow.accountAge=Stáří účtu XMR kupující / XMR prodejce
 contractWindow.numDisputes=Počet sporů XMR kupující / XMR prodejce
@@ -1436,10 +1436,10 @@ filterWindow.bannedPrivilegedDevPubKeys=Filtrované privilegované klíče pub d
 filterWindow.arbitrators=Filtrovaní rozhodci (onion adresy oddělené čárkami)
 filterWindow.mediators=Filtrovaní mediátoři (onion adresy oddělené čárkami)
 filterWindow.refundAgents=Filtrovaní rozhodci pro vrácení peněz (onion adresy oddělené čárkami)
-filterWindow.seedNode=Filtrované seed nody (onion adresy oddělené čárkami)
-filterWindow.priceRelayNode=Filtrované cenové relay nody (onion adresy oddělené čárkami)
-filterWindow.xmrNode=Filtrované Moneroové nody (adresy+porty oddělené čárkami)
-filterWindow.preventPublicXmrNetwork=Zabraňte použití veřejné moneroové sítě
+filterWindow.seedNode=Filtrované seed uzly (onion adresy oddělené čárkami)
+filterWindow.priceRelayNode=Filtrované cenové relay uzly (onion adresy oddělené čárkami)
+filterWindow.xmrNode=Filtrované uzly Monero (adresy+porty oddělené čárkami)
+filterWindow.preventPublicXmrNetwork=Zabraňte použití veřejné sítě Monero
 filterWindow.disableAutoConf=Zakázat automatické potvrzení
 filterWindow.autoConfExplorers=Filtrované průzkumníky s automatickým potvrzením (adresy oddělené čárkami)
 filterWindow.disableTradeBelowVersion=Min. verze nutná pro obchodování
@@ -1595,12 +1595,12 @@ popup.warning.startupFailed.twoInstances=Haveno již běží. Nemůžete spustit
 popup.warning.tradePeriod.halfReached=Váš obchod s ID {0} dosáhl poloviny max. povoleného obchodního období a stále není dokončen.\n\nObdobí obchodování končí {1}\n\nDalší informace o stavu obchodu naleznete na adrese \"Portfolio/Otevřené obchody\".
 popup.warning.tradePeriod.ended=Váš obchod s ID {0} dosáhl max. povoleného obchodního období a není dokončen.\n\nObdobí obchodování skončilo {1}\n\nZkontrolujte prosím svůj obchod v sekci "Portfolio/Otevřené obchody\", abyste kontaktovali mediátora.
 popup.warning.noTradingAccountSetup.headline=Nemáte nastaven obchodní účet
-popup.warning.noTradingAccountSetup.msg=Než budete moci vytvořit nabídku, musíte si nastavit národní měnu nebo cryptoový účet.\nChcete si založit účet?
+popup.warning.noTradingAccountSetup.msg=Než budete moci vytvořit nabídku, musíte si nastavit národní měnu nebo kryptoměnový účet.\nChcete si založit účet?
 popup.warning.noArbitratorsAvailable=Nejsou k dispozici žádní rozhodci.
 popup.warning.noMediatorsAvailable=Nejsou k dispozici žádní mediátoři.
 popup.warning.notFullyConnected=Musíte počkat, až budete plně připojeni k síti.\nTo může při spuštění trvat až 2 minuty.
-popup.warning.notSufficientConnectionsToXmrNetwork=Musíte počkat, až budete mít alespoň {0} připojení k moneroové síti.
-popup.warning.downloadNotComplete=Musíte počkat, až bude stahování chybějících moneroových bloků kompletní.
+popup.warning.notSufficientConnectionsToXmrNetwork=Musíte počkat, až budete mít alespoň {0} připojení k síti Monero.
+popup.warning.downloadNotComplete=Musíte počkat, až bude dokončeno stahování chybějících bloků Monero.
 popup.warning.walletNotSynced=Haveno peněženka není synchronizována s nejnovější výškou blockchainu. Počkejte, dokud se peněženka nesynchronizuje, nebo zkontrolujte své připojení.
 popup.warning.removeOffer=Opravdu chcete tuto nabídku odebrat?
 popup.warning.tooLargePercentageValue=Nelze nastavit procento 100% nebo větší.
@@ -1622,11 +1622,11 @@ popup.warning.seed=seed
 popup.warning.mandatoryUpdate.trading=Aktualizujte prosím na nejnovější verzi Haveno. Byla vydána povinná aktualizace, která zakazuje obchodování se starými verzemi. Další informace naleznete na fóru Haveno.
 popup.warning.burnXMR=Tato transakce není možná, protože poplatky za těžbu {0} by přesáhly částku převodu {1}. Počkejte prosím, dokud nebudou poplatky za těžbu opět nízké nebo dokud nenahromadíte více XMR k převodu.
 
-popup.warning.openOffer.makerFeeTxRejected=Transakční poplatek tvůrce za nabídku s ID {0} byl moneroovou sítí odmítnut.\nID transakce = {1}.\nNabídka byla odstraněna, aby se předešlo dalším problémům.\nPřejděte do \"Nastavení/Informace o síti\" a proveďte synchronizaci SPV.\nPro další pomoc prosím kontaktujte podpůrný kanál v Haveno Keybase týmu.
+popup.warning.openOffer.makerFeeTxRejected=Transakční poplatek tvůrce za nabídku s ID {0} byl odmítnut sítí Monero.\nID transakce = {1}.\nNabídka byla odstraněna, aby se předešlo dalším problémům.\nPřejděte do \"Nastavení/Informace o síti\" a proveďte synchronizaci SPV.\nPro další pomoc prosím kontaktujte podpůrný kanál v Haveno Keybase týmu.
 
 popup.warning.trade.txRejected.tradeFee=obchodní poplatek
 popup.warning.trade.txRejected.deposit=vklad
-popup.warning.trade.txRejected=Moneroová síť odmítla {0} transakci pro obchod s ID {1}.\nID transakce = {2}\nObchod byl přesunut do neúspěšných obchodů.\nPřejděte do části \"Nastavení/Informace o síti\" a proveďte synchronizaci SPV.\nPro další pomoc prosím kontaktujte podpůrný kanál v Haveno Keybase týmu.
+popup.warning.trade.txRejected=Síť Monero odmítla {0} transakci pro obchod s ID {1}.\nID transakce = {2}\nObchod byl přesunut do neúspěšných obchodů.\nPřejděte do části \"Nastavení/Informace o síti\" a proveďte synchronizaci SPV.\nPro další pomoc prosím kontaktujte podpůrný kanál v Haveno Keybase týmu.
 
 popup.warning.openOfferWithInvalidMakerFeeTx=Transakční poplatek tvůrce za nabídku s ID {0} je neplatný.\nID transakce = {1}.\nPřejděte do \"Nastavení/Informace o síti\" a proveďte synchronizaci SPV.\nPro další pomoc prosím kontaktujte podpůrný kanál v Haveno Keybase týmu.
 
@@ -1641,9 +1641,9 @@ popup.warn.downGradePrevention=Downgrade z verze {0} na verzi {1} není podporov
 popup.privateNotification.headline=Důležité soukromé oznámení!
 
 popup.securityRecommendation.headline=Důležité bezpečnostní doporučení
-popup.securityRecommendation.msg=Chtěli bychom vám připomenout, abyste zvážili použití ochrany heslem pro vaši peněženku, pokud jste ji již neaktivovali.\n\nDůrazně se také doporučuje zapsat seed slova peněženky. Tato seed slova jsou jako hlavní heslo pro obnovení vaší moneroové peněženky.\nV sekci "Seed peněženky" naleznete další informace.\n\nDále byste měli zálohovat úplnou složku dat aplikace v sekci \"Záloha\".
+popup.securityRecommendation.msg=Chtěli bychom vám připomenout, abyste zvážili použití ochrany heslem pro vaši peněženku, pokud jste ji již neaktivovali.\n\nDůrazně se také doporučuje zapsat seed slova peněženky. Tato seed slova jsou jako hlavní heslo pro obnovení vaší peněženky Monero.\nV sekci "Seed peněženky" naleznete další informace.\n\nDále byste měli zálohovat úplnou složku dat aplikace v sekci \"Záloha\".
 
-popup.xmrLocalNode.msg=Haveno zjistil, že na tomto stroji (na localhostu) běží Monero node.\n\nUjistěte se, prosím, že tento node je plně synchronizován před spuštěním Havena.
+popup.xmrLocalNode.msg=Haveno zjistil, že na tomto stroji (na localhostu) běží Monero uzel.\n\nUjistěte se, prosím, že tento uzel je plně synchronizován před spuštěním Havena.
 
 popup.shutDownInProgress.headline=Probíhá vypínání
 popup.shutDownInProgress.msg=Vypnutí aplikace může trvat několik sekund.\nProsím, nepřerušujte tento proces.
@@ -1779,10 +1779,10 @@ peerInfo.age.noRisk=Stáří platebního účtu
 peerInfo.age.chargeBackRisk=Čas od podpisu
 peerInfo.unknownAge=Stáří není známo
 
-addressTextField.openWallet=Otevřete výchozí moneroovou peněženku
+addressTextField.openWallet=Otevřete výchozí peněženku Monero
 addressTextField.copyToClipboard=Zkopírujte adresu do schránky
 addressTextField.addressCopiedToClipboard=Adresa byla zkopírována do schránky
-addressTextField.openWallet.failed=Otevření výchozí moneroové peněženky se nezdařilo. Možná nemáte žádnou nainstalovanou?
+addressTextField.openWallet.failed=Otevření výchozí peněženky Monero selhalo. Možná nemáte žádnou nainstalovanou?
 
 peerInfoIcon.tooltip={0}\nŠtítek: {1}
 
@@ -1872,7 +1872,7 @@ seed.date=Datum peněženky
 seed.restore.title=Obnovit peněženky z seed slov
 seed.restore=Obnovit peněženky
 seed.creationDate=Datum vzniku
-seed.warn.walletNotEmpty.msg=Vaše moneroová peněženka není prázdná.\n\nTuto peněženku musíte vyprázdnit, než se pokusíte obnovit starší, protože smíchání peněženek může vést ke zneplatnění záloh.\n\nDokončete své obchody, uzavřete všechny otevřené nabídky a přejděte do sekce Prostředky, kde si můžete vybrat své moneroy.\nV případě, že nemáte přístup ke svým moneroům, můžete použít nouzový nástroj k vyprázdnění peněženky.\nNouzový nástroj otevřete stisknutím kombinace kláves \"Alt+e\" nebo \"Cmd/Ctrl+e\".
+seed.warn.walletNotEmpty.msg=Vaše peněženka Monero není prázdná.\n\nTuto peněženku musíte vyprázdnit, než se pokusíte obnovit starší, protože smíchání peněženek může vést ke zneplatnění záloh.\n\nDokončete své obchody, uzavřete všechny otevřené nabídky a přejděte do sekce Prostředky, kde si můžete vybrat své moneroy.\nV případě, že nemáte přístup ke svým moneroům, můžete použít nouzový nástroj k vyprázdnění peněženky.\nNouzový nástroj otevřete stisknutím kombinace kláves \"Alt+e\" nebo \"Cmd/Ctrl+e\".
 seed.warn.walletNotEmpty.restore=Chci přesto obnovit
 seed.warn.walletNotEmpty.emptyWallet=Nejprve vyprázdním své peněženky
 seed.warn.notEncryptedAnymore=Vaše peněženky jsou šifrovány.\n\nPo obnovení již nebudou peněženky šifrovány a musíte nastavit nové heslo.\n\nChcete pokračovat?
@@ -1939,7 +1939,7 @@ shared.accountSigningState=Stav podpisu účtu
 
 #new
 payment.crypto.address.dyn={0} adresa
-payment.crypto.receiver.address=Cryptoová adresa příjemce
+payment.crypto.receiver.address=Kryptoměnová adresa příjemce
 payment.accountNr=Číslo účtu
 payment.emailOrMobile=E-mail nebo mobilní číslo
 payment.useCustomAccountName=Použijte vlastní název účtu
@@ -2080,7 +2080,7 @@ INTERAC_E_TRANSFER=Interac e-Transfer
 # suppress inspection "UnusedProperty"
 HAL_CASH=HalCash
 # suppress inspection "UnusedProperty"
-BLOCK_CHAINS=Cryptoy
+BLOCK_CHAINS=Kryptoměny
 # suppress inspection "UnusedProperty"
 PROMPT_PAY=PromptPay
 # suppress inspection "UnusedProperty"
@@ -2090,7 +2090,7 @@ TRANSFERWISE=TransferWise
 # suppress inspection "UnusedProperty"
 AMAZON_GIFT_CARD=Amazon eGift Card
 # suppress inspection "UnusedProperty"
-BLOCK_CHAINS_INSTANT=Instantní Cryptoy
+BLOCK_CHAINS_INSTANT=Instantní kryptoměny
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"
@@ -2132,7 +2132,7 @@ INTERAC_E_TRANSFER_SHORT=Interac e-Transfer
 # suppress inspection "UnusedProperty"
 HAL_CASH_SHORT=HalCash
 # suppress inspection "UnusedProperty"
-BLOCK_CHAINS_SHORT=Cryptoy
+BLOCK_CHAINS_SHORT=Kryptoměny
 # suppress inspection "UnusedProperty"
 PROMPT_PAY_SHORT=PromptPay
 # suppress inspection "UnusedProperty"
@@ -2142,7 +2142,7 @@ TRANSFERWISE_SHORT=TransferWise
 # suppress inspection "UnusedProperty"
 AMAZON_GIFT_CARD_SHORT=Amazon eGift Card
 # suppress inspection "UnusedProperty"
-BLOCK_CHAINS_INSTANT_SHORT=Instantní Cryptoy
+BLOCK_CHAINS_INSTANT_SHORT=Instantní kryptoměny
 
 # Deprecated: Cannot be deleted as it would break old trade history entries
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
It is pretty common that the node (a computer/server) is translated as uzel in czech language.
"Cryptoy" translation is a nonsense, for a cryptocurrency is used "kryptoměna" translation.

I have noticed that some variables like "shared.yourDepositTransactionId" are missing in this czech language file, but exist in original english file. As a layman user, I do not know about any convenient and fast way to merge all missing lines into a czech file so it is at a proper spot, not all at the end of file and so i can easily find and translate the merged lines. If you can not tell me the steps to do it ( I am on Linux), maybe do it yourself and i will then go through the CS file, find english strings and translate these.