### PR TITLE
fix: stream persistence encryption to avoid OOM that freezes stores

### DIFF
--- a/common/src/main/java/haveno/common/crypto/Encryption.java
+++ b/common/src/main/java/haveno/common/crypto/Encryption.java
@@ -18,7 +18,7 @@
 package haveno.common.crypto;
 
 import haveno.common.util.Utilities;
-import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -101,11 +101,11 @@ public class Encryption {
     private static byte[] getPayloadWithHmac(byte[] payload, SecretKey secretKey) {
         try {
             byte[] hmac = getHmac(payload, secretKey);
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(payload.length + hmac.length)) {
-                outputStream.write(payload);
-                outputStream.write(hmac);
-                return outputStream.toByteArray();
-            }
+            // Append the hmac with a single copy (HMAC-SHA256 is always 32 bytes) to avoid the
+            // extra full-payload copy a ByteArrayOutputStream would make.
+            byte[] payloadWithHmac = Arrays.copyOf(payload, payload.length + hmac.length);
+            System.arraycopy(hmac, 0, payloadWithHmac, payload.length, hmac.length);
+            return payloadWithHmac;
         } catch (Throwable e) {
             log.error("Could not create hmac", e);
             throw new RuntimeException("Could not create hmac", e);
@@ -136,6 +136,40 @@ public class Encryption {
 
     public static byte[] encryptPayloadWithHmac(byte[] payload, SecretKey secretKey) throws CryptoException {
         return encrypt(getPayloadWithHmac(payload, secretKey), secretKey);
+    }
+
+    /**
+     * Streams {@code encrypt(payload || hmac(payload))} directly to {@code outputStream} without
+     * ever holding the concatenated payload-with-hmac or the encrypted result fully in memory.
+     * This produces byte-identical output to {@link #encryptPayloadWithHmac(byte[], SecretKey)} but
+     * avoids the ~3x peak-memory amplification of the array based variant, which can throw
+     * OutOfMemoryError for large persisted stores (e.g. ClosedTrades for arbitrators with many trades).
+     * The provided {@code outputStream} is not closed by this method.
+     */
+    public static void encryptPayloadWithHmacToStream(byte[] payload, SecretKey secretKey, OutputStream outputStream) throws CryptoException {
+        try {
+            byte[] hmac = getHmac(payload, secretKey);
+            Cipher cipher = Cipher.getInstance(SYM_CIPHER);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+
+            // Encrypt the payload in chunks so we never allocate a full second copy of it.
+            int chunkSize = 64 * 1024;
+            byte[] outBuf = new byte[cipher.getOutputSize(chunkSize)];
+            int n;
+            for (int off = 0; off < payload.length; off += chunkSize) {
+                int len = Math.min(chunkSize, payload.length - off);
+                n = cipher.update(payload, off, len, outBuf, 0);
+                if (n > 0) outputStream.write(outBuf, 0, n);
+            }
+            // Append the hmac (also encrypted) and flush the final padded block.
+            n = cipher.update(hmac, 0, hmac.length, outBuf, 0);
+            if (n > 0) outputStream.write(outBuf, 0, n);
+            n = cipher.doFinal(outBuf, 0);
+            if (n > 0) outputStream.write(outBuf, 0, n);
+        } catch (Throwable e) {
+            log.error("error in encryptPayloadWithHmacToStream", e);
+            throw new CryptoException(e);
+        }
     }
 
     public static byte[] decryptPayloadWithHmac(byte[] encryptedPayloadWithHmac, SecretKey secretKey) throws CryptoException {

--- a/common/src/main/java/haveno/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/haveno/common/persistence/PersistenceManager.java
@@ -515,8 +515,10 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             fileOutputStream = new FileOutputStream(tempFile);
 
             if (keyRing != null) {
-                byte[] encryptedBytes = Encryption.encryptPayloadWithHmac(serialized.toByteArray(), keyRing.getSymmetricKey());
-                fileOutputStream.write(encryptedBytes);
+                // Stream the encryption directly to disk to avoid the peak-memory amplification of
+                // building the full encrypted byte[] in memory, which could throw OutOfMemoryError for
+                // large stores and silently leave the on-disk file frozen at the last successful write.
+                Encryption.encryptPayloadWithHmacToStream(serialized.toByteArray(), keyRing.getSymmetricKey(), fileOutputStream);
             } else {
                 serialized.writeDelimitedTo(fileOutputStream);
             }

--- a/common/src/test/java/haveno/common/crypto/EncryptionTest.java
+++ b/common/src/test/java/haveno/common/crypto/EncryptionTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.crypto;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Random;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EncryptionTest {
+
+    // Sizes around AES block (16) and stream chunk (64 KiB) boundaries, plus an empty payload.
+    private static final int[] SIZES = {0, 1, 15, 16, 17, 1000, 65_535, 65_536, 65_537, 100_000, 5_000_000};
+
+    @Test
+    public void testStreamWriteMatchesArrayAndRoundTrips() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        Random random = new Random(1234);
+        for (int size : SIZES) {
+            byte[] payload = new byte[size];
+            random.nextBytes(payload);
+
+            byte[] viaArray = Encryption.encryptPayloadWithHmac(payload, key);
+
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            Encryption.encryptPayloadWithHmacToStream(payload, key, bos);
+            byte[] viaStream = bos.toByteArray();
+
+            // The streaming variant must be byte-identical so existing persisted files stay readable.
+            assertArrayEquals(viaArray, viaStream, "ciphertext differs for payload size " + size);
+
+            // And it must decrypt back to the original payload with the existing array decrypt path.
+            byte[] decrypted = Encryption.decryptPayloadWithHmac(viaStream, key);
+            assertArrayEquals(payload, decrypted, "round-trip failed for payload size " + size);
+        }
+    }
+
+    @Test
+    public void testStreamDoesNotCloseOutputStream() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        TrackingOutputStream out = new TrackingOutputStream();
+        Encryption.encryptPayloadWithHmacToStream(new byte[1000], key, out);
+        assertEquals(false, out.closed, "stream must not be closed by the helper");
+    }
+
+    private static class TrackingOutputStream extends ByteArrayOutputStream {
+        boolean closed = false;
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}


### PR DESCRIPTION
Tracking issue: #2383 · companion read PR: #2382

## Summary

The **write** half of a two-PR fix for large persisted stores being lost on restart.

When the store grows large, writing it throws `OutOfMemoryError`. The failed write is caught and the temp-file → rename step is skipped, so the on-disk file is preserved but **frozen** at the last successful write — trades closed after that point never persist and appear to vanish on the next start.

### Root cause

`writeToDisk` built the entire encrypted blob in memory before writing:

```java
byte[] encryptedBytes = Encryption.encryptPayloadWithHmac(serialized.toByteArray(), key);
fileOutputStream.write(encryptedBytes);
```

`encryptPayloadWithHmac` concatenates `payload || hmac` (via a `ByteArrayOutputStream` that copies the payload twice) and then AES-encrypts it into yet another full array — roughly **3× the serialized payload** of transient allocation on top of the in-memory object graph. On a heap-constrained JVM this throws `OutOfMemoryError` inside `getPayloadWithHmac`, observed in the field as:

```
[Write-ClosedTrades_to-disk-0] ERROR haveno.common.crypto.Encryption: Could not create hmac java.lang.OutOfMemoryError: Java heap space
```

### Fix

- Add `Encryption.encryptPayloadWithHmacToStream(...)`, which AES-encrypts the payload and appended HMAC in fixed-size chunks straight to the output stream, never holding a full second copy of the payload or the full encrypted array. `writeToDisk` uses it. Output is **byte-identical** to the array method, so existing files stay readable.
- Replace the `ByteArrayOutputStream` double-copy in `getPayloadWithHmac` (still used by the network/keystore callers) with a single `Arrays.copyOf`.

This does not change the on-disk format. The crash-safety guarantee is unchanged: a failed write still throws before the temp→`storageFile` rename (so the existing file is preserved), and the now-possibly-partial temp file is deleted in `finally` exactly as before — `storageFile` is never corrupted.

### Test plan

- [x] New `EncryptionTest`: streaming encryption is byte-identical to the array method and round-trips through the existing decrypt, across boundary sizes (0, AES-block ±1, 64 KiB chunk ±1, 5 MB); the helper does not close the caller's stream.
- [x] Existing `:common` and `:p2p` suites pass.
- [x] Verified independently that the old path OOMs and the streaming path succeeds at `-Xmx400m` with a 200 MB payload.

## Merge note

`EncryptionTest.java` is owned by this PR. The companion read PR (#2382) previously also added that file (an add/add conflict); it has been removed there so the two PRs are independently mergeable. The only remaining conflict between the two is a trivial import block in `Encryption.java` — whichever merges second resolves it to keep `InputStream` (from #2382) and `OutputStream` (from this PR) and drop `ByteArrayOutputStream` (unused once this PR's `getPayloadWithHmac` rewrite lands). The added methods do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
