### PR TITLE
core: use milliseconds for all price timestamps

### DIFF
--- a/core/src/main/java/haveno/core/provider/price/MarketPrice.java
+++ b/core/src/main/java/haveno/core/provider/price/MarketPrice.java
@@ -24,18 +24,18 @@ import java.time.Instant;
 
 @Value
 public class MarketPrice {
-    public static final long MARKET_PRICE_MAX_AGE_SEC = 1800;  // 30 min
+    public static final long MARKET_PRICE_MAX_AGE_MS = 30 * 60 * 1000L;  // 30 min
 
     private final String currencyCode;
     private final double price;
-    private final long timestampSec;
+    private final long timestampMs;
     @Getter
     private final boolean isExternallyProvidedPrice;
 
-    public MarketPrice(String currencyCode, double price, long timestampSec, boolean isExternallyProvidedPrice) {
+    public MarketPrice(String currencyCode, double price, long timestampMs, boolean isExternallyProvidedPrice) {
         this.currencyCode = currencyCode;
         this.price = price;
-        this.timestampSec = timestampSec;
+        this.timestampMs = timestampMs;
         this.isExternallyProvidedPrice = isExternallyProvidedPrice;
     }
 
@@ -44,7 +44,7 @@ public class MarketPrice {
     }
 
     public boolean isRecentPriceAvailable() {
-        return isPriceAvailable() && timestampSec > (Instant.now().getEpochSecond() - MARKET_PRICE_MAX_AGE_SEC);
+        return isPriceAvailable() && timestampMs > (Instant.now().toEpochMilli() - MARKET_PRICE_MAX_AGE_MS);
     }
 
     public boolean isRecentExternalPriceAvailable() {

--- a/core/src/main/java/haveno/core/provider/price/PriceFeedService.java
+++ b/core/src/main/java/haveno/core/provider/price/PriceFeedService.java
@@ -420,8 +420,8 @@ public class PriceFeedService {
                             result = true;
                         } else {
                             errorMessage = "Price for currency " + currencyCode + " is outdated by " +
-                                    (Instant.now().getEpochSecond() - marketPrice.getTimestampSec()) / 60 + " minutes. " +
-                                    "Max. allowed age of price is " + MarketPrice.MARKET_PRICE_MAX_AGE_SEC / 60 + " minutes. " +
+                                    (Instant.now().toEpochMilli() - marketPrice.getTimestampMs()) / 1000 / 60 + " minutes. " +
+                                    "Max. allowed age of price is " + MarketPrice.MARKET_PRICE_MAX_AGE_MS / 1000 / 60 + " minutes. " +
                                     "priceProvider=" + baseUrl + ". " +
                                     "marketPrice= " + marketPrice;
                         }

--- a/core/src/main/java/haveno/core/provider/price/PriceProvider.java
+++ b/core/src/main/java/haveno/core/provider/price/PriceProvider.java
@@ -74,8 +74,8 @@ public class PriceProvider extends HttpClientProvider {
                 counterCurrencyCode = CurrencyUtil.getCurrencyCodeBase(counterCurrencyCode);
                 double price = (Double) treeMap.get("price");
                 if (isInverted) price = BigDecimal.ONE.divide(BigDecimal.valueOf(price), 10, RoundingMode.HALF_UP).doubleValue(); // XMR is always base currency, so invert price if applicable
-                long timestampSec = MathUtils.doubleToLong((Double) treeMap.get("timestampSec"));
-                marketPriceMap.put(counterCurrencyCode, new MarketPrice(counterCurrencyCode, price, timestampSec, true));
+                long timestampMs = MathUtils.doubleToLong((Double) treeMap.get("timestampMs"));
+                marketPriceMap.put(counterCurrencyCode, new MarketPrice(counterCurrencyCode, price, timestampMs, true));
             } catch (Throwable t) {
                 log.error("Error getting all prices: {}\n", t.getMessage(), t);
             }

--- a/desktop/src/main/java/haveno/desktop/main/MainView.java
+++ b/desktop/src/main/java/haveno/desktop/main/MainView.java
@@ -533,7 +533,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>  {
         return Res.get("mainView.marketPrice.tooltip",
                 "Haveno Price Index for " + selectedCurrencyCode,
                 "",
-                selectedMarketPrice != null ? DisplayUtils.formatTime(new Date(selectedMarketPrice.getTimestampSec())) : Res.get("shared.na"),
+                selectedMarketPrice != null ? DisplayUtils.formatTime(new Date(selectedMarketPrice.getTimestampMs())) : Res.get("shared.na"),
                 model.getPriceFeedService().getProviderNodeAddress());
     }
 

--- a/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
+++ b/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
@@ -96,7 +96,7 @@ public class CreateOfferViewModelTest {
         when(priceFeedService.getMarketPrice(anyString())).thenReturn(
                 new MarketPrice("USD",
                         12684.0450,
-                        Instant.now().getEpochSecond(),
+                        Instant.now().toEpochMilli(),
                         true));
         when(user.findFirstPaymentAccountWithCurrency(any())).thenReturn(paymentAccount);
         when(paymentAccount.getPaymentMethod()).thenReturn(PaymentMethod.ZELLE);

--- a/desktop/src/test/java/haveno/desktop/main/offer/offerbook/OfferBookViewModelTest.java
+++ b/desktop/src/test/java/haveno/desktop/main/offer/offerbook/OfferBookViewModelTest.java
@@ -428,7 +428,7 @@ public class OfferBookViewModelTest {
 
         final ObservableList<OfferBookListItem> offerBookListItems = FXCollections.observableArrayList();
         when(offerBook.getOfferBookListItems()).thenReturn(offerBookListItems);
-        when(priceFeedService.getMarketPrice(anyString())).thenReturn(new MarketPrice("USD", 12684.0450, Instant.now().getEpochSecond(), true));
+        when(priceFeedService.getMarketPrice(anyString())).thenReturn(new MarketPrice("USD", 12684.0450, Instant.now().toEpochMilli(), true));
 
         final OfferBookViewModel model = new FiatOfferBookViewModel(user, openOfferManager, offerBook, empty, null, null, null,
                 null, null, null, getPriceUtil(), null, coinFormatter, null);


### PR DESCRIPTION
Depends on https://github.com/haveno-dex/haveno-pricenode/pull/55 to be operational.