### PR TITLE
Parse host instead of substring-matching "localhost" when deciding to bypass the proxy

### DIFF
--- a/p2p/src/main/java/haveno/network/http/HttpClientImpl.java
+++ b/p2p/src/main/java/haveno/network/http/HttpClientImpl.java
@@ -141,10 +141,26 @@ public class HttpClientImpl implements HttpClient {
 
         hasPendingRequest = true;
         Socks5Proxy socks5Proxy = getSocks5Proxy(socks5ProxyProvider);
-        if (ignoreSocks5Proxy || socks5Proxy == null || baseUrl.contains("localhost")) {
+        if (ignoreSocks5Proxy || socks5Proxy == null || isLoopbackUrl(baseUrl)) {
             return requestWithoutProxy(baseUrl, param, httpMethod, headerKey, headerValue);
         } else {
             return doRequestWithProxy(baseUrl, param, httpMethod, socks5Proxy, headerKey, headerValue);
+        }
+    }
+
+    // Returns true only if the URL's host is a loopback/localhost literal. We parse the host rather
+    // than substring-matching "localhost" on the whole URL, otherwise a host like
+    // "localhost.example.com" (or any URL containing the word) would bypass the Tor proxy and leak
+    // the real IP. Fails closed (returns false -> request goes through the proxy) if parsing fails.
+    static boolean isLoopbackUrl(String url) {
+        try {
+            String host = new java.net.URI(url).getHost();
+            if (host == null) return false;
+            if (host.startsWith("[") && host.endsWith("]")) host = host.substring(1, host.length() - 1);
+            host = host.toLowerCase();
+            return host.equals("localhost") || host.equals("::1") || host.startsWith("127.");
+        } catch (Exception e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
Follow-up to #2347 with the fix.

`HttpClientImpl.doRequest()` decided whether to skip the Tor SOCKS proxy with
`baseUrl.contains("localhost")`, which is a substring match on the whole URL. So a base
URL like `http://localhost.example.com/...` (or anything with that word in it) skipped the
proxy and went out directly, which leaks the real IP for a Tor-only app. The reverse was
also wrong — a `http://127.0.0.1:...` node didn't match and got forced through Tor.

This parses the URI host and only treats real loopback literals (`localhost`, `::1`,
`127.0.0.0/8`) as local, and fails closed (uses the proxy) if the URL can't be parsed. I
kept the check local to `HttpClientImpl` to avoid a p2p→core dependency on
`HavenoUtils.isLocalHost`.

Happy to adjust (e.g. tighten the IPv6 handling) if you'd prefer.

Made with [Cursor](https://cursor.com)