### PR TITLE
Update freedesktop rt version in exchange.haveno.Haveno.yml

### DIFF
--- a/desktop/package/linux/exchange.haveno.Haveno.yml
+++ b/desktop/package/linux/exchange.haveno.Haveno.yml
@@ -1,6 +1,6 @@
 id: exchange.haveno.Haveno
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "24.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk21


### PR DESCRIPTION
Bump rt version from EOLed 23.08 -> 24.08

Should address: https://github.com/haveno-dex/haveno/issues/2006