### PR TITLE
Upgrade Github Runners to Ubuntu 24.04, Windows 2025

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-15, windows-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-15, windows-2025]
         include:
             - os: ubuntu-24.04
               arch: x86_64
@@ -24,7 +24,7 @@ jobs:
               arch: x86_64
             - os: macos-15
               arch: aarch64
-            - os: windows-latest
+            - os: windows-2025
               arch: x86_64
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,11 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-15, windows-latest]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-15, windows-latest]
         include:
-            - os: ubuntu-22.04
+            - os: ubuntu-24.04
               arch: x86_64
-            - os: ubuntu-22.04-arm
+            - os: ubuntu-24.04-arm
               arch: aarch64
             - os: macos-13
               arch: x86_64
@@ -38,6 +38,11 @@ jobs:
           java-version: '21'
           distribution: 'adopt'
           cache: gradle
+      - name: Create local share directory
+        # ubuntu-24.04 Github runners do not have `~/.local/share` directory by default.
+        # This causes issues when testing `FileTransferSend`
+        if: runner.os == 'Linux'
+        run: mkdir -p ~/.local/share
       - name: Build with Gradle with tests
         if: ${{ !(runner.os == 'Linux' && matrix.arch == 'aarch64') }}
         run: ./gradlew build --stacktrace --scan

--- a/.github/workflows/codacy-code-reporter.yml
+++ b/.github/workflows/codacy-code-reporter.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     if: github.repository == 'haveno-dex/haveno'
     name: Publish coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   issueLabeled:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Bounty explanation
         uses: peter-evans/create-or-update-comment@v3


### PR DESCRIPTION
Fix `FileNotFoundException` errors when running tests on Ubuntu 24.04.
Tests were failing because the user data directory did not exist in the
new GitHub Ubuntu-24.04 runner environment.

The changes:
* Updates all GitHub Actions workflows to use `ubuntu-24.04`
* Pre-emptively update Windows runner to `windows-2025`
  * `windows-latest` automatically upgrades to `server-2025` on 
    September 2, 2025 (actions/runner-images#12677)
* Creates `~/.local/share` directory in CI pipeline to ensure the user
  data directory exists during tests

This resolves the blocking issue that prevented the Ubuntu upgrade by
ensuring the required directory structure exists in the CI environment.

---

### Original PR Description:

Fix `FileTransferSender` to create temp directories during tests to
prevent `FileNotFoundException` errors when running on Ubuntu 24.04.
Tests were failing because the user data directory did not exist in the
new Github Ubuntu-24.04 Runner environment.

The change:
- Updates all GitHub Actions workflows to use `ubuntu-24.04`
- Pre-emptively update `windows-latest` to `windows-2025`
  - actions/runner-images#12677
- Modifies `FileTransferSender` to create a temporary directory when running
  tests instead of attempting to write to the user data directory
- Adds proper error handling if temp directory creation fails

This resolves the blocking issue that prevented the Ubuntu upgrade.

With regards to the missing `~/.local/share` on `ubuntu-24.04`, I can think of 2 ways to resolve this:
1. Detect that tests are being run and use an ephemeral temporary directory
2. `mkdir -p ~/.local/share` in the CI pipeline

I've opted for Option 1, but more than happy to switch to Option 2 or an alternate solution.