### PR TITLE
fix(wallet): extend SYNC_TIMEOUT_MS to handle high-latency Tor connections

### DIFF
--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletBase.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletBase.java
@@ -33,7 +33,7 @@ public abstract class XmrWalletBase {
 
     // constants
     protected static final int MAX_SYNC_ATTEMPTS = 5;
-    protected static final long SYNC_TIMEOUT_MS = 180000;
+    protected static final long SYNC_TIMEOUT_MS = 1800000;
     private static final String SYNC_TIMEOUT_MSG = "Sync timeout called";
     private static final String RECEIVED_ERROR_RESPONSE_MSG = "Received error response from RPC request";
     private static final long SAVE_AFTER_ELAPSED_SECONDS = 300;


### PR DESCRIPTION
### Description
This PR strictly addresses the 2-year-old Tor/remote node read-timeout bug within `XmrWalletBase.java`.

### Root Cause Analysis
During heavy operations like fetching ring signatures or output distributions (`get_output_distribution`) over highly latent Tor (.onion) networks, remote daemons often take longer than 3 minutes to process and stream the response blocks. The current hardcoded `SYNC_TIMEOUT_MS = 180000` (3 minutes) forces a premature `RuntimeException` on line 104, cutting the socket and triggering false-positive "no connection to daemon" errors in the UI, despite the remote node being fully operational.

### Solution
Extended `SYNC_TIMEOUT_MS` from 3 minutes to 30 minutes (`1800000` ms) to allow highly latent anonymous routing networks ample time to successfully propagate heavy blockchain state requests without throwing unhandled exceptions. Built and verified successfully using Gradle. Please review the single-line diff objectively.