### PR TITLE
ui: adjust default displayed cryptos based on usage

### DIFF
--- a/core/src/main/java/haveno/core/locale/CurrencyUtil.java
+++ b/core/src/main/java/haveno/core/locale/CurrencyUtil.java
@@ -198,15 +198,11 @@ public class CurrencyUtil {
         final List<CryptoCurrency> result = new ArrayList<>();
         result.add(new CryptoCurrency("BTC", "Bitcoin"));
         result.add(new CryptoCurrency("BCH", "Bitcoin Cash"));
-        result.add(new CryptoCurrency("DOGE", "Dogecoin"));
         result.add(new CryptoCurrency("ETH", "Ether"));
         result.add(new CryptoCurrency("LTC", "Litecoin"));
-        result.add(new CryptoCurrency("XRP", "Ripple"));
-        result.add(new CryptoCurrency("ADA", "Cardano"));
-        result.add(new CryptoCurrency("SOL", "Solana"));
-        result.add(new CryptoCurrency("TRX", "Tron"));
         result.add(new CryptoCurrency("DAI-ERC20", "Dai Stablecoin"));
         result.add(new CryptoCurrency("USDT-ERC20", "Tether USD"));
+        result.add(new CryptoCurrency("USDT-TRC20", "Tether USD"));
         result.add(new CryptoCurrency("USDC-ERC20", "USD Coin"));
         result.sort(TradeCurrency::compareTo);
         return result;


### PR DESCRIPTION
These are displayed by default:

- BTC
- BCH
- ETH
- LTC
- DAI-ERC20
- USDT-ERC20
- USDT-TRC20
- USDC-ERC20

And these are hidden by default:

- ADA
- DOGE
- XRP
- SOL
- TRX