### PR TITLE
Final haveno-with-external-tor.sh PR

### DIFF
--- a/scripts/deployment/haveno-with-external-tor.sh
+++ b/scripts/deployment/haveno-with-external-tor.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+TORHOME="$HOME/.local/share/Haveno/xmr_mainnet/tor"
+tor -f $TORHOME/torrc --ControlPortWriteToFile $TORHOME/.tor/control.port --DisableNetwork 0
+/opt/haveno/bin/Haveno --torControlUseSafeCookieAuth --torControlCookieFile=$TORHOME/.tor/control_auth_cookie --torControlPort=$(cat $TORHOME/.tor/control.port | sed 's/.*:\([0-9]\+\)/\1/')
+kill $(cat $TORHOME/pid)


### PR DESCRIPTION
Solves Tor's AUTO controlport setting by saving the control port ( --ControlPortWriteToFile $TORHOME/.tor/control.port ) and getting it for launching haveno ( --torControlPort=$(cat $TORHOME/.tor/control.port | sed 's/.*:\([0-9]\+\)/\1/') )

Bypasses Tor's DisableNetwork 1 config (crashing Haveno at startup) with --DisableNetwork 0