### PR TITLE
Migrate MacOS 13 to 15-intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-15, windows-2025]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15-intel, macos-15, windows-2025]
         include:
             - os: ubuntu-24.04
               arch: x86_64
             - os: ubuntu-24.04-arm
               arch: aarch64
-            - os: macos-13
+            - os: macos-15-intel
               arch: x86_64
             - os: macos-15
               arch: aarch64


### PR DESCRIPTION
`macos-13` is being retired on December 4th 2025

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

Migrate to `macos-15-intel` to maintain x86_64 MacOS builds.