### PR TITLE
Add make AppImage target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ build
 /haveno-*
 /lib
 /xchange
+/AppImage
+Haveno-*.AppImage
 desktop.ini
 */target/*
 *.class

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,24 @@ deploy-tmux:
 	# Attach to the tmux session
 	tmux attach-session -t localnet
 
-.PHONY: build seednode localnet
+APPIMAGETOOL ?= appimagetool
+AppImage:
+	rm -rf AppImage
+	./gradlew :desktop:build -x test -x checkstyleMain -x checkstyleTest
+	mkdir -p AppImage/lib AppImage/java
+	ln lib/*                                                                      AppImage/lib/
+	ln haveno-desktop desktop/package/AppRun desktop/package/linux/Haveno.desktop AppImage/
+	ln desktop/package/linux/haveno.svg                                           AppImage/exchange.haveno.Haveno.svg
+	ln desktop/package/linux/icon.png                                             AppImage/.DirIcon
+	cp -Lr ~/.sdkman/candidates/java/current/LICENSE \
+	       ~/.sdkman/candidates/java/current/bin     \
+	       ~/.sdkman/candidates/java/current/lib     \
+	       ~/.sdkman/candidates/java/current/conf    \
+	       AppImage/java/
+	rm -rf AppImage/java/lib/client/ AppImage/java/lib/src.zip
+	$(APPIMAGETOOL) AppImage
+
+.PHONY: build seednode localnet AppImage
 
 # Local network
 

--- a/desktop/package/AppRun
+++ b/desktop/package/AppRun
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+network=XMR_STAGENET
+case "$1" in
+	--mainnet)	network=XMR_MAINNET;  shift ;;
+	--stagenet)	network=XMR_STAGENET; shift ;;
+esac
+case "$network" in
+	XMR_MAINNET ) apiPort=1201; set -- "$@" --ignoreLocalXmrNode=false ;;
+	XMR_STAGENET) apiPort=3204                                         ;;
+esac
+
+JAVA_HOME="${0%/*}/java"
+export JAVA_HOME
+
+exec "${0%/*}/haveno-desktop" \
+	--baseCurrencyNetwork="$network" \
+	--useLocalhostForP2P=false \
+	--useDevPrivilegeKeys=false \
+	--nodePort=9999 \
+	--appName=Haveno \
+	--apiPassword=apitest \
+	--apiPort="$apiPort" \
+	"$@" \
+	--useNativeXmrWallet=false


### PR DESCRIPTION
This builds the desktop app, bundles sdkman java, and makes Haveno-x86_64.AppImage

The AppImage defaults to stagenet but forks can easily change the default to mainnet, and takes `--stagenet`/`--mainnet` to configure. The default arguments are copied from the Makefile targets

```
$ make AppImage APPIMAGETOOL=../appimagetool-x86_64.AppImage
rm -rf AppImage
./gradlew :desktop:build -x test -x checkstyleMain -x checkstyleTest

> Task :core:havenoDeps
Verifying existing archive /srv/haveno2/.localnet/monero-bins-haveno-linux-x86_64.tar.gz
Existing archive matches hash

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.6/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 2s
27 actionable tasks: 1 executed, 26 up-to-date
mkdir -p AppImage/lib AppImage/java
ln lib/*                                                                      AppImage/lib/
ln haveno-desktop desktop/package/AppRun desktop/package/linux/Haveno.desktop AppImage/
ln desktop/package/linux/haveno.svg                                           AppImage/exchange.haveno.Haveno.svg
ln desktop/package/linux/icon.png                                             AppImage/.DirIcon
cp -Lr ~/.sdkman/candidates/java/current/LICENSE \
       ~/.sdkman/candidates/java/current/bin     \
       ~/.sdkman/candidates/java/current/lib     \
       ~/.sdkman/candidates/java/current/conf    \
       AppImage/java/
rm -rf AppImage/java/lib/client/ AppImage/java/lib/src.zip
../appimagetool-x86_64.AppImage AppImage
appimagetool, continuous build (git version 7cfafc4), build 251 built on 2025-06-01 16:06:33 UTC
WARNING: appstreamcli command is missing, please install it if you want to use AppStream metadata
WARNING: gpg2 or gpg command is missing, please install it if you want to create digital signatures
/srv/haveno2/AppImage/Haveno.desktop: hint: value item "P2P" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Network
Using architecture x86_64
/srv/haveno2/AppImage should be packaged as Haveno-x86_64.AppImage
WARNING: AppStream upstream metadata is missing, please consider creating it
         in usr/share/metainfo/Haveno.appdata.xml
         Please see https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps
         for more information or use the generator at
         https://docs.appimage.org/packaging-guide/optional/appstream.html#using-the-appstream-generator
Generating squashfs...
Downloading runtime file from https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64
Downloaded runtime binary of size 944632
Parallel mksquashfs: Using 24 processors
Creating 4.0 filesystem on Haveno-x86_64.AppImage, block size 131072.
[=========================================================================================================================================================|] 4496/4496 100%

Exportable Squashfs 4.0 filesystem, zstd compressed, data block size 131072
        compressed data, compressed metadata, compressed fragments,
        compressed xattrs, compressed ids
        duplicates are removed
Filesystem size 294059.34 Kbytes (287.17 Mbytes)
        52.89% of uncompressed filesystem size (555990.10 Kbytes)
Inode table size 11423 bytes (11.16 Kbytes)
        45.51% of uncompressed inode table size (25100 bytes)
Directory table size 3035 bytes (2.96 Kbytes)
        48.11% of uncompressed directory table size (6309 bytes)
Number of duplicate files found 3
Number of inodes 241
Number of files 225
Number of fragments 41
Number of symbolic links 0
Number of device nodes 0
Number of fifo nodes 0
Number of socket nodes 0
Number of directories 16
Number of hard-links 0
Number of ids (unique uids + gids) 1
Number of uids 1
        root (0)
Number of gids 1
        root (0)
Embedding ELF...
Marking the AppImage as executable...
Embedding MD5 digest
Success

Please consider submitting your AppImage to AppImageHub, the crowd-sourced
central directory of available AppImages, by opening a pull request
at https://github.com/AppImage/appimage.github.io
```
```
$ du -h Haveno-x86_64.AppImage
288.1M  Haveno-x86_64.AppImage
$ ./Haveno-x86_64.AppImage
Jun-18 19:11:21.540 [main] INFO  haveno.common.util.Utilities: System info: os.name=Linux; os.version=6.1.0-27-amd64; os.arch=amd64; sun.arch.data.model=64; JRE=21.0.2+14-LTS (BellSoft); JVM=21.0.2+14-LTS (OpenJDK 64-Bit Server VM)
Jun-18 19:11:21.604 [main] INFO  haveno.common.app.AsciiLogo:
...
```

Closes: #270