### PR TITLE
Revert "show number of offers in payment method pulldown (#2032)"

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBook.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBook.java
@@ -232,22 +232,15 @@ public class OfferBook {
         buyOfferCountMap.clear();
         sellOfferCountMap.clear();
         final String[] ccyCode = new String[1];
-        final String[] paymentMethod = new String[1];
         final int[] offerCount = new int[1];
-        final int[] paymentMethodOfferCount = new int[1];
         offerBookListItems.forEach(o -> {
-            paymentMethod[0] = o.getOffer().getPaymentMethod().getId();
             ccyCode[0] = o.getOffer().getCounterCurrencyCode();
             if (o.getOffer().getDirection() == BUY) {
                 offerCount[0] = buyOfferCountMap.getOrDefault(ccyCode[0], 0) + 1;
-                paymentMethodOfferCount[0] = buyOfferCountMap.getOrDefault(paymentMethod[0], 0) + 1;
                 buyOfferCountMap.put(ccyCode[0], offerCount[0]);
-                buyOfferCountMap.put(paymentMethod[0], paymentMethodOfferCount[0]);
             } else {
                 offerCount[0] = sellOfferCountMap.getOrDefault(ccyCode[0], 0) + 1;
-                paymentMethodOfferCount[0] = sellOfferCountMap.getOrDefault(paymentMethod[0], 0) + 1;
                 sellOfferCountMap.put(ccyCode[0], offerCount[0]);
-                sellOfferCountMap.put(paymentMethod[0], paymentMethodOfferCount[0]);
             }
         });
         log.debug("buyOfferCountMap.size {}   sellOfferCountMap.size {}",

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookView.java
@@ -183,6 +183,7 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         Tuple3<VBox, Label, AutocompleteComboBox<PaymentMethod>> paymentBoxTuple = FormBuilder.addTopLabelAutocompleteComboBox(
                 Res.get("offerbook.filterByPaymentMethod"));
         paymentMethodComboBox = paymentBoxTuple.third;
+        paymentMethodComboBox.setCellFactory(GUIUtil.getPaymentMethodCellFactory());
         paymentMethodComboBox.setPrefWidth(250);
         paymentMethodComboBox.getStyleClass().add("input-with-border");
 
@@ -381,10 +382,6 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
                 volumeColumn.setComparator(Comparator.comparing(o -> o.getOffer().getMinVolume(), Comparator.nullsFirst(Comparator.naturalOrder())));
             }
         });
-
-        paymentMethodComboBox.setCellFactory(GUIUtil.getPaymentMethodCellFactory(Res.get("shared.oneOffer"),
-                Res.get("shared.multipleOffers"),
-                offerCounts));
 
         paymentMethodComboBox.setConverter(new PaymentMethodStringConverter(paymentMethodComboBox));
         paymentMethodComboBox.getEditor().getStyleClass().add("combo-box-editor-bold");

--- a/desktop/src/main/java/haveno/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/haveno/desktop/util/GUIUtil.java
@@ -561,9 +561,7 @@ public class GUIUtil {
         };
     }
 
-    public static Callback<ListView<PaymentMethod>, ListCell<PaymentMethod>> getPaymentMethodCellFactory(String postFixSingle,
-                                                                                                         String postFixMulti,
-                                                                                                         Map<String, Integer> offerCounts) {
+    public static Callback<ListView<PaymentMethod>, ListCell<PaymentMethod>> getPaymentMethodCellFactory() {
         return p -> new ListCell<>() {
             @Override
             protected void updateItem(PaymentMethod method, boolean empty) {
@@ -574,24 +572,16 @@ public class GUIUtil {
 
                     HBox box = new HBox();
                     box.setSpacing(20);
-                    box.setAlignment(Pos.CENTER_LEFT);
                     Label paymentType = new AutoTooltipLabel(getCurrencyType(method));
                     paymentType.getStyleClass().add("currency-label-small");
                     Label paymentMethod = new AutoTooltipLabel(Res.get(id));
                     paymentMethod.getStyleClass().add("currency-label");
-                    Label numOffersLabel = new AutoTooltipLabel();
-                    box.getChildren().addAll(paymentType, paymentMethod, numOffersLabel);
+                    box.getChildren().addAll(paymentType, paymentMethod);
 
                     if (id.equals(GUIUtil.SHOW_ALL_FLAG)) {
                         paymentType.setText(Res.get("shared.all"));
                         paymentMethod.setText(Res.get("list.currency.showAll"));
                     }
-                    Optional<Integer> offerCountOptional = Optional.ofNullable(offerCounts.get(id));
-                    offerCountOptional.ifPresent(numOffers -> {
-                        HBox.setMargin(numOffersLabel, new Insets(0, 0, 0, NUM_OFFERS_TRANSLATE_X));
-                        numOffersLabel.getStyleClass().add("offer-label");
-                        numOffersLabel.setText(numOffers + " " + (numOffers == 1 ? postFixSingle : postFixMulti));
-                    });
 
                     setGraphic(box);
 


### PR DESCRIPTION
Reverts #2032 due to a bug calculating the number of payment methods for the selected currencies.