### PR TITLE
Update tor-upgrade.md docu

### DIFF
--- a/docs/tor-upgrade.md
+++ b/docs/tor-upgrade.md
@@ -10,7 +10,7 @@ As per the project's authors, `netlayer` is _"essentially a wrapper around the o
 easy use and convenient integration into Kotlin/Java projects"_.
 
 Similarly, `tor-binary` is _"[the] Tor binary packaged in a way that can be used for java projects"_. The project
-unpacks the tor browser binaries to extract and repackage the tor binaries themselves.
+unpacks the Tor Browser binaries to extract and repackage the tor binaries themselves.
 
 Therefore, upgrading tor in Haveno comes down to upgrading these two artefacts.
 
@@ -22,8 +22,8 @@ Therefore, upgrading tor in Haveno comes down to upgrading these two artefacts.
 
  - Find out which tor version Haveno currently uses
    - Find out the current `netlayer` version (see `netlayerVersion` in `haveno/build.gradle`)
-   - Find that release on the project's [releases page][3]
-   - The release description says which tor version it includes
+   - Find that tag on the project's [Tags page][3]
+   - The tag description says which tor version it includes
 - Find out the latest available tor release
    - See the [official tor changelog][4]
 
@@ -32,23 +32,24 @@ Therefore, upgrading tor in Haveno comes down to upgrading these two artefacts.
 
 During this update, you will need to keep track of:
 
- - the new tor browser version
+ - the new Tor Browser version
  - the new tor binary version
 
 Create a PR for the `master` branch of [tor-binary][2] with the following changes:
 
- - Decide which tor browser version contains the desired tor binary version
-   - The official tor browser releases are here: https://dist.torproject.org/torbrowser/
- - For the chosen tor browser version, get the list of SHA256 checksums and its signature
-   - For example, for tor browser 10.0.12:
-     - https://dist.torproject.org/torbrowser/10.0.12/sha256sums-signed-build.txt
-     - https://dist.torproject.org/torbrowser/10.0.12/sha256sums-signed-build.txt.asc
+ - Decide which Tor Browser version contains the desired tor binary version
+   - The latest official Tor Browser releases are here: https://dist.torproject.org/torbrowser/
+   - All official Tor Browser releases are here: https://archive.torproject.org/tor-package-archive/torbrowser/
+ - For the chosen Tor Browser version, get the list of SHA256 checksums and its signature
+   - For example, for Tor Browser 14.0.7:
+     - https://dist.torproject.org/torbrowser/14.0.7/sha256sums-signed-build.txt
+     - https://dist.torproject.org/torbrowser/14.0.7/sha256sums-signed-build.txt.asc
  - Verify the signature of the checksums list (see [instructions][5])
  - Update the `tor-binary` checksums
    - For each file present in `tor-binary/tor-binary-resources/checksums`:
-     - Rename the file such that it reflects the new tor browser version, but preserves the naming scheme
+     - Rename the file such that it reflects the new Tor Browser version, but preserves the naming scheme
      - Update the contents of the file with the corresponding SHA256 checksum from the list
- - Update `torbrowser.version` to the new tor browser version in:
+ - Update `torbrowser.version` to the new Tor Browser version in:
    - `tor-binary/build.xml`
    - `tor-binary/pom.xml`
  - Update `version` to the new tor binary version in:
@@ -72,7 +73,7 @@ next.
 
 ### 3. Update `netlayer`
 
-Create a PR for the `externaltor` branch of [netlayer][1] with the following changes:
+Create a PR for the `master` branch of [netlayer][1] with the following changes:
 
  - In `netlayer/pom.xml`:
    - Update `tor-binary.version` to the `tor-binary` commit ID from above (e.g. `a4b868a`)
@@ -82,13 +83,13 @@ Create a PR for the `externaltor` branch of [netlayer][1] with the following cha
    - `netlayer/tor.external/pom.xml`
    - `netlayer/tor.native/pom.xml`
 
-Once the PR is merged, make a note of the commit ID in the `externaltor` branch (for example `32779ac`), as it will be
+Once the PR is merged, make a note of the commit ID in the `master` branch (for example `32779ac`), as it will be
 needed next.
 
 Create a tag for the new artefact version, having the new tor binary version as description, for example:
 
 ```
-# Create tag locally for new netlayer release, on the externaltor branch
+# Create tag locally for new netlayer release, on the master branch
 git tag -s 0.7.0 -m"tor 0.4.5.6"
 
 # Push it to netlayer repo
@@ -105,8 +106,6 @@ Create a Haveno PR with the following changes:
    - See instructions in `haveno/gradle/witness/gradle-witness.gradle`
 
 
-
-
 ## Credits
 
 Thanks to freimair, JesusMcCloud, mrosseel, sschuberth and cedricwalter for their work on the original
@@ -115,8 +114,8 @@ Thanks to freimair, JesusMcCloud, mrosseel, sschuberth and cedricwalter for thei
 
 
 
-[1]: https://github.com/bisq-network/netlayer "netlayer"
-[2]: https://github.com/bisq-network/tor-binary "tor-binary"
-[3]: https://github.com/bisq-network/netlayer/releases "netlayer releases"
+[1]: https://github.com/haveno-dex/netlayer "netlayer"
+[2]: https://github.com/haveno-dex/tor-binary "tor-binary"
+[3]: https://github.com/haveno-dex/netlayer/tags "netlayer Tags"
 [4]: https://gitweb.torproject.org/tor.git/plain/ChangeLog "tor changelog"
 [5]: https://support.torproject.org/tbb/how-to-verify-signature/ "verify tor signature"


### PR DESCRIPTION
- All links changed from bisq to haveno-dex.
- Dead links updated.
- Updated the branch used by haveno-dex
- Spelling corrected 'Tor Browser'