### PR TITLE
(gRPC API) Fix IsMyOffer field

### DIFF
--- a/core/src/main/java/haveno/core/api/model/OfferInfo.java
+++ b/core/src/main/java/haveno/core/api/model/OfferInfo.java
@@ -150,6 +150,7 @@ public class OfferInfo implements Payload {
                 .withSplitOutputTxHash(openOffer.getSplitOutputTxHash())
                 .withSplitOutputTxFee(openOffer.getSplitOutputTxFee())
                 .withChallenge(openOffer.getChallenge())
+                .withIsMyOffer(true)
                 .build();
     }
 


### PR DESCRIPTION
When calling the GetMyOffer or GetMyOffers endpoints, the IsMyOffer field in OfferInfo would have the default value of false when it should be true