### PR TITLE
core: verify DepositRequest nack sender is the arbitrator

### DIFF
--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -957,9 +957,12 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             }
         }
 
-        // handle nack of deposit request
+        // handle nack of deposit request. only the arbitrator processes a DepositRequest, so only the
+        // arbitrator can legitimately nack it. require the verified sender to be the arbitrator: otherwise a
+        // trade peer (also a verified peer) could forge a nack to force PUBLISH_DEPOSIT_TX_REQUEST_FAILED,
+        // which tears down the trade and deletes the wallet while the arbitrator may still publish the deposits.
         if (ackMessage.getSourceMsgClassName().equals(DepositRequest.class.getSimpleName())) {
-            if (!ackMessage.isSuccess()) {
+            if (!ackMessage.isSuccess() && verifiedPeer == trade.getArbitrator()) {
                 trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);
                 processModel.getTradeManager().requestPersistence();
             }

--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -957,10 +957,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             }
         }
 
-        // handle nack of deposit request. only the arbitrator processes a DepositRequest, so only the
-        // arbitrator can legitimately nack it. require the verified sender to be the arbitrator: otherwise a
-        // trade peer (also a verified peer) could forge a nack to force PUBLISH_DEPOSIT_TX_REQUEST_FAILED,
-        // which tears down the trade and deletes the wallet while the arbitrator may still publish the deposits.
+        // handle nack of DepositRequest from arbitrator to buyer or seller
         if (ackMessage.getSourceMsgClassName().equals(DepositRequest.class.getSimpleName())) {
             if (!ackMessage.isSuccess() && verifiedPeer == trade.getArbitrator()) {
                 trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);

--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -959,7 +959,11 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
 
         // handle nack of DepositRequest from arbitrator to buyer or seller
         if (ackMessage.getSourceMsgClassName().equals(DepositRequest.class.getSimpleName())) {
-            if (!ackMessage.isSuccess() && verifiedPeer == trade.getArbitrator()) {
+            if (!ackMessage.isSuccess()) {
+                if (verifiedPeer != trade.getArbitrator()) {
+                    log.warn("Ignoring DepositRequest NACK from non-arbitrator peer for {} {}, sender={}", trade.getClass().getSimpleName(), trade.getId(), sender);
+                    return;
+                }
                 trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);
                 processModel.getTradeManager().requestPersistence();
             }


### PR DESCRIPTION
Split out of #2366 (fix 1 of 2 — independent of the other half).

## Problem

A `DepositRequest` goes only from a trader to the **arbitrator**, so only the arbitrator can legitimately NACK it. But `TradeProtocol.onAckMessageAux` honored a `DepositRequest` NACK from **any verified peer**:

```java
if (ackMessage.getSourceMsgClassName().equals(DepositRequest.class.getSimpleName())) {
    if (!ackMessage.isSuccess()) {
        trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);
```

`AckMessage` content is attacker-chosen and is not bound to a request the victim actually sent, and the trade counterparty is also a verified peer. So a counterparty can forge `AckMessage{sourceMsgClassName:"DepositRequest", isSuccess:false}` to force the victim into `PUBLISH_DEPOSIT_TX_REQUEST_FAILED`. During trade init that drives `handleError` → `onProtocolInitializationError`, whose immediate branch deletes the trade wallet + backups while the arbitrator may still publish the deposit txs into the 2-of-3 multisig — locking the victim's funds. With a `buyerAsTakerWithoutDeposit` offer the attacker stakes nothing.

This is the `AckMessage` sibling of #2363/#2364 (`DepositResponse`): same `PUBLISH_DEPOSIT_TX_REQUEST_FAILED` → wallet-deletion outcome, via a route the `DepositResponse` sender check does not cover. The sibling ack handlers (`InitTradeRequest` nack, `PaymentSent`/`PaymentReceived` acks) already enforce the sender role; only the `DepositRequest` nack did not.

## Fix

Verify the NACK sender is the arbitrator (`TradeProtocol.java`):

```java
if (!ackMessage.isSuccess() && verifiedPeer == trade.getArbitrator()) {
    trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);
```

A legitimate arbitrator NACK still passes (`getVerifiedTradePeer` resolves the arbitrator's pub key to the same `TradePeer`, the `==` pattern the sibling blocks already use); a counterparty is rejected. Covers both the direct and mailbox ack routes, which both funnel through `onAckMessageAux`.

This alone stops the attack: with the failed state blocked, the forged nack still reaches `onProtocolInitializationError`, but since the deposit was actually requested, the existing scheduled cleanup path applies, which polls monerod and refuses to delete the wallet if either deposit tx is published.

`:core:compileJava` passes.

**No automated test:** exercising this path needs the full trade-protocol/wallet harness, which the repo does not have for unit tests (cf. #2315, #2364). Manual verification below.

## Manual verification

On regtest with two traders + arbitrator and a `buyerAsTakerWithoutDeposit` offer (victim = maker/seller, attacker = taker/buyer):

1. Drive the trade to the point where the victim has sent its `DepositRequest` (`Phase.DEPOSIT_REQUESTED`).
2. From a modified/attacker client, send the victim a direct `AckMessage{sourceType: TRADE_MESSAGE, sourceId: tradeId, sourceMsgClassName: "DepositRequest", isSuccess: false}`.
3. **Before:** the victim logs `removeTradeOnError()` and deletes its trade wallet; the arbitrator publishes the deposits; the victim's funds are locked in multisig.
4. **After:** the victim ignores the forged nack (no transition to `PUBLISH_DEPOSIT_TX_REQUEST_FAILED`) and the trade proceeds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)