### PR TITLE
core: verify DepositRequest nack sender; confirm deposits unpublished before wallet deletion

### DIFF
--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -2109,8 +2109,12 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
             return;
         }
 
-        // remove if deposit not requested or is failed
-        if (!isDepositRequested() || isDepositRequestFailed()) {
+        // remove immediately only if the deposit was never requested (nothing created or published yet).
+        // a failed deposit request must NOT short-circuit to immediate deletion: the failure may be forged or
+        // erroneous (e.g. a spoofed DepositRequest nack or DepositResponse error) while the arbitrator still
+        // publishes our deposit tx into the multisig. fall through to the scheduled cleanup below, which confirms
+        // on-chain via monerod that no deposit tx is published before deleting the wallet.
+        if (!isDepositRequested()) {
             removeTradeOnError();
             return;
         }

--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -957,9 +957,12 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             }
         }
 
-        // handle nack of deposit request
+        // handle nack of deposit request. only the arbitrator processes a DepositRequest, so only the
+        // arbitrator can legitimately nack it. require the verified sender to be the arbitrator: otherwise a
+        // trade peer (also a verified peer) could forge a nack to force PUBLISH_DEPOSIT_TX_REQUEST_FAILED,
+        // which tears down the trade and deletes the wallet while the arbitrator may still publish the deposits.
         if (ackMessage.getSourceMsgClassName().equals(DepositRequest.class.getSimpleName())) {
-            if (!ackMessage.isSuccess()) {
+            if (!ackMessage.isSuccess() && verifiedPeer == trade.getArbitrator()) {
                 trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);
                 processModel.getTradeManager().requestPersistence();
             }


### PR DESCRIPTION
Fixes #2365.

## Problem

A `DepositRequest` goes only from a trader to the **arbitrator**, so only the arbitrator can legitimately NACK it. But `TradeProtocol.onAckMessageAux` honored a `DepositRequest` NACK from **any verified peer**:

```java
if (ackMessage.getSourceMsgClassName().equals(DepositRequest.class.getSimpleName())) {
    if (!ackMessage.isSuccess()) {
        trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);
```

`AckMessage` content is attacker-chosen and is not bound to a request the victim actually sent, and the trade counterparty is also a verified peer. So a counterparty can forge `AckMessage{sourceMsgClassName:"DepositRequest", isSuccess:false}` to force the victim into `PUBLISH_DEPOSIT_TX_REQUEST_FAILED`. During trade init that drives `handleError` → `onProtocolInitializationError`, whose immediate branch deletes the trade wallet + backups while the arbitrator may still publish the deposit txs into the 2-of-3 multisig — locking the victim's funds (full analysis in #2365). With a `buyerAsTakerWithoutDeposit` offer the attacker stakes nothing.

This is the `AckMessage` sibling of #2363/#2364 (`DepositResponse`): same `PUBLISH_DEPOSIT_TX_REQUEST_FAILED` → wallet-deletion outcome, via a route the `DepositResponse` sender check does not cover. The sibling ack handlers (`InitTradeRequest` nack, `PaymentSent`/`PaymentReceived` acks) already enforce the sender role; only the `DepositRequest` nack did not.

## Fix

**1. Verify the NACK sender is the arbitrator** (`TradeProtocol.java`) — closes this vector:

```java
if (!ackMessage.isSuccess() && verifiedPeer == trade.getArbitrator()) {
    trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);
```

A legitimate arbitrator NACK still passes (`getVerifiedTradePeer` resolves the arbitrator's pub key to the same `TradePeer`, the `==` pattern the sibling blocks already use); a counterparty is rejected. Covers both the direct and mailbox ack routes, which both funnel through `onAckMessageAux`.

**2. Fail-safe teardown** (`Trade.java`) — class-hardening, independent of (1):

`onProtocolInitializationError` short-circuited to immediate `removeTradeOnError()` (which deletes the wallet) whenever `isDepositRequestFailed()`, trusting a peer-influenced state. Now it only short-circuits when the deposit was never requested; a failed deposit request falls through to the existing scheduled cleanup, which polls monerod and refuses to delete the wallet if either deposit tx is published. This also closes the #2363/#2364 `DepositResponse` route and any future setter of the failed state.

## Scope / notes

- **(1) alone stops this attack.** With the failed state blocked, the forged nack still reaches `onProtocolInitializationError`, but with `isDepositRequestFailed() == false` and deposits not yet published it takes the safe scheduled path. (2) is defense-in-depth. The split into two commits lets either be taken alone.
- **(2) blast radius:** legitimately-failed deposit requests no longer clean up *immediately* — their reserved funds/key images stay frozen until the scheduled path confirms on-chain (no deposit tx published) and deletes the wallet. That is the cost of fail-safe teardown; funds are never at risk, cleanup is just deferred. The change is also broader than "peer-supplied error" (it covers all failed-deposit states) because message provenance isn't tracked at that layer.
- Orthogonal to #2364 (different methods); builds on #2358-merged master. No conflict expected when #2364 merges.
- `:core:compileJava` passes.
- **No automated test:** exercising this path needs the full trade-protocol/wallet harness, which the repo does not have for unit tests (cf. #2315, #2364, also code-only). Manual verification below.

## Manual verification

On regtest with two traders + arbitrator and a `buyerAsTakerWithoutDeposit` offer (victim = maker/seller, attacker = taker/buyer):

1. Drive the trade to the point where the victim has sent its `DepositRequest` (`Phase.DEPOSIT_REQUESTED`).
2. From a modified/attacker client, send the victim a direct `AckMessage{sourceType: TRADE_MESSAGE, sourceId: tradeId, sourceMsgClassName: "DepositRequest", isSuccess: false}`.
3. **Before:** the victim logs `removeTradeOnError()` and deletes its trade wallet; the arbitrator publishes the deposits; the victim's funds are locked in multisig.
4. **After:** the victim ignores the forged nack (no transition to `PUBLISH_DEPOSIT_TX_REQUEST_FAILED`) and the trade proceeds normally. Independently, forcing the failed state by any route no longer deletes the wallet while deposits are unconfirmed (commit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
