### PR TITLE
fix: prevent OOM from causing trade history data loss

### DIFF
--- a/common/src/main/java/haveno/common/crypto/Encryption.java
+++ b/common/src/main/java/haveno/common/crypto/Encryption.java
@@ -17,7 +17,6 @@
 
 package haveno.common.crypto;
 
-import haveno.common.util.Hex;
 import haveno.common.util.Utilities;
 import java.io.ByteArrayOutputStream;
 import java.security.InvalidKeyException;
@@ -141,15 +140,12 @@ public class Encryption {
 
     public static byte[] decryptPayloadWithHmac(byte[] encryptedPayloadWithHmac, SecretKey secretKey) throws CryptoException {
         byte[] payloadWithHmac = decrypt(encryptedPayloadWithHmac, secretKey);
-        String payloadWithHmacAsHex = Hex.encode(payloadWithHmac);
-        // first part is raw message
-        int length = payloadWithHmacAsHex.length();
-        int sep = length - 64;
-        String payloadAsHex = payloadWithHmacAsHex.substring(0, sep);
-        // last 64 bytes is hmac
-        String hmacAsHex = payloadWithHmacAsHex.substring(sep, length);
-        if (verifyHmac(Hex.decode(payloadAsHex), Hex.decode(hmacAsHex), secretKey)) {
-            return Hex.decode(payloadAsHex);
+        // HMAC-SHA256 is always 32 bytes; split directly to avoid hex-encoding memory amplification
+        int payloadLen = payloadWithHmac.length - 32;
+        byte[] payload = Arrays.copyOfRange(payloadWithHmac, 0, payloadLen);
+        byte[] hmac = Arrays.copyOfRange(payloadWithHmac, payloadLen, payloadWithHmac.length);
+        if (verifyHmac(payload, hmac, secretKey)) {
+            return payload;
         } else {
             throw new CryptoException(HMAC_ERROR_MSG);
         }

--- a/common/src/main/java/haveno/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/haveno/common/persistence/PersistenceManager.java
@@ -386,6 +386,10 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             T persistableEnvelope = (T) persistenceProtoResolver.fromProto(proto);
             log.info("Reading {} completed in {} ms", fileName, System.currentTimeMillis() - ts);
             return persistableEnvelope;
+        } catch (OutOfMemoryError e) {
+            // Do not treat OOM as file corruption — the file is valid but too large for current heap.
+            // Re-throw so the file is not moved to backup_of_corrupted_data and data is preserved.
+            throw e;
         } catch (Throwable t) {
             log.error("Reading {} failed with {}.", fileName, t.getMessage(), t);
             try {


### PR DESCRIPTION
## Summary

Two bugs combine to silently destroy trade history when `ClosedTrades` grows large (e.g. arbitrators with many disputes):

### Bug 1 — `decryptPayloadWithHmac` hex-encodes the entire payload (`Encryption.java`)

The original code converted the decrypted byte array to a hex `String` before splitting off the HMAC:

```java
String payloadWithHmacAsHex = Hex.encode(payloadWithHmac); // 2× memory
String payloadAsHex = payloadWithHmacAsHex.substring(0, sep); // another copy
String hmacAsHex = payloadWithHmacAsHex.substring(sep, length); // another copy
return Hex.decode(payloadAsHex); // another copy
```

Peak memory to read a 50 MB file was ~6× the payload. On heap-constrained JVMs this throws \`OutOfMemoryError\`.

**Fix:** split with \`Arrays.copyOfRange\` at \`length - 32\` (HMAC-SHA256 is always 32 bytes). No hex encoding needed.

### Bug 2 — \`catch(Throwable)\` in \`getPersisted\` treats OOM as file corruption (`PersistenceManager.java`)

\`OutOfMemoryError\` is a \`Throwable\`, so the read-path catch called \`removeAndBackupFile\`, moving the valid storage file to \`backup_of_corrupted_data/\`. The file was not corrupt — the JVM ran out of heap. The app then started with empty trade history.

**Fix:** catch \`OutOfMemoryError\` before \`catch(Throwable)\` and re-throw it, so a valid file is never moved on OOM.

## Chain of events that causes data loss

1. \`ClosedTrades\` accumulates to tens of MB (common for arbitrators)
2. Write attempt OOMs inside \`encrypt\` → write fails, **original file preserved**
3. On next startup, \`decryptPayloadWithHmac\` OOMs due to hex amplification
4. \`catch(Throwable)\` moves the file to \`backup_of_corrupted_data/\`
5. App starts with empty trade history — data appears lost

**Recovery note:** data is not actually deleted, only moved. Users who have already hit this can recover from \`backup_of_corrupted_data/\` in their Haveno data directory.

## Test plan

- [x] Existing encryption unit tests pass
- [x] Verify \`decryptPayloadWithHmac(encryptPayloadWithHmac(payload, key), key)\` round-trips correctly for arbitrary payloads
- [x] Simulate OOM during \`getPersisted\` and confirm storage file is not moved to backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)