### PR TITLE
core: switch daemon nodes immediately on tx daemon errors

### DIFF
--- a/core/src/main/java/haveno/core/trade/HavenoUtils.java
+++ b/core/src/main/java/haveno/core/trade/HavenoUtils.java
@@ -674,6 +674,14 @@ public class HavenoUtils {
         return t != null && t.getMessage() != null && t.getMessage().contains("Read timed out");
     }
 
+    public static boolean isDaemonConnectionIssue(Throwable t) {
+        if (t == null || t.getMessage() == null) return false;
+        String message = t.getMessage().toLowerCase(Locale.ROOT);
+        return message.contains("no connection to daemon") ||
+                message.contains("failed to get output distribution") ||
+                message.contains("failed to get height");
+    }
+
     public static boolean isUnresponsive(Throwable t) {
         return isConnectionRefused(t) || isReadTimeout(t) || XmrWalletBase.isSyncWithProgressTimeout(t);
     }

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
@@ -1911,8 +1911,11 @@ public class XmrWalletService extends XmrWalletBase {
     }
 
     public void handleMainWalletError(Exception e, MoneroRpcConnection sourceConnection, int numAttempts) {
+        boolean daemonConnectionIssue = HavenoUtils.isDaemonConnectionIssue(e);
         if (HavenoUtils.isUnresponsive(e)) forceCloseMainWallet(); // wallet can be stuck a while
-        if (numAttempts % TradeProtocol.REQUEST_CONNECTION_SWITCH_EVERY_NUM_ATTEMPTS == 0) requestConnectionSwitchSynchronous(sourceConnection); // request connection switch every n attempts
+        if (daemonConnectionIssue || numAttempts % TradeProtocol.REQUEST_CONNECTION_SWITCH_EVERY_NUM_ATTEMPTS == 0) {
+            requestConnectionSwitchSynchronous(sourceConnection);
+        }
         initMainWallet();
     }
 

--- a/core/src/test/java/haveno/core/trade/HavenoUtilsTest.java
+++ b/core/src/test/java/haveno/core/trade/HavenoUtilsTest.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.trade;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HavenoUtilsTest {
+
+    @Test
+    public void detectsDaemonConnectionIssuesFromKnownMessages() {
+        assertTrue(HavenoUtils.isDaemonConnectionIssue(new RuntimeException("no connection to daemon")));
+        assertTrue(HavenoUtils.isDaemonConnectionIssue(new RuntimeException("failed to get output distribution")));
+        assertTrue(HavenoUtils.isDaemonConnectionIssue(new RuntimeException("Failed to get height")));
+    }
+
+    @Test
+    public void ignoresUnrelatedMessages() {
+        assertFalse(HavenoUtils.isDaemonConnectionIssue(new RuntimeException("Not enough money")));
+        assertFalse(HavenoUtils.isDaemonConnectionIssue(new RuntimeException("Read timed out")));
+        assertFalse(HavenoUtils.isDaemonConnectionIssue(new RuntimeException((String) null)));
+        assertFalse(HavenoUtils.isDaemonConnectionIssue(null));
+    }
+}


### PR DESCRIPTION
Fixes #1093.

This change treats the daemon-side tx creation failures named in the issue as connection failures instead of waiting for the generic every-N-attempts node rotation.

What changed:
- add `HavenoUtils.isDaemonConnectionIssue()` for `no connection to daemon`, `failed to get output distribution`, and `failed to get height`
- switch to the next best daemon immediately when `handleMainWalletError()` sees one of those failures
- add a focused unit test for the classifier

Why this direction:
- callers already retry tx creation, so the useful gap here is faster node rotation when the current daemon has already shown the exact failure signatures from #1093
- this keeps the fix small and aligned with the issue feedback that previous PRs should target connection handling rather than add another retry layer

Verification:
- `./gradlew :core:test --tests haveno.core.trade.HavenoUtilsTest`