### PR TITLE
Workaround #2099, #2100: Prevent NPE in JFXTextFieldSkinHavenoStyle

### DIFF
--- a/desktop/src/main/java/haveno/desktop/components/JFXTextFieldSkinHavenoStyle.java
+++ b/desktop/src/main/java/haveno/desktop/components/JFXTextFieldSkinHavenoStyle.java
@@ -90,6 +90,11 @@ public class JFXTextFieldSkinHavenoStyle<T extends TextField & IFXLabelFloatCont
 
 
     private void updateTextPos() {
+        // Guard against null textNode (can happen during early initialization)
+        if (textNode == null) {
+            return;
+        }
+        
         double textWidth = textNode.getLayoutBounds().getWidth();
         final double promptWidth = promptText == null ? 0 : promptText.getLayoutBounds().getWidth();
         switch (getSkinnable().getAlignment().getHpos()) {


### PR DESCRIPTION
Fixes #2099 
Fixes #2100

Problem:
When running Haveno built from source (`./gradlew run`), crashes occur: Cannot invoke "getLayoutBounds()" because "this.textNode" is null at JFXTextFieldSkinHavenoStyle.updateTextPos():93

this issue in my case, breaks the UI, but works well after the fix.

Does not occur when using the installer package!!!

Solution:
Add defensive null check  if `textNode` not initialized, return early.

<img width="1202" height="740" alt="Screenshot 2026-01-07 at 11 49 34 PM" src="https://github.com/user-attachments/assets/146c7f7c-aee2-4670-be4b-59c808ade090" />
Testing
- Compiled and ran via gradle for 90+ seconds
- No NPE errors
- UI renders correctly