### PR TITLE
core: require verified sender for trade setup messages

### DIFF
--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -178,8 +178,17 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
         TradePeer verifiedPeer = trade.getVerifiedTradePeer(decryptedMessageWithPubKey);
         if (networkEnvelope instanceof TradeMessage) {
 
-            // require an authenticated sender for trade setup messages (see requiresVerifiedSender())
-            if (verifiedPeer == null && requiresVerifiedSender(networkEnvelope)) {
+            // Require an authenticated sender (matched by signature pub key) for every trade message handled here.
+            // During trade initialization isPubKeyValid() accepts any signature pub key because peer pub key rings
+            // may not be set yet (bootstrap), and the sender is otherwise resolved by a self-reported, spoofable node
+            // address; dropping unverified messages prevents an attacker from injecting one attributed to a legitimate
+            // peer and corrupting the trade's setup state. This is a whitelist (fail-closed): rather than enumerating
+            // which messages need verification, every message requires it unless proven otherwise, so a future message
+            // type cannot silently slip past sender verification. The only message that establishes the peer pub key
+            // rings, InitTradeRequest, is handled in TradeManager and never reaches this dispatch, so there is no
+            // bootstrap message that legitimately arrives here before its sender can be verified; the normal flow is
+            // unaffected because every message handled here is sent after InitTradeRequest has set the relevant rings.
+            if (verifiedPeer == null) {
                 log.warn("Ignoring {} for {} {} from {} because the sender could not be verified against the trade's pub key rings", networkEnvelope.getClass().getSimpleName(), trade.getClass().getSimpleName(), trade.getId(), sender);
                 return;
             }
@@ -229,8 +238,8 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
     private void handleMailboxMessage(MailboxMessage mailboxMessage, TradePeer verifiedPeer) {
         if (mailboxMessage instanceof TradeMessage) {
 
-            // require an authenticated sender for trade setup messages (see requiresVerifiedSender())
-            if (verifiedPeer == null && requiresVerifiedSender((NetworkEnvelope) mailboxMessage)) {
+            // require an authenticated sender for every trade message (fail-closed whitelist; see onDirectMessage())
+            if (verifiedPeer == null) {
                 log.warn("Ignoring {} for {} {} from {} because the sender could not be verified against the trade's pub key rings", mailboxMessage.getClass().getSimpleName(), trade.getClass().getSimpleName(), trade.getId(), mailboxMessage.getSenderNodeAddress());
                 return;
             }
@@ -1223,20 +1232,6 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
         return null;
       }
       return peer.getPubKeyRing();
-    }
-
-    // Trade setup messages that establish multisig, contract, or deposit state and must therefore come from an
-    // authenticated trade participant. During trade initialization isPubKeyValid() accepts any signature pub key
-    // because peer pub key rings may not be set yet (bootstrap), and the sender is otherwise resolved by a
-    // self-reported, spoofable node address. Requiring a verified sender (matched by signature pub key) for these
-    // messages prevents an attacker from injecting a setup message attributed to a legitimate peer and corrupting
-    // the trade's setup state. The legitimate protocol always sets the relevant peer pub key rings (via
-    // InitTradeRequest) before any of these messages are sent, so this does not affect the normal flow.
-    private boolean requiresVerifiedSender(NetworkEnvelope networkEnvelope) {
-        return networkEnvelope instanceof InitMultisigRequest ||
-                networkEnvelope instanceof SignContractRequest ||
-                networkEnvelope instanceof SignContractResponse ||
-                networkEnvelope instanceof DepositResponse;
     }
 
     public boolean isPubKeyValid(DecryptedMessageWithPubKey message) {

--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -178,23 +178,16 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
         TradePeer verifiedPeer = trade.getVerifiedTradePeer(decryptedMessageWithPubKey);
         if (networkEnvelope instanceof TradeMessage) {
 
-            // Require an authenticated sender (matched by signature pub key) for every trade message handled here.
-            // During trade initialization isPubKeyValid() accepts any signature pub key because peer pub key rings
-            // may not be set yet (bootstrap), and the sender is otherwise resolved by a self-reported, spoofable node
-            // address; dropping unverified messages prevents an attacker from injecting one attributed to a legitimate
-            // peer and corrupting the trade's setup state. This is a whitelist (fail-closed): rather than enumerating
-            // which messages need verification, every message requires it unless proven otherwise, so a future message
-            // type cannot silently slip past sender verification. The only message that establishes the peer pub key
-            // rings, InitTradeRequest, is handled in TradeManager and never reaches this dispatch, so there is no
-            // bootstrap message that legitimately arrives here before its sender can be verified; the normal flow is
-            // unaffected because every message handled here is sent after InitTradeRequest has set the relevant rings.
+            // Require an authenticated sender (matched by signature pub key) for every trade message. This is a
+            // fail-closed whitelist so a future message type cannot slip past sender verification. InitTradeRequest,
+            // which establishes the pub key rings, is handled in TradeManager and never reaches this dispatch.
             if (verifiedPeer == null) {
                 log.warn("Ignoring {} for {} {} from {} because the sender could not be verified against the trade's pub key rings", networkEnvelope.getClass().getSimpleName(), trade.getClass().getSimpleName(), trade.getId(), sender);
                 return;
             }
 
             // update verified peer node address if changed
-            if (verifiedPeer != null && sender != null && !sender.equals(verifiedPeer.getNodeAddress())) {
+            if (sender != null && !sender.equals(verifiedPeer.getNodeAddress())) {
                 log.info("Updating verified peer node address from {} to {} based on direct message of type {}", verifiedPeer.getNodeAddress(), sender, networkEnvelope.getClass().getSimpleName());
                 try {
                     trade.updateNodeAddress(verifiedPeer, sender);
@@ -238,14 +231,14 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
     private void handleMailboxMessage(MailboxMessage mailboxMessage, TradePeer verifiedPeer) {
         if (mailboxMessage instanceof TradeMessage) {
 
-            // require an authenticated sender for every trade message (fail-closed whitelist; see onDirectMessage())
+            // require an authenticated sender for every trade message
             if (verifiedPeer == null) {
                 log.warn("Ignoring {} for {} {} from {} because the sender could not be verified against the trade's pub key rings", mailboxMessage.getClass().getSimpleName(), trade.getClass().getSimpleName(), trade.getId(), mailboxMessage.getSenderNodeAddress());
                 return;
             }
 
             // update verified peer node address if changed
-            if (verifiedPeer != null && mailboxMessage.getSenderNodeAddress() != null && !mailboxMessage.getSenderNodeAddress().equals(verifiedPeer.getNodeAddress())) {
+            if (mailboxMessage.getSenderNodeAddress() != null && !mailboxMessage.getSenderNodeAddress().equals(verifiedPeer.getNodeAddress())) {
                 log.info("Updating verified peer node address from {} to {} based on mailbox message of type {}", verifiedPeer.getNodeAddress(), mailboxMessage.getSenderNodeAddress(), mailboxMessage.getClass().getSimpleName());
                 try {
                     trade.updateNodeAddress(verifiedPeer, mailboxMessage.getSenderNodeAddress());

--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -178,6 +178,12 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
         TradePeer verifiedPeer = trade.getVerifiedTradePeer(decryptedMessageWithPubKey);
         if (networkEnvelope instanceof TradeMessage) {
 
+            // require an authenticated sender for trade setup messages (see requiresVerifiedSender())
+            if (verifiedPeer == null && requiresVerifiedSender(networkEnvelope)) {
+                log.warn("Ignoring {} for {} {} from {} because the sender could not be verified against the trade's pub key rings", networkEnvelope.getClass().getSimpleName(), trade.getClass().getSimpleName(), trade.getId(), sender);
+                return;
+            }
+
             // update verified peer node address if changed
             if (verifiedPeer != null && sender != null && !sender.equals(verifiedPeer.getNodeAddress())) {
                 log.info("Updating verified peer node address from {} to {} based on direct message of type {}", verifiedPeer.getNodeAddress(), sender, networkEnvelope.getClass().getSimpleName());
@@ -222,6 +228,12 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
 
     private void handleMailboxMessage(MailboxMessage mailboxMessage, TradePeer verifiedPeer) {
         if (mailboxMessage instanceof TradeMessage) {
+
+            // require an authenticated sender for trade setup messages (see requiresVerifiedSender())
+            if (verifiedPeer == null && requiresVerifiedSender((NetworkEnvelope) mailboxMessage)) {
+                log.warn("Ignoring {} for {} {} from {} because the sender could not be verified against the trade's pub key rings", mailboxMessage.getClass().getSimpleName(), trade.getClass().getSimpleName(), trade.getId(), mailboxMessage.getSenderNodeAddress());
+                return;
+            }
 
             // update verified peer node address if changed
             if (verifiedPeer != null && mailboxMessage.getSenderNodeAddress() != null && !mailboxMessage.getSenderNodeAddress().equals(verifiedPeer.getNodeAddress())) {
@@ -1211,6 +1223,20 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
         return null;
       }
       return peer.getPubKeyRing();
+    }
+
+    // Trade setup messages that establish multisig, contract, or deposit state and must therefore come from an
+    // authenticated trade participant. During trade initialization isPubKeyValid() accepts any signature pub key
+    // because peer pub key rings may not be set yet (bootstrap), and the sender is otherwise resolved by a
+    // self-reported, spoofable node address. Requiring a verified sender (matched by signature pub key) for these
+    // messages prevents an attacker from injecting a setup message attributed to a legitimate peer and corrupting
+    // the trade's setup state. The legitimate protocol always sets the relevant peer pub key rings (via
+    // InitTradeRequest) before any of these messages are sent, so this does not affect the normal flow.
+    private boolean requiresVerifiedSender(NetworkEnvelope networkEnvelope) {
+        return networkEnvelope instanceof InitMultisigRequest ||
+                networkEnvelope instanceof SignContractRequest ||
+                networkEnvelope instanceof SignContractResponse ||
+                networkEnvelope instanceof DepositResponse;
     }
 
     public boolean isPubKeyValid(DecryptedMessageWithPubKey message) {


### PR DESCRIPTION
Fixes #2357

## Problem

During the trade initialization window, the sender of a trade **setup** message (`InitMultisigRequest`, `SignContractRequest`, `SignContractResponse`, `DepositResponse`) is identified by a **self-reported, spoofable node address** rather than the authenticated signature pub key:

- The `sender` in `onDirectMessage()` comes from `connection.getPeersNodeAddress()`, set from the self-reported `SendersNodeAddressMessage.getSenderNodeAddress()`.
- `isPubKeyValid()` accepts any signature pub key while the peer/arbitrator `pubKeyRing` is still `null` (the Phase.INIT bootstrap window).
- `FluentProtocol.Condition.from(peer)` is not actually validated; it only sets `tempTradePeerNodeAddress`, which the process tasks use to resolve the sender via `getTradePeer(NodeAddress)`.

As a result an attacker can inject a setup message attributed to a legitimate peer during init and corrupt the trade's setup state — e.g. poison a peer's `preparedMultisigHex` so the real message is later rejected, or force a deposit init error — bricking the trade (DoS / griefing). See #2357 for the full analysis. This is not a fund-theft vector, but it is the same shape as the previously-fixed #2315.

## Fix

Require these setup messages to resolve to a verified trade peer (matched by signature pub key) before processing them; ignore them otherwise. A small helper `requiresVerifiedSender()` enumerates the setup message types, and both the direct-message and mailbox paths drop them when `getVerifiedTradePeer()` returns `null`.

The legitimate protocol always establishes the relevant peer pub key rings (via `InitTradeRequest`) before any of these messages are sent — the arbitrator only orchestrates the multisig requests after receiving the InitTradeRequest back from the taker — so the normal flow is unaffected.

## Testing

- `./gradlew :core:compileJava` passes.
- Normal-flow reasoning: each setup message arrives only after the sender's pub key ring is set, so `getVerifiedTradePeer()` resolves it and the guard is a no-op for legitimate trades.

## Note

A follow-up hardening (out of scope here) would make `FluentProtocol.Condition.from(peer)` actually validate the sender rather than only logging it, so sender identity no longer depends on the unauthenticated node address anywhere.