### PR TITLE
core: confirm deposits unpublished before deleting wallet on protocol init error

### DIFF
--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -2109,11 +2109,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
             return;
         }
 
-        // remove immediately only if the deposit was never requested (nothing created or published yet).
-        // a failed deposit request must NOT short-circuit to immediate deletion: the failure may be forged or
-        // erroneous (e.g. a spoofed DepositRequest nack or DepositResponse error) while the arbitrator still
-        // publishes our deposit tx into the multisig. fall through to the scheduled cleanup below, which confirms
-        // on-chain via monerod that no deposit tx is published before deleting the wallet.
+        // remove immediately if deposit not requested
         if (!isDepositRequested()) {
             removeTradeOnError();
             return;

--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -2109,8 +2109,12 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
             return;
         }
 
-        // remove if deposit not requested or is failed
-        if (!isDepositRequested() || isDepositRequestFailed()) {
+        // remove immediately only if the deposit was never requested (nothing created or published yet).
+        // a failed deposit request must NOT short-circuit to immediate deletion: the failure may be forged or
+        // erroneous (e.g. a spoofed DepositRequest nack or DepositResponse error) while the arbitrator still
+        // publishes our deposit tx into the multisig. fall through to the scheduled cleanup below, which confirms
+        // on-chain via monerod that no deposit tx is published before deleting the wallet.
+        if (!isDepositRequested()) {
             removeTradeOnError();
             return;
         }


### PR DESCRIPTION
Split out of #2366 (fix 2 of 2 — independent of the other half; defense-in-depth class-hardening).

## Problem

`Trade.onProtocolInitializationError` short-circuited to immediate `removeTradeOnError()` (which deletes the trade wallet and backups) whenever `isDepositRequestFailed()`, trusting a peer-influenced state. A forged or erroneous deposit-request failure could therefore delete the wallet while the arbitrator still publishes the deposit txs into the multisig, locking funds.

This is the same `PUBLISH_DEPOSIT_TX_REQUEST_FAILED` → wallet-deletion outcome covered by the `DepositRequest`/`DepositResponse` sender checks (#2363/#2364, and the sibling fix for the `DepositRequest` nack route), but hardens the consuming side independent of how the failed state was reached.

## Fix

Only short-circuit when the deposit was never requested. When a deposit request has been made, fall through to the existing scheduled cleanup, which polls monerod and refuses to delete the wallet if either deposit tx is published. This neutralizes the whole class of forged/erroneous teardown triggers, not just one message route.

## Scope / notes

- **Blast radius:** legitimately-failed deposit requests no longer clean up *immediately* — their reserved funds/key images stay frozen until the scheduled path confirms on-chain (no deposit tx published) and deletes the wallet. That is the cost of fail-safe teardown; funds are never at risk, cleanup is just deferred. The change is broader than "peer-supplied error" (it covers all failed-deposit states) because message provenance isn't tracked at that layer.
- `:core:compileJava` passes.
- **No automated test:** exercising this path needs the full trade-protocol/wallet harness, which the repo does not have for unit tests (cf. #2315, #2364). Manual verification below.

## Manual verification

Forcing `PUBLISH_DEPOSIT_TX_REQUEST_FAILED` by any route (e.g. the forged-nack scenario in the sibling PR, or a genuine deposit-request failure) no longer deletes the wallet while deposits are unconfirmed; cleanup instead falls through to the scheduled path that checks on-chain state before deleting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)