### PR TITLE
add or remove trade state listeners on jfx thread

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesDataModel.java
@@ -320,12 +320,12 @@ public class PendingTradesDataModel extends ActivatableDataModel {
             for (Trade trade : tradeManager.getObservableList()) {
                 if (isTradeShown(trade)) {
                     if (hiddenTrades.contains(trade)) {
-                        trade.stateProperty().removeListener(hiddenStateChangeListener);
+                        UserThread.execute(() -> trade.stateProperty().removeListener(hiddenStateChangeListener));
                         hiddenTrades.remove(trade);
                     }
                 } else {
                     if (!hiddenTrades.contains(trade)) {
-                        trade.stateProperty().addListener(hiddenStateChangeListener);
+                        UserThread.execute(() -> trade.stateProperty().addListener(hiddenStateChangeListener));
                         hiddenTrades.add(trade);
                     }
                 }
@@ -390,7 +390,7 @@ public class PendingTradesDataModel extends ActivatableDataModel {
                     takerTxId.set(nullToEmptyString(takerDepositTxHash));
                     if (makerDepositTxHash != null || takerDepositTxHash != null) {
                         notificationCenter.setSelectedTradeId(tradeId);
-                        selectedTrade.stateProperty().removeListener(tradeStateChangeListener);
+                        UserThread.execute(() -> selectedTrade.stateProperty().removeListener(tradeStateChangeListener));
                     }
                 };
                 selectedTrade.stateProperty().addListener(tradeStateChangeListener);

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -544,9 +544,12 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
                 chatPopupStage.xProperty().removeListener(yPositionListener);
             }
 
-            trade.stateProperty().removeListener(tradeStateListener);
-            trade.disputeStateProperty().addListener(disputeStateListener);
-            trade.mediationResultStateProperty().addListener(mediationResultStateListener);
+            UserThread.execute(() -> {
+                trade.stateProperty().removeListener(tradeStateListener);
+                trade.disputeStateProperty().addListener(disputeStateListener);
+                trade.mediationResultStateProperty().addListener(mediationResultStateListener);
+            });
+
             traderChatManager.requestPersistence();
         });
 


### PR DESCRIPTION
Avoids a reported bug when setting the trade state property, likely due to adding a removing listeners concurrently with setting trade state.