### PR TITLE
Add Dependabot and update GitHub Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Bounty explanation
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@v4
         if: github.event.label.name == '💰bounty'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add Dependabot configuration for weekly GitHub Actions updates and
upgrade the `peter-evans/create-or-update-comment` action to `v4`.

This ensures our GitHub Actions dependencies are automatically kept
up-to-date with security patches and new features.