### PR TITLE
Add Accepted Countries and City to OfferInfo (#2101)

### DIFF
--- a/core/src/main/java/haveno/core/api/model/OfferInfo.java
+++ b/core/src/main/java/haveno/core/api/model/OfferInfo.java
@@ -27,6 +27,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Optional;
 
 import static haveno.core.util.PriceUtil.reformatMarketPrice;
@@ -80,6 +81,8 @@ public class OfferInfo implements Payload {
     private final boolean isPrivateOffer;
     private final String challenge;
     private final String extraInfo;
+    private final List<String> acceptedCountryCodes;
+    private final String city;
 
     public OfferInfo(OfferInfoBuilder builder) {
         this.id = builder.getId();
@@ -116,6 +119,8 @@ public class OfferInfo implements Payload {
         this.isPrivateOffer = builder.isPrivateOffer();
         this.challenge = builder.getChallenge();
         this.extraInfo = builder.getExtraInfo();
+        this.acceptedCountryCodes = builder.getAcceptedCountryCodes();
+        this.city = builder.getCity();
     }
 
     public static OfferInfo toOfferInfo(Offer offer) {
@@ -185,7 +190,9 @@ public class OfferInfo implements Payload {
                 .withArbitratorSigner(offer.getOfferPayload().getArbitratorSigner() == null ? null : offer.getOfferPayload().getArbitratorSigner().getFullAddress())
                 .withIsPrivateOffer(offer.isPrivateOffer())
                 .withChallenge(offer.getChallenge())
-                .withExtraInfo(offer.getCombinedExtraInfo());
+                .withExtraInfo(offer.getCombinedExtraInfo())
+                .withAcceptedCountryCodes(offer.getAcceptedCountryCodes())
+                .withCity(offer.getF2FCity());
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -229,6 +236,8 @@ public class OfferInfo implements Payload {
         Optional.ofNullable(splitOutputTxHash).ifPresent(builder::setSplitOutputTxHash);
         Optional.ofNullable(challenge).ifPresent(builder::setChallenge);
         Optional.ofNullable(extraInfo).ifPresent(builder::setExtraInfo);
+        Optional.ofNullable(acceptedCountryCodes).ifPresent(builder::addAllAcceptedCountryCodes);
+        builder.setCity(city == null ? "" : city);
         return builder.build();
     }
 
@@ -269,6 +278,8 @@ public class OfferInfo implements Payload {
                 .withIsPrivateOffer(proto.getIsPrivateOffer())
                 .withChallenge(proto.getChallenge())
                 .withExtraInfo(proto.getExtraInfo())
+                .withAcceptedCountryCodes(proto.getAcceptedCountryCodesList())
+                .withCity(proto.getCity())
                 .build();
     }
 }

--- a/core/src/main/java/haveno/core/api/model/builder/OfferInfoBuilder.java
+++ b/core/src/main/java/haveno/core/api/model/builder/OfferInfoBuilder.java
@@ -18,6 +18,7 @@
 package haveno.core.api.model.builder;
 
 import haveno.core.api.model.OfferInfo;
+import java.util.List;
 import lombok.Getter;
 
 /*
@@ -66,6 +67,8 @@ public final class OfferInfoBuilder {
     private boolean isPrivateOffer;
     private String challenge;
     private String extraInfo;
+    private List<String> acceptedCountryCodes;
+    private String city;
 
     public OfferInfoBuilder withId(String id) {
         this.id = id;
@@ -249,6 +252,16 @@ public final class OfferInfoBuilder {
 
     public OfferInfoBuilder withExtraInfo(String extraInfo) {
         this.extraInfo = extraInfo;
+        return this;
+    }
+
+    public OfferInfoBuilder withAcceptedCountryCodes(List<String> acceptedCountryCodes) {
+        this.acceptedCountryCodes = acceptedCountryCodes;
+        return this;
+    }
+
+    public OfferInfoBuilder withCity(String city) {
+        this.city = city;
         return this;
     }
 

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -612,6 +612,8 @@ message OfferInfo {
     bool is_private_offer = 32;
     string challenge = 33;
     string extra_info = 34;
+    repeated string accepted_country_codes = 35;
+    string city = 36;
 }
 
 message AvailabilityResultWithDescription {


### PR DESCRIPTION
This pull request implements issue #2101 by exposing "Accepted Countries" and "City" fields through the gRPC API"s OfferInfo model. These fields are essential for providing more detailed offer information to API consumers.

Changes:
- grpc.proto: Added repeated string accepted_country_codes and string city to the OfferInfo message.
- OfferInfo.java and OfferInfoBuilder.java:
  - Updated the API model to include the new fields.
  - Implemented mapping logic to extract data from the internal Offer and OfferPayload objects.
  - Integrated with gRPC serialization/deserialization logic.

Verification:
The project was compiled successfully using Gradle (Task :core:compileJava) to ensure that the new protobuf fields and Java mappings are correctly integrated.