### PR TITLE
Fix delete and backup account on windows

### DIFF
--- a/common/src/main/java/haveno/common/app/Log.java
+++ b/common/src/main/java/haveno/common/app/Log.java
@@ -23,6 +23,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.filter.ThresholdFilter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
@@ -37,6 +38,10 @@ public class Log {
     }
 
     public static void setup(String fileName) {
+        if (logbackLogger != null) {
+            stopFileLogging();
+        }
+
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 
         RollingFileAppender<ILoggingEvent> appender = new RollingFileAppender<>();
@@ -107,5 +112,21 @@ public class Log {
 
     public static void setCustomLogLevel(String pattern, Level logLevel) {
         ((Logger) LoggerFactory.getLogger(pattern)).setLevel(logLevel);
+    }
+
+    public static void stopFileLogging() {
+        var context = logbackLogger.getLoggerContext();
+
+        for (Logger logger : context.getLoggerList()) {
+            var iteratorForAppenders = logger.iteratorForAppenders();
+            while (iteratorForAppenders.hasNext()) {
+                var appender = iteratorForAppenders.next();
+                if (appender instanceof FileAppender) {
+                    logger.detachAppender(appender);
+                    appender.stop();
+                    System.out.println("Released: " + ((FileAppender<?>) appender).getFile());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This fixes a few things. When deleting an account, the logger gets stopped to release those files and then started after the delete regardless of whether it succeeded or not. Also, key files were not being released so I have updated those file streams to use try with resources.

I have also included a fix for account backup which failed to zip some files as they were locked due to the account being open.