### PR TITLE
core: streaming-safe persistence + append-only closed-trades log

### DIFF
--- a/common/src/main/java/haveno/common/crypto/Encryption.java
+++ b/common/src/main/java/haveno/common/crypto/Encryption.java
@@ -18,6 +18,7 @@
 package haveno.common.crypto;
 
 import haveno.common.util.Utilities;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
@@ -32,6 +33,7 @@ import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
 import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
@@ -182,6 +184,91 @@ public class Encryption {
             return payload;
         } else {
             throw new CryptoException(HMAC_ERROR_MSG);
+        }
+    }
+
+    /**
+     * Streaming counterpart of {@link #decryptPayloadWithHmac(byte[], SecretKey)} for large persisted
+     * files. This is "pass 1" of a two-pass read: it decrypts {@code encryptedInput} in chunks, verifies
+     * the trailing HMAC over the payload, and returns the payload length (decrypted length minus the
+     * 32-byte HMAC) without ever holding the full decrypted payload in memory. The caller then re-reads
+     * the file with {@link #decryptStream(InputStream, SecretKey)} limited to the returned length to parse
+     * the (already integrity-checked) payload.
+     *
+     * <p>Throws {@link CryptoException} if the input is not a valid hmac-protected encrypted stream (bad
+     * padding, fewer than 32 decrypted bytes, or hmac mismatch), so callers can fall back to reading an
+     * unencrypted legacy file. {@link OutOfMemoryError} is intentionally not caught so a heap-constrained
+     * read is never mistaken for a corrupt file.
+     *
+     * @return the payload length in bytes (always {@code >= 0})
+     */
+    public static long verifyPayloadWithHmacStream(InputStream encryptedInput, SecretKey secretKey) throws CryptoException {
+        try {
+            Cipher cipher = Cipher.getInstance(SYM_CIPHER);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey);
+            Mac mac = Mac.getInstance(HMAC);
+            mac.init(secretKey);
+
+            // We feed every decrypted byte except the final 32 (the hmac) into the mac and count it as
+            // payload; the final 32 bytes are kept in 'hold' and compared against the computed hmac at EOF.
+            byte[] hold = new byte[32];
+            int holdLen = 0;
+            long payloadLen = 0;
+            byte[] readBuf = new byte[64 * 1024];
+            try (CipherInputStream cipherInputStream = new CipherInputStream(encryptedInput, cipher)) {
+                int read;
+                while ((read = cipherInputStream.read(readBuf)) != -1) {
+                    int emit = holdLen + read - 32; // decrypted bytes that can no longer be part of the hmac
+                    if (emit <= 0) {
+                        System.arraycopy(readBuf, 0, hold, holdLen, read);
+                        holdLen += read;
+                        continue;
+                    }
+                    int fromHold = Math.min(emit, holdLen);
+                    if (fromHold > 0) {
+                        mac.update(hold, 0, fromHold);
+                        payloadLen += fromHold;
+                    }
+                    int fromBuf = emit - fromHold;
+                    if (fromBuf > 0) {
+                        mac.update(readBuf, 0, fromBuf);
+                        payloadLen += fromBuf;
+                    }
+                    // The new trailing 32 bytes = leftover of hold followed by the tail of readBuf.
+                    int remHold = holdLen - fromHold;
+                    if (remHold > 0) System.arraycopy(hold, fromHold, hold, 0, remHold);
+                    int tail = read - fromBuf;
+                    System.arraycopy(readBuf, fromBuf, hold, remHold, tail);
+                    holdLen = remHold + tail; // == 32
+                }
+            }
+            if (holdLen != 32) throw new CryptoException(HMAC_ERROR_MSG);
+            if (!Arrays.equals(mac.doFinal(), hold)) {
+                throw new CryptoException(HMAC_ERROR_MSG);
+            }
+            return payloadLen;
+        } catch (OutOfMemoryError e) {
+            throw e;
+        } catch (CryptoException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    /**
+     * "Pass 2" of the streaming read: returns a stream that decrypts {@code encryptedInput} on the fly.
+     * The returned stream yields {@code payload || hmac}; callers limit it to the payload length returned
+     * by {@link #verifyPayloadWithHmacStream(InputStream, SecretKey)} so only the (already verified)
+     * payload is consumed. Closing the returned stream closes {@code encryptedInput}.
+     */
+    public static InputStream decryptStream(InputStream encryptedInput, SecretKey secretKey) throws CryptoException {
+        try {
+            Cipher cipher = Cipher.getInstance(SYM_CIPHER);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey);
+            return new CipherInputStream(encryptedInput, cipher);
+        } catch (Throwable e) {
+            throw new CryptoException(e);
         }
     }
 

--- a/common/src/main/java/haveno/common/crypto/Encryption.java
+++ b/common/src/main/java/haveno/common/crypto/Encryption.java
@@ -18,6 +18,8 @@
 package haveno.common.crypto;
 
 import haveno.common.util.Utilities;
+import java.io.FilterOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.InvalidKeyException;
@@ -25,7 +27,6 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
@@ -34,6 +35,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
@@ -102,12 +104,8 @@ public class Encryption {
 
     private static byte[] getPayloadWithHmac(byte[] payload, SecretKey secretKey) {
         try {
-            byte[] hmac = getHmac(payload, secretKey);
-            // Append the hmac with a single copy (HMAC-SHA256 is always 32 bytes) to avoid the
-            // extra full-payload copy a ByteArrayOutputStream would make.
-            byte[] payloadWithHmac = Arrays.copyOf(payload, payload.length + hmac.length);
-            System.arraycopy(hmac, 0, payloadWithHmac, payload.length, hmac.length);
-            return payloadWithHmac;
+            // Single-allocation concat (no ByteArrayOutputStream copy of the full payload).
+            return Utilities.concatenateByteArrays(payload, getHmac(payload, secretKey));
         } catch (Throwable e) {
             log.error("Could not create hmac", e);
             throw new RuntimeException("Could not create hmac", e);
@@ -124,10 +122,18 @@ public class Encryption {
         }
     }
 
-    private static byte[] getHmac(byte[] payload, SecretKey secretKey) throws NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException {
+    private static byte[] getHmac(byte[] payload, SecretKey secretKey) throws NoSuchAlgorithmException, InvalidKeyException {
+        return createHmac(secretKey).doFinal(payload);
+    }
+
+    /**
+     * Returns an initialized {@code HmacSHA256} Mac for the store hmac, so callers that verify
+     * streamed payloads use the same algorithm as the writers in this class.
+     */
+    public static Mac createHmac(SecretKey secretKey) throws NoSuchAlgorithmException, InvalidKeyException {
         Mac mac = Mac.getInstance(HMAC);
         mac.init(secretKey);
-        return mac.doFinal(payload);
+        return mac;
     }
 
 
@@ -141,36 +147,88 @@ public class Encryption {
     }
 
     /**
-     * Streams {@code encrypt(payload || hmac(payload))} directly to {@code outputStream} without
-     * ever holding the concatenated payload-with-hmac or the encrypted result fully in memory.
-     * This produces byte-identical output to {@link #encryptPayloadWithHmac(byte[], SecretKey)} but
-     * avoids the ~3x peak-memory amplification of the array based variant, which can throw
-     * OutOfMemoryError for large persisted stores (e.g. ClosedTrades for arbitrators with many trades).
+     * A payload that can be written to a stream more than once, producing identical bytes each time
+     * (e.g. a protobuf {@code Message::writeTo}). Lets hmac computation and encryption run as two
+     * write passes without ever materializing the payload as a single byte[].
+     */
+    public interface PayloadWriter {
+        void writeTo(OutputStream outputStream) throws IOException;
+    }
+
+    /**
+     * Streams {@code encrypt(payload || hmac(payload))} directly to {@code outputStream} with
+     * constant memory: pass 1 feeds the payload through the hmac, pass 2 feeds it through the
+     * cipher, so neither the payload, the payload-with-hmac nor the encrypted result is ever held
+     * fully in memory. This produces byte-identical output to
+     * {@link #encryptPayloadWithHmac(byte[], SecretKey)} so existing persisted files stay
+     * compatible, but cannot throw OutOfMemoryError for large persisted stores (e.g. ClosedTrades
+     * or DisputeLists for arbitrators with many trades).
      * The provided {@code outputStream} is not closed by this method.
      */
-    public static void encryptPayloadWithHmacToStream(byte[] payload, SecretKey secretKey, OutputStream outputStream) throws CryptoException {
+    public static void encryptPayloadWithHmacToStream(PayloadWriter payloadWriter, SecretKey secretKey, OutputStream outputStream) throws CryptoException {
         try {
-            byte[] hmac = getHmac(payload, secretKey);
+            Mac mac = createHmac(secretKey);
+            payloadWriter.writeTo(new MacUpdatingOutputStream(mac));
+            byte[] hmac = mac.doFinal();
+
             Cipher cipher = Cipher.getInstance(SYM_CIPHER);
             cipher.init(Cipher.ENCRYPT_MODE, secretKey);
-
-            // Encrypt the payload in chunks so we never allocate a full second copy of it.
-            int chunkSize = 64 * 1024;
-            byte[] outBuf = new byte[cipher.getOutputSize(chunkSize)];
-            int n;
-            for (int off = 0; off < payload.length; off += chunkSize) {
-                int len = Math.min(chunkSize, payload.length - off);
-                n = cipher.update(payload, off, len, outBuf, 0);
-                if (n > 0) outputStream.write(outBuf, 0, n);
+            // Closing the CipherOutputStream flushes the final padded block; the shield keeps the
+            // caller's stream open.
+            try (CipherOutputStream cipherOutputStream = new CipherOutputStream(new CloseShieldOutputStream(outputStream), cipher)) {
+                payloadWriter.writeTo(cipherOutputStream);
+                cipherOutputStream.write(hmac);
             }
-            // Append the hmac (also encrypted) and flush the final padded block.
-            n = cipher.update(hmac, 0, hmac.length, outBuf, 0);
-            if (n > 0) outputStream.write(outBuf, 0, n);
-            n = cipher.doFinal(outBuf, 0);
-            if (n > 0) outputStream.write(outBuf, 0, n);
         } catch (Throwable e) {
             log.error("error in encryptPayloadWithHmacToStream", e);
             throw new CryptoException(e);
+        }
+    }
+
+    /**
+     * Convenience overload for payloads already held in memory; writes in chunks so the cipher
+     * never allocates a full second copy.
+     */
+    public static void encryptPayloadWithHmacToStream(byte[] payload, SecretKey secretKey, OutputStream outputStream) throws CryptoException {
+        int chunkSize = 64 * 1024;
+        encryptPayloadWithHmacToStream(out -> {
+            for (int off = 0; off < payload.length; off += chunkSize) {
+                out.write(payload, off, Math.min(chunkSize, payload.length - off));
+            }
+        }, secretKey, outputStream);
+    }
+
+    private static class MacUpdatingOutputStream extends OutputStream {
+        private final Mac mac;
+
+        private MacUpdatingOutputStream(Mac mac) {
+            this.mac = mac;
+        }
+
+        @Override
+        public void write(int b) {
+            mac.update((byte) b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            mac.update(b, off, len);
+        }
+    }
+
+    private static class CloseShieldOutputStream extends FilterOutputStream {
+        private CloseShieldOutputStream(OutputStream out) {
+            super(out);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            out.write(b, off, len); // FilterOutputStream would write byte-by-byte
+        }
+
+        @Override
+        public void close() throws IOException {
+            flush(); // keep the underlying stream open
         }
     }
 
@@ -206,8 +264,7 @@ public class Encryption {
         try {
             Cipher cipher = Cipher.getInstance(SYM_CIPHER);
             cipher.init(Cipher.DECRYPT_MODE, secretKey);
-            Mac mac = Mac.getInstance(HMAC);
-            mac.init(secretKey);
+            Mac mac = createHmac(secretKey);
 
             // We feed every decrypted byte except the final 32 (the hmac) into the mac and count it as
             // payload; the final 32 bytes are kept in 'hold' and compared against the computed hmac at EOF.

--- a/common/src/main/java/haveno/common/crypto/Encryption.java
+++ b/common/src/main/java/haveno/common/crypto/Encryption.java
@@ -18,7 +18,7 @@
 package haveno.common.crypto;
 
 import haveno.common.util.Utilities;
-import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -101,11 +101,11 @@ public class Encryption {
     private static byte[] getPayloadWithHmac(byte[] payload, SecretKey secretKey) {
         try {
             byte[] hmac = getHmac(payload, secretKey);
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(payload.length + hmac.length)) {
-                outputStream.write(payload);
-                outputStream.write(hmac);
-                return outputStream.toByteArray();
-            }
+            // Append the hmac with a single copy (HMAC-SHA256 is always 32 bytes) to avoid the
+            // extra full-payload copy a ByteArrayOutputStream would make.
+            byte[] payloadWithHmac = Arrays.copyOf(payload, payload.length + hmac.length);
+            System.arraycopy(hmac, 0, payloadWithHmac, payload.length, hmac.length);
+            return payloadWithHmac;
         } catch (Throwable e) {
             log.error("Could not create hmac", e);
             throw new RuntimeException("Could not create hmac", e);
@@ -136,6 +136,40 @@ public class Encryption {
 
     public static byte[] encryptPayloadWithHmac(byte[] payload, SecretKey secretKey) throws CryptoException {
         return encrypt(getPayloadWithHmac(payload, secretKey), secretKey);
+    }
+
+    /**
+     * Streams {@code encrypt(payload || hmac(payload))} directly to {@code outputStream} without
+     * ever holding the concatenated payload-with-hmac or the encrypted result fully in memory.
+     * This produces byte-identical output to {@link #encryptPayloadWithHmac(byte[], SecretKey)} but
+     * avoids the ~3x peak-memory amplification of the array based variant, which can throw
+     * OutOfMemoryError for large persisted stores (e.g. ClosedTrades for arbitrators with many trades).
+     * The provided {@code outputStream} is not closed by this method.
+     */
+    public static void encryptPayloadWithHmacToStream(byte[] payload, SecretKey secretKey, OutputStream outputStream) throws CryptoException {
+        try {
+            byte[] hmac = getHmac(payload, secretKey);
+            Cipher cipher = Cipher.getInstance(SYM_CIPHER);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+
+            // Encrypt the payload in chunks so we never allocate a full second copy of it.
+            int chunkSize = 64 * 1024;
+            byte[] outBuf = new byte[cipher.getOutputSize(chunkSize)];
+            int n;
+            for (int off = 0; off < payload.length; off += chunkSize) {
+                int len = Math.min(chunkSize, payload.length - off);
+                n = cipher.update(payload, off, len, outBuf, 0);
+                if (n > 0) outputStream.write(outBuf, 0, n);
+            }
+            // Append the hmac (also encrypted) and flush the final padded block.
+            n = cipher.update(hmac, 0, hmac.length, outBuf, 0);
+            if (n > 0) outputStream.write(outBuf, 0, n);
+            n = cipher.doFinal(outBuf, 0);
+            if (n > 0) outputStream.write(outBuf, 0, n);
+        } catch (Throwable e) {
+            log.error("error in encryptPayloadWithHmacToStream", e);
+            throw new CryptoException(e);
+        }
     }
 
     public static byte[] decryptPayloadWithHmac(byte[] encryptedPayloadWithHmac, SecretKey secretKey) throws CryptoException {

--- a/common/src/main/java/haveno/common/file/FileUtil.java
+++ b/common/src/main/java/haveno/common/file/FileUtil.java
@@ -42,6 +42,10 @@ import java.util.Scanner;
 @Slf4j
 public class FileUtil {
 
+    // Where corrupted store files are preserved for recovery; referenced by the
+    // popup.warning.incompatibleDB resource string shown to the user.
+    public static final String CORRUPTED_BACKUP_FOLDER = "backup_of_corrupted_data";
+
     private static final String BACKUP_DIR = "backup";
     
     public static void rollingBackup(File dir, String fileName, int numMaxBackupFiles) {

--- a/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
+++ b/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
@@ -43,18 +43,23 @@ import lombok.extern.slf4j.Slf4j;
  * where {@code ciphertext = Encryption.encryptPayloadWithHmac(record)} (AES + trailing HMAC-SHA256).
  * The length prefix lives outside the ciphertext so frames can be located and a torn tail truncated
  * without decrypting. Each {@link #append(byte[])} fsyncs, so a fully-written frame is durable and a
- * process crash can only leave a partial trailing frame.
+ * process crash can only leave a partial trailing frame. A <i>failed</i> append (e.g. disk full) can
+ * also leave a partial trailing frame while the process keeps running; the log tracks its known-good
+ * length across successful writes and truncates such a tear away before the next append, so a torn
+ * frame can never end up buried mid-log by later appends.
  *
- * <p>Replay ({@link #readAllValidRecords()}) distinguishes the two failure modes:
+ * <p>Replay ({@link #readAllValidRecords()}) distinguishes the failure modes:
  * <ul>
  *   <li><b>Torn tail</b> (incomplete final frame from a crash mid-append): the log is truncated back
- *       to the last good frame boundary and the valid prefix is returned. This is the expected,
- *       silent self-repair.</li>
- *   <li><b>Corruption</b> (a fully-present frame whose HMAC fails — bit rot or tampering): the whole
- *       log is moved to {@code backup_of_corrupted_data/} (parity with {@code PersistenceManager}),
- *       a clean log is rebuilt from the valid prefix, and the prefix is returned so the maximum
- *       recoverable history survives. Logged loudly.</li>
+ *       to the last good frame boundary and the valid prefix is returned. Because a bit flip in an
+ *       (unauthenticated) length prefix mid-log is indistinguishable from a torn tail, the dropped
+ *       bytes are first preserved by copying the whole file to {@code backup_of_corrupted_data/}.</li>
+ *   <li><b>Corruption</b> (a non-positive length prefix, or a fully-present frame whose HMAC fails —
+ *       bit rot or tampering): the whole log is moved to {@code backup_of_corrupted_data/}, a clean
+ *       log is rebuilt from the valid prefix, and the prefix is returned so the maximum recoverable
+ *       history survives. Logged loudly.</li>
  * </ul>
+ * Backups use a timestamped file name so successive incidents never overwrite each other.
  *
  * <p>This class is generic (it deals in {@code byte[]} records and a symmetric key); domain encoding
  * is the caller's responsibility. Appends are serialized on the instance monitor so concurrent calls
@@ -64,13 +69,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class EncryptedAppendLog {
 
-    private static final String CORRUPTED_BACKUP_FOLDER = "backup_of_corrupted_data";
-
     private final File dir;
     private final String fileName;
     private final SecretKey secretKey;
     private final int numMaxBackupFiles;
     private final Object lock = new Object();
+    // File length up to which all frames are known intact. -1 until the first full replay (or
+    // rewrite) establishes it; maintained across appends so a failed append's partial frame can be
+    // truncated away before the next write instead of being buried by it.
+    private long knownGoodLength = -1;
 
     public EncryptedAppendLog(File dir, String fileName, SecretKey secretKey, int numMaxBackupFiles) {
         this.dir = dir;
@@ -95,18 +102,70 @@ public class EncryptedAppendLog {
      * Appends one record: encrypt + frame + write + fsync. Durable on return.
      */
     public void append(byte[] record) throws CryptoException {
-        byte[] ciphertext = Encryption.encryptPayloadWithHmac(record, secretKey);
+        appendAll(List.of(record));
+    }
+
+    /**
+     * Appends multiple records as consecutive frames with a single fsync. Durable on return; on
+     * failure the file is truncated back to its pre-call length, so the batch is all-or-nothing on
+     * disk (a crash between write and truncate leaves a tear that the next append or replay repairs).
+     */
+    public void appendAll(List<byte[]> records) throws CryptoException {
+        if (records.isEmpty()) return;
+        List<byte[]> ciphertexts = new ArrayList<>(records.size());
+        for (byte[] record : records) ciphertexts.add(Encryption.encryptPayloadWithHmac(record, secretKey));
         synchronized (lock) {
             if (!dir.exists() && !dir.mkdir()) log.warn("make dir failed {}", dir);
+            repairTailBeforeAppend();
+            long written = 0;
             try (FileOutputStream fos = new FileOutputStream(logFile(), true);
                  DataOutputStream out = new DataOutputStream(new BufferedOutputStream(fos))) {
-                out.writeInt(ciphertext.length);
-                out.write(ciphertext);
+                for (byte[] ciphertext : ciphertexts) {
+                    writeFrame(out, ciphertext);
+                    written += 4L + ciphertext.length;
+                }
                 out.flush();
                 fos.getFD().sync();
             } catch (IOException e) {
+                // The frame may have partially reached the disk. Truncate the tear away now
+                // (best effort; repairTailBeforeAppend covers us if this fails too).
+                try {
+                    truncateTo(logFile(), knownGoodLength);
+                } catch (IOException e2) {
+                    log.warn("Could not truncate {} back to {} after failed append", fileName, knownGoodLength, e2);
+                }
                 throw new RuntimeException("Could not append to " + fileName, e);
             }
+            knownGoodLength += written;
+        }
+    }
+
+    // Called under the instance lock before every append. Ensures the file ends exactly at the
+    // known-good frame boundary so a partial frame left by an earlier failed append (or anything
+    // else that changed the file) is removed before new frames are written after it.
+    private void repairTailBeforeAppend() {
+        if (knownGoodLength < 0) {
+            // First write of this session without a prior replay: replay once to validate the tail
+            // (and self-repair it), which also initializes knownGoodLength.
+            readAllValidRecords();
+            return;
+        }
+        File logFile = logFile();
+        long fileLength = logFile.exists() ? logFile.length() : 0;
+        if (fileLength == knownGoodLength) return;
+        if (fileLength < knownGoodLength) {
+            // The file shrank behind our back; fall back to a full replay to re-establish the boundary.
+            log.warn("{} is shorter ({}) than its known-good length ({}); re-validating.", fileName, fileLength, knownGoodLength);
+            knownGoodLength = -1;
+            readAllValidRecords();
+            return;
+        }
+        log.warn("Truncating {} bytes of torn/unknown tail from {} before appending (known-good length {}).",
+                fileLength - knownGoodLength, fileName, knownGoodLength);
+        try {
+            truncateTo(logFile, knownGoodLength);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not repair " + fileName + " before append", e);
         }
     }
 
@@ -118,7 +177,10 @@ public class EncryptedAppendLog {
         synchronized (lock) {
             File logFile = logFile();
             List<byte[]> records = new ArrayList<>();
-            if (!logFile.exists()) return records;
+            if (!logFile.exists()) {
+                knownGoodLength = 0;
+                return records;
+            }
 
             long fileLength = logFile.length();
             long goodLength = 0;
@@ -133,8 +195,14 @@ public class EncryptedAppendLog {
                         break;
                     }
                     int len = in.readInt();
-                    if (len <= 0 || len > remaining - 4) {
-                        tornTail = true; // garbage/torn length: ciphertext can't fit in remaining bytes
+                    if (len <= 0) {
+                        // append() only ever writes positive lengths, so a complete non-positive
+                        // prefix cannot be a torn write - it is corruption of the prefix itself.
+                        corrupt = true;
+                        break;
+                    }
+                    if (len > remaining - 4) {
+                        tornTail = true; // torn length or torn frame: ciphertext can't fit in remaining bytes
                         break;
                     }
                     byte[] ciphertext = new byte[len];
@@ -158,15 +226,25 @@ public class EncryptedAppendLog {
 
             try {
                 if (corrupt) {
+                    File backupFile = corruptedBackupFile();
                     log.error("Corrupt record in {} at offset {} (file length {}). Backing up to {} and " +
                                     "rebuilding from the {} valid leading record(s).",
-                            fileName, goodLength, fileLength, CORRUPTED_BACKUP_FOLDER, records.size());
-                    FileUtil.removeAndBackupFile(dir, logFile, fileName, CORRUPTED_BACKUP_FOLDER);
+                            fileName, goodLength, fileLength, backupFile, records.size());
+                    FileUtil.renameFile(logFile, backupFile);
                     rewrite(records);
                 } else if (tornTail && goodLength < fileLength) {
-                    log.warn("Truncating torn tail of {}: keeping {} bytes ({} valid record(s)), dropping {} bytes.",
-                            fileName, goodLength, records.size(), fileLength - goodLength);
+                    // A mid-log length-prefix corruption is indistinguishable from a genuine torn
+                    // tail, so preserve the dropped bytes before truncating - they may hold valid
+                    // frames that a smarter recovery (or a fixed build) can still extract.
+                    File backupFile = corruptedBackupFile();
+                    log.warn("Truncating torn tail of {}: keeping {} bytes ({} valid record(s)), dropping {} bytes. " +
+                                    "Pre-truncation copy preserved at {}.",
+                            fileName, goodLength, records.size(), fileLength - goodLength, backupFile);
+                    FileUtil.copyFile(logFile, backupFile);
                     truncateTo(logFile, goodLength);
+                    knownGoodLength = goodLength;
+                } else {
+                    knownGoodLength = fileLength;
                 }
             } catch (IOException e) {
                 throw new RuntimeException("Could not repair " + fileName, e);
@@ -187,12 +265,13 @@ public class EncryptedAppendLog {
             try {
                 if (!dir.exists() && !dir.mkdir()) log.warn("make dir failed {}", dir);
                 FileUtil.deleteFileIfExists(tempFile); // discard any stale temp from an interrupted rewrite
+                long written = 0;
                 try (FileOutputStream fos = new FileOutputStream(tempFile);
                      DataOutputStream out = new DataOutputStream(new BufferedOutputStream(fos))) {
                     for (byte[] record : records) {
                         byte[] ciphertext = Encryption.encryptPayloadWithHmac(record, secretKey);
-                        out.writeInt(ciphertext.length);
-                        out.write(ciphertext);
+                        writeFrame(out, ciphertext);
+                        written += 4L + ciphertext.length;
                     }
                     out.flush();
                     fos.getFD().sync();
@@ -200,6 +279,7 @@ public class EncryptedAppendLog {
                 // Keep a rolling backup of the pre-rewrite log as a safety net against a faulty compaction.
                 if (logFile.exists()) FileUtil.rollingBackup(dir, fileName, numMaxBackupFiles);
                 FileUtil.renameFile(tempFile, logFile);
+                knownGoodLength = written;
             } catch (IOException | CryptoException e) {
                 throw new RuntimeException("Could not rewrite " + fileName, e);
             } finally {
@@ -212,6 +292,19 @@ public class EncryptedAppendLog {
                 }
             }
         }
+    }
+
+    // The single place that knows the on-disk frame encoding: [4-byte big-endian length][ciphertext].
+    private static void writeFrame(DataOutputStream out, byte[] ciphertext) throws IOException {
+        out.writeInt(ciphertext.length);
+        out.write(ciphertext);
+    }
+
+    // Timestamped so successive incidents never overwrite an earlier backup.
+    private File corruptedBackupFile() {
+        File backupDir = new File(dir, FileUtil.CORRUPTED_BACKUP_FOLDER);
+        if (!backupDir.exists() && !backupDir.mkdir()) log.warn("make dir failed {}", backupDir);
+        return new File(backupDir, System.currentTimeMillis() + "_" + fileName);
     }
 
     private static void truncateTo(File file, long length) throws IOException {

--- a/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
+++ b/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
@@ -1,0 +1,223 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.persistence;
+
+import haveno.common.crypto.CryptoException;
+import haveno.common.crypto.Encryption;
+import haveno.common.file.FileUtil;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * An append-only, encrypted, crash-safe record log.
+ *
+ * <p>Each record is framed on disk as {@code [4-byte big-endian length N][N bytes ciphertext]},
+ * where {@code ciphertext = Encryption.encryptPayloadWithHmac(record)} (AES + trailing HMAC-SHA256).
+ * The length prefix lives outside the ciphertext so frames can be located and a torn tail truncated
+ * without decrypting. Each {@link #append(byte[])} fsyncs, so a fully-written frame is durable and a
+ * process crash can only leave a partial trailing frame.
+ *
+ * <p>Replay ({@link #readAllValidRecords()}) distinguishes the two failure modes:
+ * <ul>
+ *   <li><b>Torn tail</b> (incomplete final frame from a crash mid-append): the log is truncated back
+ *       to the last good frame boundary and the valid prefix is returned. This is the expected,
+ *       silent self-repair.</li>
+ *   <li><b>Corruption</b> (a fully-present frame whose HMAC fails — bit rot or tampering): the whole
+ *       log is moved to {@code backup_of_corrupted_data/} (parity with {@code PersistenceManager}),
+ *       a clean log is rebuilt from the valid prefix, and the prefix is returned so the maximum
+ *       recoverable history survives. Logged loudly.</li>
+ * </ul>
+ *
+ * <p>This class is generic (it deals in {@code byte[]} records and a symmetric key); domain encoding
+ * is the caller's responsibility. Appends are serialized on the instance monitor so concurrent calls
+ * cannot interleave frames; callers that need the log to match an in-memory order should append under
+ * their own ordering lock.
+ */
+@Slf4j
+public class EncryptedAppendLog {
+
+    private static final String CORRUPTED_BACKUP_FOLDER = "backup_of_corrupted_data";
+
+    private final File dir;
+    private final String fileName;
+    private final SecretKey secretKey;
+    private final int numMaxBackupFiles;
+    private final Object lock = new Object();
+
+    public EncryptedAppendLog(File dir, String fileName, SecretKey secretKey, int numMaxBackupFiles) {
+        this.dir = dir;
+        this.fileName = fileName;
+        this.secretKey = secretKey;
+        this.numMaxBackupFiles = numMaxBackupFiles;
+    }
+
+    private File logFile() {
+        return new File(dir, fileName);
+    }
+
+    private File tempFile() {
+        return new File(dir, fileName + ".tmp");
+    }
+
+    public boolean exists() {
+        return logFile().exists();
+    }
+
+    /**
+     * Appends one record: encrypt + frame + write + fsync. Durable on return.
+     */
+    public void append(byte[] record) throws CryptoException {
+        byte[] ciphertext = Encryption.encryptPayloadWithHmac(record, secretKey);
+        synchronized (lock) {
+            if (!dir.exists() && !dir.mkdir()) log.warn("make dir failed {}", dir);
+            try (FileOutputStream fos = new FileOutputStream(logFile(), true);
+                 DataOutputStream out = new DataOutputStream(new BufferedOutputStream(fos))) {
+                out.writeInt(ciphertext.length);
+                out.write(ciphertext);
+                out.flush();
+                fos.getFD().sync();
+            } catch (IOException e) {
+                throw new RuntimeException("Could not append to " + fileName, e);
+            }
+        }
+    }
+
+    /**
+     * Replays the log, returning the valid records in append order. Self-repairs a torn tail and
+     * backs up + rebuilds on mid-log corruption (see class javadoc).
+     */
+    public List<byte[]> readAllValidRecords() {
+        synchronized (lock) {
+            File logFile = logFile();
+            List<byte[]> records = new ArrayList<>();
+            if (!logFile.exists()) return records;
+
+            long fileLength = logFile.length();
+            long goodLength = 0;
+            boolean tornTail = false;
+            boolean corrupt = false;
+
+            try (DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(logFile)))) {
+                while (goodLength < fileLength) {
+                    long remaining = fileLength - goodLength;
+                    if (remaining < 4) {
+                        tornTail = true; // partial length prefix
+                        break;
+                    }
+                    int len = in.readInt();
+                    if (len <= 0 || len > remaining - 4) {
+                        tornTail = true; // garbage/torn length: ciphertext can't fit in remaining bytes
+                        break;
+                    }
+                    byte[] ciphertext = new byte[len];
+                    in.readFully(ciphertext);
+                    byte[] record;
+                    try {
+                        record = Encryption.decryptPayloadWithHmac(ciphertext, secretKey);
+                    } catch (CryptoException e) {
+                        // A fully-present frame that fails its HMAC is not a torn write -> real corruption.
+                        corrupt = true;
+                        break;
+                    }
+                    records.add(record);
+                    goodLength += 4L + len;
+                }
+            } catch (EOFException e) {
+                tornTail = true; // hit EOF mid-frame
+            } catch (IOException e) {
+                throw new RuntimeException("Could not read " + fileName, e);
+            }
+
+            try {
+                if (corrupt) {
+                    log.error("Corrupt record in {} at offset {} (file length {}). Backing up to {} and " +
+                                    "rebuilding from the {} valid leading record(s).",
+                            fileName, goodLength, fileLength, CORRUPTED_BACKUP_FOLDER, records.size());
+                    FileUtil.removeAndBackupFile(dir, logFile, fileName, CORRUPTED_BACKUP_FOLDER);
+                    rewrite(records);
+                } else if (tornTail && goodLength < fileLength) {
+                    log.warn("Truncating torn tail of {}: keeping {} bytes ({} valid record(s)), dropping {} bytes.",
+                            fileName, goodLength, records.size(), fileLength - goodLength);
+                    truncateTo(logFile, goodLength);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Could not repair " + fileName, e);
+            }
+            return records;
+        }
+    }
+
+    /**
+     * Atomically replaces the log with a fresh one containing exactly {@code records} (compaction or
+     * migration). Writes to a temp file, fsyncs, then renames into place; a failure leaves the
+     * existing log untouched.
+     */
+    public void rewrite(List<byte[]> records) {
+        synchronized (lock) {
+            File logFile = logFile();
+            File tempFile = tempFile();
+            try {
+                if (!dir.exists() && !dir.mkdir()) log.warn("make dir failed {}", dir);
+                FileUtil.deleteFileIfExists(tempFile); // discard any stale temp from an interrupted rewrite
+                try (FileOutputStream fos = new FileOutputStream(tempFile);
+                     DataOutputStream out = new DataOutputStream(new BufferedOutputStream(fos))) {
+                    for (byte[] record : records) {
+                        byte[] ciphertext = Encryption.encryptPayloadWithHmac(record, secretKey);
+                        out.writeInt(ciphertext.length);
+                        out.write(ciphertext);
+                    }
+                    out.flush();
+                    fos.getFD().sync();
+                }
+                // Keep a rolling backup of the pre-rewrite log as a safety net against a faulty compaction.
+                if (logFile.exists()) FileUtil.rollingBackup(dir, fileName, numMaxBackupFiles);
+                FileUtil.renameFile(tempFile, logFile);
+            } catch (IOException | CryptoException e) {
+                throw new RuntimeException("Could not rewrite " + fileName, e);
+            } finally {
+                if (tempFile.exists()) {
+                    try {
+                        FileUtil.deleteFileIfExists(tempFile);
+                    } catch (IOException ignore) {
+                        log.warn("Could not delete temp file {}", tempFile);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void truncateTo(File file, long length) throws IOException {
+        try (FileChannel ch = FileChannel.open(file.toPath(), StandardOpenOption.WRITE)) {
+            ch.truncate(length);
+            ch.force(true);
+        }
+    }
+}

--- a/common/src/main/java/haveno/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/haveno/common/persistence/PersistenceManager.java
@@ -37,12 +37,15 @@ import haveno.common.proto.persistable.PersistenceProtoResolver;
 import haveno.common.util.GcUtil;
 import static haveno.common.util.Preconditions.checkDir;
 import haveno.common.util.SingleThreadExecutorUtils;
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -52,6 +55,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -82,6 +86,9 @@ public class PersistenceManager<T extends PersistableEnvelope> {
     public static final Map<String, PersistenceManager<?>> ALL_PERSISTENCE_MANAGERS = new HashMap<>();
     private static boolean flushAtShutdownCalled;
     public static final AtomicBoolean allServicesInitialized = new AtomicBoolean(false);
+    // CipherInputStream pulls from the underlying stream in 512-byte chunks, so encrypted reads go
+    // through a buffer of this size to keep syscalls proportional to the buffer, not the chunk.
+    private static final int READ_BUFFER_SIZE = 64 * 1024;
 
     public static void onAllServicesInitialized() {
         allServicesInitialized.set(true);
@@ -391,7 +398,7 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             log.error("Reading {} failed with {}.", fileName, t.getMessage(), t);
             try {
                 // We keep a backup which might be used for recovery
-                FileUtil.removeAndBackupFile(dir, storageFile, fileName, "backup_of_corrupted_data");
+                FileUtil.removeAndBackupFile(dir, storageFile, fileName, FileUtil.CORRUPTED_BACKUP_FOLDER);
                 DevEnv.logErrorAndThrowIfDevMode(t.toString());
             } catch (IOException e1) {
                 e1.printStackTrace();
@@ -408,28 +415,65 @@ public class PersistenceManager<T extends PersistableEnvelope> {
     // Reads an encrypted store in two streaming passes so we never hold the whole decrypted payload in
     // memory (which previously caused OutOfMemoryError on large stores such as ClosedTrades). Pass 1
     // verifies the hmac and returns the payload length; pass 2 re-reads and parses only the verified
-    // payload bytes. A file that is not a valid encrypted store (e.g. a legacy unencrypted one) makes
-    // pass 1 throw CryptoException, in which case we fall back to reading it without decryption.
+    // payload bytes, re-checking the hmac over the bytes it actually parsed (the file could in theory
+    // change between the two opens, e.g. through an external backup/sync tool - pass 1's verification
+    // covered a different read). A file that is not a valid encrypted store (e.g. a legacy unencrypted
+    // one) makes pass 1 throw CryptoException, in which case we fall back to reading it without
+    // decryption. The raw FileInputStreams are buffered because CipherInputStream pulls from the
+    // underlying stream in 512-byte chunks - unbuffered, a large store costs ~2000 read syscalls per MB.
     private protobuf.PersistableEnvelope readEncrypted(File storageFile, SecretKey symmetricKey) throws Exception {
         long payloadLength;
-        try (FileInputStream verifyStream = new FileInputStream(storageFile)) {
+        try (InputStream verifyStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
             payloadLength = Encryption.verifyPayloadWithHmacStream(verifyStream, symmetricKey);
         } catch (CryptoException ce) {
             log.warn("Expected encrypted persisted file, attempting to getPersisted without decryption");
-            try (FileInputStream rawStream = new FileInputStream(storageFile)) {
+            try (InputStream rawStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
                 return protobuf.PersistableEnvelope.parseDelimitedFrom(rawStream);
             }
         }
-        try (FileInputStream parseStream = new FileInputStream(storageFile);
-             InputStream decryptStream = Encryption.decryptStream(parseStream, symmetricKey);
-             InputStream payloadStream = ByteStreams.limit(decryptStream, payloadLength)) {
+        try (InputStream parseStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE);
+             InputStream decryptStream = Encryption.decryptStream(parseStream, symmetricKey)) {
+            Mac mac = Encryption.createHmac(symmetricKey);
+            InputStream payloadStream = new MacUpdatingInputStream(ByteStreams.limit(decryptStream, payloadLength), mac);
             // The previous read used parseFrom(byte[]), whose array decoder imposes no message size limit.
             // The stream decoder defaults to a 64 MB limit, so we lift it explicitly; otherwise a large but
             // valid store (the very case this streaming read exists for) would throw "Protocol message too
             // large" and be wrongly moved to backup_of_corrupted_data.
             CodedInputStream codedInput = CodedInputStream.newInstance(payloadStream);
             codedInput.setSizeLimit(Integer.MAX_VALUE);
-            return protobuf.PersistableEnvelope.parseFrom(codedInput);
+            protobuf.PersistableEnvelope proto = protobuf.PersistableEnvelope.parseFrom(codedInput);
+            // Authenticate what we just parsed: consume the rest of the payload (if any), then compare
+            // the trailing hmac from this same read against the mac over the parsed bytes.
+            ByteStreams.exhaust(payloadStream);
+            byte[] expectedHmac = new byte[32];
+            ByteStreams.readFully(decryptStream, expectedHmac);
+            if (!Arrays.equals(mac.doFinal(), expectedHmac)) {
+                throw new IOException("Storage file " + storageFile.getName() + " changed while it was being read");
+            }
+            return proto;
+        }
+    }
+
+    private static class MacUpdatingInputStream extends FilterInputStream {
+        private final Mac mac;
+
+        private MacUpdatingInputStream(InputStream in, Mac mac) {
+            super(in);
+            this.mac = mac;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int b = in.read();
+            if (b >= 0) mac.update((byte) b);
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int read = in.read(b, off, len);
+            if (read > 0) mac.update(b, off, read);
+            return read;
         }
     }
 
@@ -540,10 +584,12 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             fileOutputStream = new FileOutputStream(tempFile);
 
             if (keyRing != null) {
-                // Stream the encryption directly to disk to avoid the peak-memory amplification of
-                // building the full encrypted byte[] in memory, which could throw OutOfMemoryError for
-                // large stores and silently leave the on-disk file frozen at the last successful write.
-                Encryption.encryptPayloadWithHmacToStream(serialized.toByteArray(), keyRing.getSymmetricKey(), fileOutputStream);
+                // Stream the encryption directly to disk with constant memory: the proto is written
+                // through the hmac and the cipher in two passes, so neither a serialized byte[] nor
+                // an encrypted byte[] of the whole store is ever built. The array-building variants
+                // could throw OutOfMemoryError for large stores and silently leave the on-disk file
+                // frozen at the last successful write.
+                Encryption.encryptPayloadWithHmacToStream(serialized::writeTo, keyRing.getSymmetricKey(), fileOutputStream);
             } else {
                 serialized.writeDelimitedTo(fileOutputStream);
             }

--- a/common/src/main/java/haveno/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/haveno/common/persistence/PersistenceManager.java
@@ -515,8 +515,10 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             fileOutputStream = new FileOutputStream(tempFile);
 
             if (keyRing != null) {
-                byte[] encryptedBytes = Encryption.encryptPayloadWithHmac(serialized.toByteArray(), keyRing.getSymmetricKey());
-                fileOutputStream.write(encryptedBytes);
+                // Stream the encryption directly to disk to avoid the peak-memory amplification of
+                // building the full encrypted byte[] in memory, which could throw OutOfMemoryError for
+                // large stores and silently leave the on-disk file frozen at the last successful write.
+                Encryption.encryptPayloadWithHmacToStream(serialized.toByteArray(), keyRing.getSymmetricKey(), fileOutputStream);
             } else {
                 serialized.writeDelimitedTo(fileOutputStream);
             }

--- a/common/src/main/java/haveno/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/haveno/common/persistence/PersistenceManager.java
@@ -18,8 +18,10 @@
 package haveno.common.persistence;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.google.protobuf.CodedInputStream;
 import haveno.common.Timer;
 import haveno.common.UserThread;
 import haveno.common.app.DevEnv;
@@ -35,11 +37,11 @@ import haveno.common.proto.persistable.PersistenceProtoResolver;
 import haveno.common.util.GcUtil;
 import static haveno.common.util.Preconditions.checkDir;
 import haveno.common.util.SingleThreadExecutorUtils;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -50,6 +52,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import javax.crypto.SecretKey;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -366,20 +369,14 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         }
 
         long ts = System.currentTimeMillis();
-        try (FileInputStream fileInputStream = new FileInputStream(storageFile)) {
+        try {
             protobuf.PersistableEnvelope proto;
             if (keyRing != null) {
-                byte[] encryptedBytes = fileInputStream.readAllBytes();
-                try {
-                    byte[] decryptedBytes = Encryption.decryptPayloadWithHmac(encryptedBytes, keyRing.getSymmetricKey());
-                    proto = protobuf.PersistableEnvelope.parseFrom(decryptedBytes);
-                } catch (CryptoException ce) {
-                    log.warn("Expected encrypted persisted file, attempting to getPersisted without decryption");
-                    ByteArrayInputStream bs = new ByteArrayInputStream(encryptedBytes);
-                    proto = protobuf.PersistableEnvelope.parseDelimitedFrom(bs);
-                }
+                proto = readEncrypted(storageFile, keyRing.getSymmetricKey());
             } else {
-                proto = protobuf.PersistableEnvelope.parseDelimitedFrom(fileInputStream);
+                try (FileInputStream fileInputStream = new FileInputStream(storageFile)) {
+                    proto = protobuf.PersistableEnvelope.parseDelimitedFrom(fileInputStream);
+                }
             }
 
             //noinspection unchecked
@@ -406,6 +403,34 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             }
         }
         return null;
+    }
+
+    // Reads an encrypted store in two streaming passes so we never hold the whole decrypted payload in
+    // memory (which previously caused OutOfMemoryError on large stores such as ClosedTrades). Pass 1
+    // verifies the hmac and returns the payload length; pass 2 re-reads and parses only the verified
+    // payload bytes. A file that is not a valid encrypted store (e.g. a legacy unencrypted one) makes
+    // pass 1 throw CryptoException, in which case we fall back to reading it without decryption.
+    private protobuf.PersistableEnvelope readEncrypted(File storageFile, SecretKey symmetricKey) throws Exception {
+        long payloadLength;
+        try (FileInputStream verifyStream = new FileInputStream(storageFile)) {
+            payloadLength = Encryption.verifyPayloadWithHmacStream(verifyStream, symmetricKey);
+        } catch (CryptoException ce) {
+            log.warn("Expected encrypted persisted file, attempting to getPersisted without decryption");
+            try (FileInputStream rawStream = new FileInputStream(storageFile)) {
+                return protobuf.PersistableEnvelope.parseDelimitedFrom(rawStream);
+            }
+        }
+        try (FileInputStream parseStream = new FileInputStream(storageFile);
+             InputStream decryptStream = Encryption.decryptStream(parseStream, symmetricKey);
+             InputStream payloadStream = ByteStreams.limit(decryptStream, payloadLength)) {
+            // The previous read used parseFrom(byte[]), whose array decoder imposes no message size limit.
+            // The stream decoder defaults to a 64 MB limit, so we lift it explicitly; otherwise a large but
+            // valid store (the very case this streaming read exists for) would throw "Protocol message too
+            // large" and be wrongly moved to backup_of_corrupted_data.
+            CodedInputStream codedInput = CodedInputStream.newInstance(payloadStream);
+            codedInput.setSizeLimit(Integer.MAX_VALUE);
+            return protobuf.PersistableEnvelope.parseFrom(codedInput);
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/common/src/test/java/haveno/common/crypto/EncryptionTest.java
+++ b/common/src/test/java/haveno/common/crypto/EncryptionTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.crypto;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Random;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EncryptionTest {
+
+    // Sizes around AES block (16) and stream chunk (64 KiB) boundaries, plus an empty payload.
+    private static final int[] SIZES = {0, 1, 15, 16, 17, 1000, 65_535, 65_536, 65_537, 100_000, 5_000_000};
+
+    @Test
+    public void testStreamWriteMatchesArrayAndRoundTrips() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        Random random = new Random(1234);
+        for (int size : SIZES) {
+            byte[] payload = new byte[size];
+            random.nextBytes(payload);
+
+            byte[] viaArray = Encryption.encryptPayloadWithHmac(payload, key);
+
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            Encryption.encryptPayloadWithHmacToStream(payload, key, bos);
+            byte[] viaStream = bos.toByteArray();
+
+            // The streaming variant must be byte-identical so existing persisted files stay readable.
+            assertArrayEquals(viaArray, viaStream, "ciphertext differs for payload size " + size);
+
+            // And it must decrypt back to the original payload with the existing array decrypt path.
+            byte[] decrypted = Encryption.decryptPayloadWithHmac(viaStream, key);
+            assertArrayEquals(payload, decrypted, "round-trip failed for payload size " + size);
+        }
+    }
+
+    @Test
+    public void testStreamDoesNotCloseOutputStream() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        TrackingOutputStream out = new TrackingOutputStream();
+        Encryption.encryptPayloadWithHmacToStream(new byte[1000], key, out);
+        assertEquals(false, out.closed, "stream must not be closed by the helper");
+    }
+
+    private static class TrackingOutputStream extends ByteArrayOutputStream {
+        boolean closed = false;
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/common/src/test/java/haveno/common/crypto/EncryptionTest.java
+++ b/common/src/test/java/haveno/common/crypto/EncryptionTest.java
@@ -54,6 +54,28 @@ public class EncryptionTest {
     }
 
     @Test
+    public void testWriterVariantMatchesArray() throws CryptoException {
+        // The PayloadWriter variant (used with protobuf Message::writeTo to avoid materializing the
+        // payload) must be byte-identical to the array variant, including when the payload arrives
+        // in many small writes as protobuf's 4 KB CodedOutputStream buffer produces.
+        SecretKey key = Encryption.generateSecretKey(256);
+        Random random = new Random(4321);
+        byte[] payload = new byte[300_000];
+        random.nextBytes(payload);
+
+        byte[] viaArray = Encryption.encryptPayloadWithHmac(payload, key);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        Encryption.encryptPayloadWithHmacToStream(out -> {
+            for (int off = 0; off < payload.length; off += 4096) {
+                out.write(payload, off, Math.min(4096, payload.length - off));
+            }
+        }, key, bos);
+
+        assertArrayEquals(viaArray, bos.toByteArray(), "writer-based ciphertext differs from array variant");
+    }
+
+    @Test
     public void testStreamDoesNotCloseOutputStream() throws CryptoException {
         SecretKey key = Encryption.generateSecretKey(256);
         TrackingOutputStream out = new TrackingOutputStream();

--- a/common/src/test/java/haveno/common/persistence/EncryptedAppendLogTest.java
+++ b/common/src/test/java/haveno/common/persistence/EncryptedAppendLogTest.java
@@ -70,6 +70,24 @@ public class EncryptedAppendLogTest {
         }
     }
 
+    // Backups are written to backup_of_corrupted_data/ with a timestamped name so incidents never
+    // overwrite each other.
+    private int corruptedBackupCount() {
+        File[] files = new File(dir, "backup_of_corrupted_data").listFiles((d, name) -> name.endsWith("_Test.log"));
+        return files == null ? 0 : files.length;
+    }
+
+    // Returns the byte offset of the given zero-based frame's length prefix.
+    private static int frameOffset(byte[] bytes, int frame) {
+        int offset = 0;
+        for (int i = 0; i < frame; i++) {
+            int len = ((bytes[offset] & 0xff) << 24) | ((bytes[offset + 1] & 0xff) << 16)
+                    | ((bytes[offset + 2] & 0xff) << 8) | (bytes[offset + 3] & 0xff);
+            offset += 4 + len;
+        }
+        return offset;
+    }
+
     @Test
     public void testEmptyLogReturnsEmpty() {
         assertFalse(newLog().exists());
@@ -121,6 +139,9 @@ public class EncryptedAppendLogTest {
         assertRecords(full, read);
         // The torn tail must have been repaired on disk.
         assertEquals(goodLength, logFile.length(), "log should be truncated back to last good frame");
+        // The dropped bytes must have been preserved first (a mid-log length corruption is
+        // indistinguishable from a torn tail, so nothing is ever destroyed without a copy).
+        assertEquals(1, corruptedBackupCount(), "pre-truncation copy must be preserved");
         // And a re-read returns the same clean prefix.
         assertRecords(full, newLog().readAllValidRecords());
     }
@@ -135,25 +156,89 @@ public class EncryptedAppendLogTest {
         byte[] bytes = Files.readAllBytes(logFile.toPath());
 
         // Find the ciphertext of the 3rd frame and flip a byte inside it (a full frame, not the tail).
-        int offset = 0;
-        int targetFrame = 2; // zero-based
-        int corruptBytePos = -1;
-        for (int frame = 0; frame <= targetFrame; frame++) {
-            int len = ((bytes[offset] & 0xff) << 24) | ((bytes[offset + 1] & 0xff) << 16)
-                    | ((bytes[offset + 2] & 0xff) << 8) | (bytes[offset + 3] & 0xff);
-            if (frame == targetFrame) corruptBytePos = offset + 4 + len / 2;
-            offset += 4 + len;
-        }
-        bytes[corruptBytePos] ^= 0x5a;
+        int offset = frameOffset(bytes, 2);
+        int len = ((bytes[offset] & 0xff) << 24) | ((bytes[offset + 1] & 0xff) << 16)
+                | ((bytes[offset + 2] & 0xff) << 8) | (bytes[offset + 3] & 0xff);
+        bytes[offset + 4 + len / 2] ^= 0x5a;
         Files.write(logFile.toPath(), bytes);
 
         List<byte[]> read = newLog().readAllValidRecords();
         // Only the valid leading prefix survives.
         assertRecords(List.of("keep-1", "keep-2"), read);
         // Original corrupt log preserved for recovery.
-        assertTrue(new File(dir, "backup_of_corrupted_data/Test.log").exists(), "corrupt log must be backed up");
+        assertEquals(1, corruptedBackupCount(), "corrupt log must be backed up");
         // Log rebuilt clean from the prefix; re-read is stable and equal.
         assertRecords(List.of("keep-1", "keep-2"), newLog().readAllValidRecords());
+    }
+
+    @Test
+    public void testCorruptedLengthPrefixIsBackedUpNotSilentlyTruncated() throws Exception {
+        EncryptedAppendLog log = newLog();
+        List<String> all = List.of("keep-1", "keep-2", "PREFIX-HIT", "after-1", "after-2");
+        for (String s : all) log.append(rec(s));
+
+        File logFile = new File(dir, "Test.log");
+        byte[] bytes = Files.readAllBytes(logFile.toPath());
+
+        // Flip the sign bit of the 3rd frame's length prefix (the prefix is outside the HMAC).
+        // A complete non-positive length can never come from a torn append, so this must be treated
+        // as corruption: whole file moved to backup, log rebuilt from the valid prefix.
+        bytes[frameOffset(bytes, 2)] |= (byte) 0x80;
+        Files.write(logFile.toPath(), bytes);
+
+        assertRecords(List.of("keep-1", "keep-2"), newLog().readAllValidRecords());
+        assertEquals(1, corruptedBackupCount(), "file with corrupted prefix must be backed up");
+        assertRecords(List.of("keep-1", "keep-2"), newLog().readAllValidRecords());
+    }
+
+    @Test
+    public void testOversizedLengthPrefixMidLogPreservesDroppedBytes() throws Exception {
+        EncryptedAppendLog log = newLog();
+        List<String> all = List.of("keep-1", "keep-2", "PREFIX-HIT", "after-1", "after-2");
+        for (String s : all) log.append(rec(s));
+
+        File logFile = new File(dir, "Test.log");
+        long originalLength = logFile.length();
+        byte[] bytes = Files.readAllBytes(logFile.toPath());
+
+        // Set a huge (but positive) length in the 3rd frame's prefix: indistinguishable from a torn
+        // tail, so the suffix is truncated - but only after the whole file is copied to backup.
+        int offset = frameOffset(bytes, 2);
+        bytes[offset] = 0x7f;
+        Files.write(logFile.toPath(), bytes);
+
+        assertRecords(List.of("keep-1", "keep-2"), newLog().readAllValidRecords());
+        assertEquals(1, corruptedBackupCount(), "dropped bytes must be preserved in a backup copy");
+        File[] backups = new File(dir, "backup_of_corrupted_data").listFiles((d, name) -> name.endsWith("_Test.log"));
+        assertEquals(originalLength, backups[0].length(), "backup must contain the full pre-truncation file");
+    }
+
+    @Test
+    public void testTornFrameFromFailedAppendIsRepairedBeforeNextAppend() throws Exception {
+        EncryptedAppendLog log = newLog();
+        for (String s : List.of("one", "two")) log.append(rec(s));
+
+        // Simulate a failed append (e.g. disk full) that left a partial frame: a plausible length
+        // prefix followed by too little ciphertext, written directly behind the good frames.
+        File logFile = new File(dir, "Test.log");
+        try (RandomAccessFile raf = new RandomAccessFile(logFile, "rw")) {
+            raf.seek(raf.length());
+            raf.writeInt(50_000); // claims 50 KB ciphertext...
+            raf.write(rec("...but only a few bytes made it"));
+        }
+
+        // The same instance already knows the good length, so the next append must truncate the
+        // torn frame away instead of burying it mid-log.
+        log.append(rec("three"));
+        assertRecords(List.of("one", "two", "three"), newLog().readAllValidRecords());
+    }
+
+    @Test
+    public void testAppendAllWritesBatchInOrder() throws Exception {
+        EncryptedAppendLog log = newLog();
+        log.append(rec("solo"));
+        log.appendAll(List.of(rec("batch-1"), rec("batch-2"), rec("batch-3")));
+        assertRecords(List.of("solo", "batch-1", "batch-2", "batch-3"), newLog().readAllValidRecords());
     }
 
     @Test
@@ -179,6 +264,6 @@ public class EncryptedAppendLogTest {
         EncryptedAppendLog wrongKeyLog = new EncryptedAppendLog(dir, "Test.log", Encryption.generateSecretKey(256), 3);
         List<byte[]> read = wrongKeyLog.readAllValidRecords();
         assertTrue(read.isEmpty(), "no records should be recovered with the wrong key");
-        assertTrue(new File(dir, "backup_of_corrupted_data/Test.log").exists());
+        assertEquals(1, corruptedBackupCount(), "undecryptable log must be backed up");
     }
 }

--- a/common/src/test/java/haveno/common/persistence/EncryptedAppendLogTest.java
+++ b/common/src/test/java/haveno/common/persistence/EncryptedAppendLogTest.java
@@ -1,0 +1,184 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.persistence;
+
+import haveno.common.crypto.Encryption;
+import haveno.common.file.FileUtil;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EncryptedAppendLogTest {
+
+    private File dir;
+    private SecretKey key;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        dir = File.createTempFile("append_log_test", "");
+        assertTrue(dir.delete());
+        assertTrue(dir.mkdir());
+        key = Encryption.generateSecretKey(256);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        FileUtil.deleteDirectory(dir);
+    }
+
+    private EncryptedAppendLog newLog() {
+        return new EncryptedAppendLog(dir, "Test.log", key, 3);
+    }
+
+    private static byte[] rec(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static void assertRecords(List<String> expected, List<byte[]> actual) {
+        assertEquals(expected.size(), actual.size(), "record count");
+        for (int i = 0; i < expected.size(); i++) {
+            assertArrayEquals(rec(expected.get(i)), actual.get(i), "record " + i);
+        }
+    }
+
+    @Test
+    public void testEmptyLogReturnsEmpty() {
+        assertFalse(newLog().exists());
+        assertTrue(newLog().readAllValidRecords().isEmpty());
+    }
+
+    @Test
+    public void testAppendThenReadInOrder() throws Exception {
+        EncryptedAppendLog log = newLog();
+        List<String> expected = List.of("alpha", "bravo", "charlie", "delta");
+        for (String s : expected) log.append(rec(s));
+        // Read with a fresh instance to prove durability across "restarts".
+        assertRecords(expected, newLog().readAllValidRecords());
+    }
+
+    @Test
+    public void testLargeRecordsAcrossCryptoChunkBoundary() throws Exception {
+        EncryptedAppendLog log = newLog();
+        Random random = new Random(42);
+        int[] sizes = {0, 1, 16, 65_535, 65_536, 65_537, 200_000};
+        List<byte[]> expected = new ArrayList<>();
+        for (int size : sizes) {
+            byte[] payload = new byte[size];
+            random.nextBytes(payload);
+            expected.add(payload);
+            log.append(payload);
+        }
+        List<byte[]> read = newLog().readAllValidRecords();
+        assertEquals(expected.size(), read.size());
+        for (int i = 0; i < expected.size(); i++) assertArrayEquals(expected.get(i), read.get(i), "size " + sizes[i]);
+    }
+
+    @Test
+    public void testTornTailIsTruncatedAndPrefixKept() throws Exception {
+        EncryptedAppendLog log = newLog();
+        List<String> full = List.of("one", "two", "three");
+        for (String s : full) log.append(rec(s));
+
+        File logFile = new File(dir, "Test.log");
+        long goodLength = logFile.length();
+
+        // Simulate a crash mid-append: append a 4th record, then chop its frame partway through.
+        log.append(rec("torn-tail-record-that-was-being-written"));
+        try (RandomAccessFile raf = new RandomAccessFile(logFile, "rw")) {
+            raf.setLength(goodLength + 5); // keep the 3 good frames + a few bytes of the 4th
+        }
+
+        List<byte[]> read = newLog().readAllValidRecords();
+        assertRecords(full, read);
+        // The torn tail must have been repaired on disk.
+        assertEquals(goodLength, logFile.length(), "log should be truncated back to last good frame");
+        // And a re-read returns the same clean prefix.
+        assertRecords(full, newLog().readAllValidRecords());
+    }
+
+    @Test
+    public void testMidLogCorruptionBacksUpAndRebuildsFromPrefix() throws Exception {
+        EncryptedAppendLog log = newLog();
+        List<String> all = List.of("keep-1", "keep-2", "CORRUPT-ME", "after-1", "after-2");
+        for (String s : all) log.append(rec(s));
+
+        File logFile = new File(dir, "Test.log");
+        byte[] bytes = Files.readAllBytes(logFile.toPath());
+
+        // Find the ciphertext of the 3rd frame and flip a byte inside it (a full frame, not the tail).
+        int offset = 0;
+        int targetFrame = 2; // zero-based
+        int corruptBytePos = -1;
+        for (int frame = 0; frame <= targetFrame; frame++) {
+            int len = ((bytes[offset] & 0xff) << 24) | ((bytes[offset + 1] & 0xff) << 16)
+                    | ((bytes[offset + 2] & 0xff) << 8) | (bytes[offset + 3] & 0xff);
+            if (frame == targetFrame) corruptBytePos = offset + 4 + len / 2;
+            offset += 4 + len;
+        }
+        bytes[corruptBytePos] ^= 0x5a;
+        Files.write(logFile.toPath(), bytes);
+
+        List<byte[]> read = newLog().readAllValidRecords();
+        // Only the valid leading prefix survives.
+        assertRecords(List.of("keep-1", "keep-2"), read);
+        // Original corrupt log preserved for recovery.
+        assertTrue(new File(dir, "backup_of_corrupted_data/Test.log").exists(), "corrupt log must be backed up");
+        // Log rebuilt clean from the prefix; re-read is stable and equal.
+        assertRecords(List.of("keep-1", "keep-2"), newLog().readAllValidRecords());
+    }
+
+    @Test
+    public void testRewriteReplacesContentAtomically() throws Exception {
+        EncryptedAppendLog log = newLog();
+        for (String s : List.of("old-1", "old-2", "old-3", "old-4")) log.append(rec(s));
+
+        List<byte[]> compacted = new ArrayList<>();
+        compacted.add(rec("new-a"));
+        compacted.add(rec("new-b"));
+        log.rewrite(compacted);
+
+        assertRecords(List.of("new-a", "new-b"), newLog().readAllValidRecords());
+        // Appends continue to work after a rewrite.
+        log.append(rec("new-c"));
+        assertRecords(List.of("new-a", "new-b", "new-c"), newLog().readAllValidRecords());
+    }
+
+    @Test
+    public void testWrongKeyTreatsRecordsAsCorrupt() throws Exception {
+        newLog().append(rec("secret"));
+        // A different key cannot decrypt -> first full frame fails HMAC -> treated as corruption.
+        EncryptedAppendLog wrongKeyLog = new EncryptedAppendLog(dir, "Test.log", Encryption.generateSecretKey(256), 3);
+        List<byte[]> read = wrongKeyLog.readAllValidRecords();
+        assertTrue(read.isEmpty(), "no records should be recovered with the wrong key");
+        assertTrue(new File(dir, "backup_of_corrupted_data/Test.log").exists());
+    }
+}

--- a/common/src/test/java/haveno/common/persistence/PersistenceManagerTest.java
+++ b/common/src/test/java/haveno/common/persistence/PersistenceManagerTest.java
@@ -18,6 +18,7 @@
 package haveno.common.persistence;
 
 import haveno.common.Payload;
+import haveno.common.crypto.Encryption;
 import haveno.common.crypto.KeyRing;
 import haveno.common.crypto.KeyStorage;
 import haveno.common.file.FileUtil;
@@ -32,9 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import javax.crypto.Cipher;
-import javax.crypto.CipherOutputStream;
-import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -103,18 +101,12 @@ public class PersistenceManagerTest {
         assertTrue(latch.await(15, TimeUnit.SECONDS), "write did not complete");
     }
 
-    // Writes encrypt(payload || hmac(payload)) to a file with constant memory, matching the on-disk
-    // format produced by PersistenceManager. Used to create large fixtures without the array encrypt's
-    // peak-memory amplification.
+    // Writes encrypt(payload || hmac(payload)) to a file with constant memory through the same
+    // production helper PersistenceManager uses, so the fixture format can never drift from the
+    // real writer. Avoids the array encrypt's peak-memory amplification for large fixtures.
     private void writeEncryptedFile(byte[] payload, SecretKey key, File file) throws Exception {
-        Mac mac = Mac.getInstance("HmacSHA256");
-        mac.init(key);
-        byte[] hmac = mac.doFinal(payload);
-        Cipher cipher = Cipher.getInstance("AES");
-        cipher.init(Cipher.ENCRYPT_MODE, key);
-        try (CipherOutputStream cos = new CipherOutputStream(new FileOutputStream(file), cipher)) {
-            cos.write(payload);
-            cos.write(hmac);
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            Encryption.encryptPayloadWithHmacToStream(payload, key, fos);
         }
     }
 

--- a/common/src/test/java/haveno/common/persistence/PersistenceManagerTest.java
+++ b/common/src/test/java/haveno/common/persistence/PersistenceManagerTest.java
@@ -1,0 +1,183 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.persistence;
+
+import haveno.common.Payload;
+import haveno.common.crypto.KeyRing;
+import haveno.common.crypto.KeyStorage;
+import haveno.common.file.FileUtil;
+import haveno.common.proto.persistable.NavigationPath;
+import haveno.common.proto.persistable.PersistableEnvelope;
+import haveno.common.proto.persistable.PersistablePayload;
+import haveno.common.proto.persistable.PersistenceProtoResolver;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PersistenceManagerTest {
+
+    private File dir;
+    private KeyRing keyRing;
+    private PersistenceManager<NavigationPath> persistenceManager;
+
+    private static final PersistenceProtoResolver RESOLVER = new PersistenceProtoResolver() {
+        @Override
+        public PersistableEnvelope fromProto(protobuf.PersistableEnvelope proto) {
+            if (proto.getMessageCase() == protobuf.PersistableEnvelope.MessageCase.NAVIGATION_PATH) {
+                return NavigationPath.fromProto(proto.getNavigationPath());
+            }
+            throw new IllegalArgumentException("Unexpected message case " + proto.getMessageCase());
+        }
+
+        @Override
+        public Payload fromProto(protobuf.PaymentAccountPayload proto) {
+            return null;
+        }
+
+        @Override
+        public PersistablePayload fromProto(protobuf.PersistableNetworkPayload proto) {
+            return null;
+        }
+    };
+
+    @BeforeEach
+    public void setup() throws Exception {
+        dir = File.createTempFile("persistence_test", "");
+        assertTrue(dir.delete());
+        assertTrue(dir.mkdir());
+        keyRing = new KeyRing(new KeyStorage(dir), null, true);
+        persistenceManager = new PersistenceManager<>(dir, RESOLVER, null, keyRing);
+        PersistenceManager.allServicesInitialized.set(true);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (persistenceManager != null) persistenceManager.shutdown();
+        // Restore the shared static flag so we don't leak state into other tests in the same JVM.
+        PersistenceManager.allServicesInitialized.set(false);
+        FileUtil.deleteDirectory(dir);
+    }
+
+    // A NavigationPath whose serialized form spans several 64 KiB streaming-decrypt chunks.
+    private NavigationPath largeNavigationPath() {
+        List<String> entries = new ArrayList<>();
+        for (int i = 0; i < 5000; i++) entries.add("navigation/path/segment/number/" + i + "/with/some/padding");
+        return new NavigationPath(entries);
+    }
+
+    private void persistAndWait(NavigationPath data, String fileName) throws InterruptedException {
+        persistenceManager.initialize(data, fileName, PersistenceManager.Source.PRIVATE);
+        CountDownLatch latch = new CountDownLatch(1);
+        persistenceManager.persistNow(latch::countDown);
+        assertTrue(latch.await(15, TimeUnit.SECONDS), "write did not complete");
+    }
+
+    // Writes encrypt(payload || hmac(payload)) to a file with constant memory, matching the on-disk
+    // format produced by PersistenceManager. Used to create large fixtures without the array encrypt's
+    // peak-memory amplification.
+    private void writeEncryptedFile(byte[] payload, SecretKey key, File file) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(key);
+        byte[] hmac = mac.doFinal(payload);
+        Cipher cipher = Cipher.getInstance("AES");
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+        try (CipherOutputStream cos = new CipherOutputStream(new FileOutputStream(file), cipher)) {
+            cos.write(payload);
+            cos.write(hmac);
+        }
+    }
+
+    @Test
+    public void testEncryptedWriteThenStreamingReadRoundTrip() throws Exception {
+        NavigationPath data = largeNavigationPath();
+        persistAndWait(data, "EncryptedStore");
+
+        // Sanity: the on-disk file is actually present.
+        assertTrue(new File(dir, "EncryptedStore").length() > 0);
+
+        NavigationPath read = persistenceManager.getPersisted("EncryptedStore");
+        assertEquals(data, read);
+    }
+
+    @Test
+    public void testLegacyUnencryptedFileIsStillReadable() throws Exception {
+        NavigationPath data = largeNavigationPath();
+        // Write the store the old, unencrypted way (delimited protobuf) directly to the storage file.
+        File storageFile = new File(dir, "LegacyStore");
+        try (FileOutputStream fos = new FileOutputStream(storageFile)) {
+            data.toProtoMessage().writeDelimitedTo(fos);
+        }
+        persistenceManager.initialize(data, "LegacyStore", PersistenceManager.Source.PRIVATE);
+
+        NavigationPath read = persistenceManager.getPersisted("LegacyStore");
+        assertEquals(data, read);
+    }
+
+    @Test
+    public void testStoreOverProtobufDefaultSizeLimitRoundTrips() throws Exception {
+        // A store whose serialized payload exceeds protobuf's default 64 MB stream-parse limit. The
+        // streaming read must lift that limit (as the old parseFrom(byte[]) path implicitly did) so a
+        // large valid store is not rejected as "Protocol message too large" and moved to backup.
+        int oversize = 66 * 1024 * 1024;
+        String big = "a".repeat(oversize); // Latin-1 -> compact (1 byte/char) on the heap
+        NavigationPath data = new NavigationPath(List.of(big));
+        byte[] payload = ((protobuf.PersistableEnvelope) data.toProtoMessage()).toByteArray();
+        writeEncryptedFile(payload, keyRing.getSymmetricKey(), new File(dir, "LargeStore"));
+        payload = null; // allow GC before the read rebuilds the payload
+        persistenceManager.initialize(data, "LargeStore", PersistenceManager.Source.PRIVATE);
+
+        NavigationPath read = persistenceManager.getPersisted("LargeStore");
+        assertEquals(1, read.getPath().size());
+        assertEquals(oversize, read.getPath().get(0).length());
+    }
+
+    @Test
+    public void testCorruptEncryptedFileIsMovedToBackup() throws Exception {
+        NavigationPath data = largeNavigationPath();
+        persistAndWait(data, "CorruptStore");
+
+        // Corrupt a swath of the ciphertext so neither decryption-verification nor the unencrypted
+        // fallback can parse it.
+        File storageFile = new File(dir, "CorruptStore");
+        byte[] bytes = java.nio.file.Files.readAllBytes(storageFile.toPath());
+        for (int i = 0; i < bytes.length; i++) bytes[i] ^= 0x5a;
+        java.nio.file.Files.write(storageFile.toPath(), bytes);
+
+        NavigationPath read = persistenceManager.getPersisted("CorruptStore");
+        assertNull(read, "corrupt file must not return data");
+        assertFalse(storageFile.exists(), "corrupt file should be moved out of place");
+        assertTrue(new File(dir, "backup_of_corrupted_data/CorruptStore").exists(),
+                "corrupt file should be preserved in backup_of_corrupted_data");
+    }
+}

--- a/core/src/main/java/haveno/core/trade/ClosedTradableManager.java
+++ b/core/src/main/java/haveno/core/trade/ClosedTradableManager.java
@@ -19,8 +19,8 @@ package haveno.core.trade;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import haveno.common.UserThread;
 import haveno.common.crypto.KeyRing;
-import haveno.common.persistence.PersistenceManager;
 import haveno.common.proto.persistable.PersistedDataHost;
 import haveno.core.offer.Offer;
 import haveno.core.offer.OpenOffer;
@@ -56,7 +56,7 @@ public class ClosedTradableManager implements PersistedDataHost {
     private final PriceFeedService priceFeedService;
     private final Preferences preferences;
     private final TradeStatisticsManager tradeStatisticsManager;
-    private final PersistenceManager<TradableList<Tradable>> persistenceManager;
+    private final ClosedTradesStore store;
     private final CleanupMailboxMessagesService cleanupMailboxMessagesService;
 
     private final TradableList<Tradable> closedTradables = new TradableList<>();
@@ -66,30 +66,45 @@ public class ClosedTradableManager implements PersistedDataHost {
                                  PriceFeedService priceFeedService,
                                  Preferences preferences,
                                  TradeStatisticsManager tradeStatisticsManager,
-                                 PersistenceManager<TradableList<Tradable>> persistenceManager,
+                                 ClosedTradesStore store,
                                  CleanupMailboxMessagesService cleanupMailboxMessagesService) {
         this.keyRing = keyRing;
         this.priceFeedService = priceFeedService;
         this.preferences = preferences;
         this.tradeStatisticsManager = tradeStatisticsManager;
         this.cleanupMailboxMessagesService = cleanupMailboxMessagesService;
-        this.persistenceManager = persistenceManager;
-
-        this.persistenceManager.initialize(closedTradables, "ClosedTrades", PersistenceManager.Source.PRIVATE);
+        this.store = store;
     }
 
     @Override
     public void readPersisted(Runnable completeHandler) {
-        persistenceManager.readPersisted(persisted -> {
-            synchronized (persisted.getList()) {
-                closedTradables.setAll(persisted.getList());
-                closedTradables.stream()
-                        .filter(tradable -> tradable.getOffer() != null)
-                        .forEach(tradable -> tradable.getOffer().setPriceFeedService(priceFeedService));
+        // Replay the append-only log off the user thread (it can be large), then publish to the
+        // in-memory ObservableList on the user thread, mirroring PersistenceManager.readPersisted.
+        new Thread(() -> {
+            List<Tradable> loaded;
+            try {
+                loaded = store.load();
+            } catch (OutOfMemoryError e) {
+                // Do not continue with a partial/empty list that a later append could overwrite;
+                // preserve the data and halt this path, mirroring the OOM handling in #2353.
+                throw e;
+            } catch (Throwable t) {
+                // A decode/parse fault must not hang startup (completeHandler would never run). The
+                // on-disk log is left untouched so a fixed build can still recover it; proceed empty.
+                log.error("Could not load closed trades; continuing with an empty list. The log on disk is left intact for recovery.", t);
+                loaded = List.of();
             }
-            completeHandler.run();
-        },
-        completeHandler);
+            List<Tradable> result = loaded;
+            UserThread.execute(() -> {
+                synchronized (closedTradables.getList()) {
+                    closedTradables.setAll(result);
+                    closedTradables.stream()
+                            .filter(tradable -> tradable.getOffer() != null)
+                            .forEach(tradable -> tradable.getOffer().setPriceFeedService(priceFeedService));
+                }
+                completeHandler.run();
+            });
+        }, "ClosedTradesStore-read").start();
     }
 
     public void onAllServicesInitialized() {
@@ -101,7 +116,7 @@ public class ClosedTradableManager implements PersistedDataHost {
         synchronized (closedTradables.getList()) {
             if (closedTradables.add(tradable)) {
                 maybeClearSensitiveData();
-                requestPersistence();
+                store.appendUpsert(tradable);
             }
         }
     }
@@ -109,7 +124,7 @@ public class ClosedTradableManager implements PersistedDataHost {
     public void remove(Tradable tradable) {
         synchronized (closedTradables.getList()) {
             if (closedTradables.remove(tradable)) {
-                requestPersistence();
+                store.appendDelete(tradable.getId());
             }
         }
     }
@@ -161,12 +176,16 @@ public class ClosedTradableManager implements PersistedDataHost {
     public void maybeClearSensitiveData() {
         synchronized (closedTradables.getList()) {
             log.info("checking closed trades eligibility for having sensitive data cleared");
+            List<Trade> cleared = new ArrayList<>();
             closedTradables.stream()
                 .filter(e -> e instanceof Trade)
                 .map(e -> (Trade) e)
                 .filter(e -> canTradeHaveSensitiveDataCleared(e.getId()))
-                .forEach(Trade::maybeClearSensitiveData);
-            requestPersistence();
+                .forEach(trade -> {
+                    if (trade.maybeClearSensitiveData()) cleared.add(trade);
+                });
+            // Persist only the trades that actually changed, so this stays cheap on every add().
+            cleared.forEach(store::appendUpsert);
         }
     }
 
@@ -228,14 +247,10 @@ public class ClosedTradableManager implements PersistedDataHost {
         return tradable instanceof MakerTrade || tradable.getOffer().isMyOffer(keyRing);
     }
 
-    private void requestPersistence() {
-        persistenceManager.requestPersistence();
-    }
-
     public void removeTrade(Trade trade) {
         synchronized (closedTradables.getList()) {
             if (closedTradables.remove(trade)) {
-                requestPersistence();
+                store.appendDelete(trade.getId());
             }
         }
     }

--- a/core/src/main/java/haveno/core/trade/ClosedTradableManager.java
+++ b/core/src/main/java/haveno/core/trade/ClosedTradableManager.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import haveno.common.UserThread;
 import haveno.common.crypto.KeyRing;
+import haveno.common.file.CorruptedStorageFileHandler;
 import haveno.common.proto.persistable.PersistedDataHost;
 import haveno.core.offer.Offer;
 import haveno.core.offer.OpenOffer;
@@ -57,9 +58,15 @@ public class ClosedTradableManager implements PersistedDataHost {
     private final Preferences preferences;
     private final TradeStatisticsManager tradeStatisticsManager;
     private final ClosedTradesStore store;
+    private final CorruptedStorageFileHandler corruptedStorageFileHandler;
     private final CleanupMailboxMessagesService cleanupMailboxMessagesService;
 
     private final TradableList<Tradable> closedTradables = new TradableList<>();
+    // Orders log appends with the list mutations they mirror: held across mutation + append so the
+    // log replays to the same list. The list monitor is only held for the in-memory part, so readers
+    // (including the JavaFX thread via UI bindings) never wait on disk I/O. Lock order is always
+    // persistLock -> list monitor; never take persistLock while holding the list monitor.
+    private final Object persistLock = new Object();
 
     @Inject
     public ClosedTradableManager(KeyRing keyRing,
@@ -67,11 +74,13 @@ public class ClosedTradableManager implements PersistedDataHost {
                                  Preferences preferences,
                                  TradeStatisticsManager tradeStatisticsManager,
                                  ClosedTradesStore store,
+                                 CorruptedStorageFileHandler corruptedStorageFileHandler,
                                  CleanupMailboxMessagesService cleanupMailboxMessagesService) {
         this.keyRing = keyRing;
         this.priceFeedService = priceFeedService;
         this.preferences = preferences;
         this.tradeStatisticsManager = tradeStatisticsManager;
+        this.corruptedStorageFileHandler = corruptedStorageFileHandler;
         this.cleanupMailboxMessagesService = cleanupMailboxMessagesService;
         this.store = store;
     }
@@ -90,8 +99,10 @@ public class ClosedTradableManager implements PersistedDataHost {
                 throw e;
             } catch (Throwable t) {
                 // A decode/parse fault must not hang startup (completeHandler would never run). The
-                // on-disk log is left untouched so a fixed build can still recover it; proceed empty.
+                // on-disk log is left untouched so a fixed build can still recover it; proceed empty
+                // but surface the problem to the user instead of failing silently.
                 log.error("Could not load closed trades; continuing with an empty list. The log on disk is left intact for recovery.", t);
+                corruptedStorageFileHandler.addFile(ClosedTradesStore.LOG_FILE_NAME);
                 loaded = List.of();
             }
             List<Tradable> result = loaded;
@@ -113,33 +124,44 @@ public class ClosedTradableManager implements PersistedDataHost {
     }
 
     public void add(Tradable tradable) {
-        synchronized (closedTradables.getList()) {
-            if (closedTradables.add(tradable)) {
-                maybeClearSensitiveData();
-                store.appendUpsert(tradable);
+        synchronized (persistLock) {
+            List<Trade> cleared;
+            synchronized (closedTradables.getList()) {
+                if (!closedTradables.add(tradable)) return;
+                cleared = clearSensitiveDataForEligibleTrades();
             }
+            // Serialize and write outside the list monitor; persistLock keeps the log ordered.
+            List<byte[]> entries = new ArrayList<>(cleared.size() + 1);
+            for (Trade trade : cleared) entries.add(ClosedTradesStore.upsertBytes(trade));
+            entries.add(ClosedTradesStore.upsertBytes(tradable));
+            store.appendEntries(entries);
         }
     }
 
     public void remove(Tradable tradable) {
-        synchronized (closedTradables.getList()) {
-            if (closedTradables.remove(tradable)) {
-                store.appendDelete(tradable.getId());
+        synchronized (persistLock) {
+            boolean removed;
+            synchronized (closedTradables.getList()) {
+                removed = closedTradables.remove(tradable);
             }
+            if (removed) store.appendEntries(List.of(ClosedTradesStore.deleteBytes(tradable.getId())));
         }
     }
 
     /**
-     * Re-persists an already-closed trade whose in-place mutable state changed (e.g. process data
-     * cleared on shut down). No-op if the trade is not in the closed list, so callers can invoke it
-     * unconditionally; pending trades keep their own whole-list flush. This restores what the old
-     * "serialize the whole list on flush" model captured implicitly for such mutations.
+     * Re-persists an already-closed trade whose in-place mutable state changed (e.g. payout or ack
+     * state updated after the close, process data cleared on shut down). No-op if the trade is not
+     * in the closed list, so callers can invoke it unconditionally; pending trades keep their own
+     * whole-list flush. This restores what the old "serialize the whole list on flush" model
+     * captured implicitly for such mutations.
      */
     public void persistClosedTrade(Trade trade) {
-        synchronized (closedTradables.getList()) {
-            if (closedTradables.stream().anyMatch(t -> t.getId().equals(trade.getId()))) {
-                store.appendUpsert(trade);
+        synchronized (persistLock) {
+            boolean contained;
+            synchronized (closedTradables.getList()) {
+                contained = closedTradables.stream().anyMatch(t -> t.getId().equals(trade.getId()));
             }
+            if (contained) store.appendEntries(List.of(ClosedTradesStore.upsertBytes(trade)));
         }
     }
 
@@ -188,19 +210,33 @@ public class ClosedTradableManager implements PersistedDataHost {
     }
 
     public void maybeClearSensitiveData() {
-        synchronized (closedTradables.getList()) {
-            log.info("checking closed trades eligibility for having sensitive data cleared");
-            List<Trade> cleared = new ArrayList<>();
-            closedTradables.stream()
+        synchronized (persistLock) {
+            List<Trade> cleared;
+            synchronized (closedTradables.getList()) {
+                cleared = clearSensitiveDataForEligibleTrades();
+            }
+            // Serialize and batch-write outside the list monitor (one fsync for the whole batch), so
+            // a mass clearing - e.g. when the user first enables the clear-data setting and thousands
+            // of trades become eligible at once - cannot stall readers or the UI on per-trade fsyncs.
+            List<byte[]> entries = new ArrayList<>(cleared.size());
+            for (Trade trade : cleared) entries.add(ClosedTradesStore.upsertBytes(trade));
+            store.appendEntries(entries);
+        }
+    }
+
+    // Clears sensitive data on all eligible trades and returns the ones that actually changed, so
+    // only those get re-persisted. Callers must hold the list monitor.
+    private List<Trade> clearSensitiveDataForEligibleTrades() {
+        log.info("checking closed trades eligibility for having sensitive data cleared");
+        List<Trade> cleared = new ArrayList<>();
+        closedTradables.stream()
                 .filter(e -> e instanceof Trade)
                 .map(e -> (Trade) e)
                 .filter(e -> canTradeHaveSensitiveDataCleared(e.getId()))
                 .forEach(trade -> {
                     if (trade.maybeClearSensitiveData()) cleared.add(trade);
                 });
-            // Persist only the trades that actually changed, so this stays cheap on every add().
-            cleared.forEach(store::appendUpsert);
-        }
+        return cleared;
     }
 
     public boolean canTradeHaveSensitiveDataCleared(String tradeId) {
@@ -262,10 +298,6 @@ public class ClosedTradableManager implements PersistedDataHost {
     }
 
     public void removeTrade(Trade trade) {
-        synchronized (closedTradables.getList()) {
-            if (closedTradables.remove(trade)) {
-                store.appendDelete(trade.getId());
-            }
-        }
+        remove(trade);
     }
 }

--- a/core/src/main/java/haveno/core/trade/ClosedTradableManager.java
+++ b/core/src/main/java/haveno/core/trade/ClosedTradableManager.java
@@ -129,6 +129,20 @@ public class ClosedTradableManager implements PersistedDataHost {
         }
     }
 
+    /**
+     * Re-persists an already-closed trade whose in-place mutable state changed (e.g. process data
+     * cleared on shut down). No-op if the trade is not in the closed list, so callers can invoke it
+     * unconditionally; pending trades keep their own whole-list flush. This restores what the old
+     * "serialize the whole list on flush" model captured implicitly for such mutations.
+     */
+    public void persistClosedTrade(Trade trade) {
+        synchronized (closedTradables.getList()) {
+            if (closedTradables.stream().anyMatch(t -> t.getId().equals(trade.getId()))) {
+                store.appendUpsert(trade);
+            }
+        }
+    }
+
     public boolean wasMyOffer(Offer offer) {
         return offer.isMyOffer(keyRing);
     }

--- a/core/src/main/java/haveno/core/trade/ClosedTradesStore.java
+++ b/core/src/main/java/haveno/core/trade/ClosedTradesStore.java
@@ -1,0 +1,224 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.trade;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+import com.google.protobuf.InvalidProtocolBufferException;
+import haveno.common.config.Config;
+import haveno.common.crypto.CryptoException;
+import haveno.common.crypto.KeyRing;
+import haveno.common.file.FileUtil;
+import haveno.common.persistence.EncryptedAppendLog;
+import haveno.common.persistence.PersistenceManager;
+import haveno.core.proto.persistable.CorePersistenceProtoResolver;
+import haveno.core.xmr.wallet.XmrWalletService;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Append-only, encrypted backing store for the closed-trade history.
+ *
+ * <p>Replaces the old "serialize the whole {@code TradableList} and atomically rewrite the {@code
+ * ClosedTrades} file on every change" model — which is O(n) per closed trade and was the root cause
+ * of the OOM-on-write that froze stores (issue #2383) — with an {@link EncryptedAppendLog}. Closing a
+ * trade appends one small record (O(1)); the full history is only re-encrypted during infrequent
+ * compaction. The in-memory {@code ObservableList} that the GUI binds to is unchanged.
+ *
+ * <p>The log holds {@link protobuf.TradableLogEntry} records: an {@code upsert} adds or replaces the
+ * tradable with the matching id, a {@code delete_id} tombstones one. Replaying in order
+ * (latest-wins per id, first-seen insertion order preserved) reconstructs the equivalent list.
+ */
+@Slf4j
+public class ClosedTradesStore {
+
+    static final String LEGACY_FILE_NAME = "ClosedTrades";          // old monolithic store
+    static final String LOG_FILE_NAME = "ClosedTrades.log";         // new append-only log
+    static final String LEGACY_BACKUP_NAME = "ClosedTrades.legacy-backup";
+
+    private static final int NUM_MAX_BACKUP_FILES = 3;
+    // Compact when the log holds a lot more records than live trades (mutations/tombstones accumulated)
+    // and it is worth the rewrite. Keeps replay bounded without rewriting on every small change.
+    private static final int MIN_RECORDS_FOR_COMPACTION = 512;
+    private static final int COMPACTION_RATIO = 2;
+
+    private final File dir;
+    private final KeyRing keyRing;
+    private final CorePersistenceProtoResolver protoResolver;
+    private final Provider<XmrWalletService> xmrWalletService;
+    // Used only for the one-time legacy read during migration; never initialize()d, so it is not
+    // registered for shutdown flush and will not rewrite the (renamed) legacy file.
+    private final PersistenceManager<TradableList<Tradable>> legacyPersistenceManager;
+
+    private EncryptedAppendLog appendLog;
+
+    @Inject
+    public ClosedTradesStore(@Named(Config.STORAGE_DIR) File dir,
+                             KeyRing keyRing,
+                             CorePersistenceProtoResolver protoResolver,
+                             Provider<XmrWalletService> xmrWalletService,
+                             PersistenceManager<TradableList<Tradable>> legacyPersistenceManager) {
+        this.dir = dir;
+        this.keyRing = keyRing;
+        this.protoResolver = protoResolver;
+        this.xmrWalletService = xmrWalletService;
+        this.legacyPersistenceManager = legacyPersistenceManager;
+    }
+
+    private EncryptedAppendLog appendLog() {
+        if (appendLog == null) {
+            SecretKey symmetricKey = keyRing.getSymmetricKey();
+            if (symmetricKey == null) throw new IllegalStateException("Cannot use ClosedTradesStore before the key ring is unlocked");
+            appendLog = new EncryptedAppendLog(dir, LOG_FILE_NAME, symmetricKey, NUM_MAX_BACKUP_FILES);
+        }
+        return appendLog;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Writes
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public void appendUpsert(Tradable tradable) {
+        append(protobuf.TradableLogEntry.newBuilder()
+                .setUpsert((protobuf.Tradable) tradable.toProtoMessage())
+                .build());
+    }
+
+    public void appendDelete(String id) {
+        append(protobuf.TradableLogEntry.newBuilder()
+                .setDeleteId(id)
+                .build());
+    }
+
+    private void append(protobuf.TradableLogEntry entry) {
+        try {
+            appendLog().append(entry.toByteArray());
+        } catch (CryptoException e) {
+            throw new RuntimeException("Could not append to " + LOG_FILE_NAME, e);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Read / replay
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Loads the closed trades, migrating a legacy monolithic store on first run. Returns the
+     * reconstructed list in original insertion order. Must be called with the key ring unlocked.
+     */
+    public List<Tradable> load() {
+        maybeMigrateLegacy();
+
+        List<byte[]> records = appendLog().readAllValidRecords();
+        // Replay keyed by id: upsert replaces in place (LinkedHashMap.put keeps the original position),
+        // delete removes. Iteration order is therefore the first-seen insertion order.
+        LinkedHashMap<String, Tradable> byId = new LinkedHashMap<>();
+        for (byte[] record : records) {
+            protobuf.TradableLogEntry entry;
+            try {
+                entry = protobuf.TradableLogEntry.parseFrom(record);
+            } catch (InvalidProtocolBufferException e) {
+                // Records are HMAC-authenticated, so a parse failure is a schema/version fault, not
+                // corruption; fail loudly rather than silently drop a trade.
+                throw new RuntimeException("Could not parse an authenticated TradableLogEntry from " + LOG_FILE_NAME, e);
+            }
+            switch (entry.getEntryCase()) {
+                case UPSERT:
+                    Tradable tradable = TradableList.tradableFromProto(entry.getUpsert(), protoResolver, xmrWalletService.get());
+                    byId.put(tradable.getId(), tradable);
+                    break;
+                case DELETE_ID:
+                    byId.remove(entry.getDeleteId());
+                    break;
+                default:
+                    log.warn("Ignoring {} record with no entry set", LOG_FILE_NAME);
+            }
+        }
+
+        List<Tradable> result = new ArrayList<>(byId.values());
+        maybeCompact(records.size(), result);
+        return result;
+    }
+
+    private void maybeCompact(int recordsRead, List<Tradable> liveTrades) {
+        int live = liveTrades.size();
+        if (!shouldCompact(recordsRead, live)) return;
+        log.info("Compacting {}: {} records -> {} live trades", LOG_FILE_NAME, recordsRead, live);
+        List<byte[]> compacted = new ArrayList<>(live);
+        for (Tradable tradable : liveTrades) compacted.add(upsertBytes(tradable));
+        appendLog().rewrite(compacted);
+    }
+
+    // Compact once the log carries enough superseded/tombstoned records that a rewrite is worth it,
+    // but never on every small change. Package-private for testing.
+    static boolean shouldCompact(int recordsRead, int liveTrades) {
+        return recordsRead > Math.max((long) liveTrades * COMPACTION_RATIO, MIN_RECORDS_FOR_COMPACTION);
+    }
+
+    private static byte[] upsertBytes(Tradable tradable) {
+        return protobuf.TradableLogEntry.newBuilder()
+                .setUpsert((protobuf.Tradable) tradable.toProtoMessage())
+                .build()
+                .toByteArray();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // Migration
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    // One-time migration: if the legacy monolithic ClosedTrades exists and no log does yet, read the
+    // legacy file once (reusing PersistenceManager's streaming decrypt), write its trades into a fresh
+    // log, and freeze the legacy file as a backup. The log is created via an atomic rename, so its
+    // existence means migration finished; a crash mid-migration simply re-runs it next start.
+    private void maybeMigrateLegacy() {
+        File logFile = new File(dir, LOG_FILE_NAME);
+        File legacyFile = new File(dir, LEGACY_FILE_NAME);
+        if (logFile.exists() || !legacyFile.exists()) return;
+
+        log.info("Migrating legacy monolithic {} to append-only {}", LEGACY_FILE_NAME, LOG_FILE_NAME);
+        TradableList<Tradable> legacy = legacyPersistenceManager.getPersisted(LEGACY_FILE_NAME);
+        if (legacy == null) {
+            // The read failed. Either it was transient (key ring not ready / shutting down) — in which
+            // case we must retry on a later start — or the file was genuinely corrupt, in which case
+            // getPersisted has already moved it to backup_of_corrupted_data (so legacyFile no longer
+            // exists and the next start skips migration). In neither case may we create an empty log and
+            // rename the legacy file to a backup: that would strand real history and block the retry.
+            log.warn("Legacy {} present but could not be read; deferring migration", LEGACY_FILE_NAME);
+            return;
+        }
+        List<byte[]> records = new ArrayList<>();
+        synchronized (legacy.getList()) {
+            for (Tradable tradable : legacy.getList()) records.add(upsertBytes(tradable));
+        }
+        appendLog().rewrite(records);
+
+        if (legacyFile.exists()) {
+            try {
+                FileUtil.renameFile(legacyFile, new File(dir, LEGACY_BACKUP_NAME));
+            } catch (IOException e) {
+                log.warn("Could not rename legacy {} to {}; leaving it in place", LEGACY_FILE_NAME, LEGACY_BACKUP_NAME, e);
+            }
+        }
+    }
+}

--- a/core/src/main/java/haveno/core/trade/ClosedTradesStore.java
+++ b/core/src/main/java/haveno/core/trade/ClosedTradesStore.java
@@ -20,10 +20,9 @@ package haveno.core.trade;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.name.Named;
-import com.google.protobuf.InvalidProtocolBufferException;
 import haveno.common.config.Config;
-import haveno.common.crypto.CryptoException;
 import haveno.common.crypto.KeyRing;
+import haveno.common.file.CorruptedStorageFileHandler;
 import haveno.common.file.FileUtil;
 import haveno.common.persistence.EncryptedAppendLog;
 import haveno.common.persistence.PersistenceManager;
@@ -32,8 +31,10 @@ import haveno.core.xmr.wallet.XmrWalletService;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,6 +50,11 @@ import lombok.extern.slf4j.Slf4j;
  * <p>The log holds {@link protobuf.TradableLogEntry} records: an {@code upsert} adds or replaces the
  * tradable with the matching id, a {@code delete_id} tombstones one. Replaying in order
  * (latest-wins per id, first-seen insertion order preserved) reconstructs the equivalent list.
+ *
+ * <p>Writes never throw into callers (trade completion and offer cancellation must not fail because
+ * a history write failed): a failed batch is kept in memory and retried in order before the next
+ * write. Callers are responsible for ordering: appends must be issued in the same order as the list
+ * mutations they mirror (see {@code ClosedTradableManager}'s persist lock).
  */
 @Slf4j
 public class ClosedTradesStore {
@@ -67,22 +73,28 @@ public class ClosedTradesStore {
     private final KeyRing keyRing;
     private final CorePersistenceProtoResolver protoResolver;
     private final Provider<XmrWalletService> xmrWalletService;
+    private final CorruptedStorageFileHandler corruptedStorageFileHandler;
     // Used only for the one-time legacy read during migration; never initialize()d, so it is not
     // registered for shutdown flush and will not rewrite the (renamed) legacy file.
     private final PersistenceManager<TradableList<Tradable>> legacyPersistenceManager;
 
     private EncryptedAppendLog appendLog;
+    // Entries whose write failed (e.g. disk full); retried in order before the next write so a
+    // transient failure delays durability instead of dropping history or breaking the caller.
+    private final List<byte[]> failedEntries = new ArrayList<>();
 
     @Inject
     public ClosedTradesStore(@Named(Config.STORAGE_DIR) File dir,
                              KeyRing keyRing,
                              CorePersistenceProtoResolver protoResolver,
                              Provider<XmrWalletService> xmrWalletService,
+                             CorruptedStorageFileHandler corruptedStorageFileHandler,
                              PersistenceManager<TradableList<Tradable>> legacyPersistenceManager) {
         this.dir = dir;
         this.keyRing = keyRing;
         this.protoResolver = protoResolver;
         this.xmrWalletService = xmrWalletService;
+        this.corruptedStorageFileHandler = corruptedStorageFileHandler;
         this.legacyPersistenceManager = legacyPersistenceManager;
     }
 
@@ -100,23 +112,56 @@ public class ClosedTradesStore {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void appendUpsert(Tradable tradable) {
-        append(protobuf.TradableLogEntry.newBuilder()
-                .setUpsert((protobuf.Tradable) tradable.toProtoMessage())
-                .build());
+        appendEntries(List.of(upsertBytes(tradable)));
     }
 
     public void appendDelete(String id) {
-        append(protobuf.TradableLogEntry.newBuilder()
-                .setDeleteId(id)
-                .build());
+        appendEntries(List.of(deleteBytes(id)));
     }
 
-    private void append(protobuf.TradableLogEntry entry) {
-        try {
-            appendLog().append(entry.toByteArray());
-        } catch (CryptoException e) {
-            throw new RuntimeException("Could not append to " + LOG_FILE_NAME, e);
+    /**
+     * Appends the given pre-encoded {@link protobuf.TradableLogEntry} records as one batch with a
+     * single fsync. Never throws (a failed batch is kept and retried before the next write) except
+     * for {@link OutOfMemoryError}, which is rethrown so heap exhaustion is never mistaken for a
+     * write failure.
+     */
+    public void appendEntries(List<byte[]> entries) {
+        synchronized (failedEntries) {
+            List<byte[]> batch;
+            if (failedEntries.isEmpty()) {
+                batch = entries;
+            } else {
+                batch = new ArrayList<>(failedEntries.size() + entries.size());
+                batch.addAll(failedEntries);
+                batch.addAll(entries);
+            }
+            if (batch.isEmpty()) return;
+            try {
+                appendLog().appendAll(batch);
+                failedEntries.clear();
+            } catch (OutOfMemoryError e) {
+                throw e;
+            } catch (Throwable t) {
+                log.error("Could not append {} record(s) to {}; keeping them in memory and retrying on the next write.",
+                        batch.size(), LOG_FILE_NAME, t);
+                failedEntries.clear();
+                failedEntries.addAll(batch);
+            }
         }
+    }
+
+    static byte[] upsertBytes(Tradable tradable) {
+        return protobuf.TradableLogEntry.newBuilder()
+                .setUpsert((protobuf.Tradable) tradable.toProtoMessage())
+                .build()
+                .toByteArray();
+    }
+
+    static byte[] deleteBytes(String id) {
+        return protobuf.TradableLogEntry.newBuilder()
+                .setDeleteId(id)
+                .build()
+                .toByteArray();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -124,40 +169,64 @@ public class ClosedTradesStore {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * Loads the closed trades, migrating a legacy monolithic store on first run. Returns the
-     * reconstructed list in original insertion order. Must be called with the key ring unlocked.
+     * Loads the closed trades, merging in any legacy monolithic store that has not been migrated
+     * yet. Returns the reconstructed list in original insertion order. Must be called with the key
+     * ring unlocked.
+     *
+     * <p>Records that are authenticated but cannot be decoded (schema from a newer version, or a
+     * decode fault) are skipped rather than failing the whole load; when that happens the log is
+     * reported via {@link CorruptedStorageFileHandler} so the user is notified, and compaction is
+     * suppressed so the skipped records stay on disk for a fixed build to recover.
      */
     public List<Tradable> load() {
-        maybeMigrateLegacy();
-
         List<byte[]> records = appendLog().readAllValidRecords();
+
         // Replay keyed by id: upsert replaces in place (LinkedHashMap.put keeps the original position),
-        // delete removes. Iteration order is therefore the first-seen insertion order.
+        // delete removes. Iteration order is therefore the first-seen insertion order. seenIds tracks
+        // every id the log has ever mentioned (including tombstoned ones) for the legacy merge below.
         LinkedHashMap<String, Tradable> byId = new LinkedHashMap<>();
+        Set<String> seenIds = new HashSet<>();
+        int skipped = 0;
         for (byte[] record : records) {
-            protobuf.TradableLogEntry entry;
             try {
-                entry = protobuf.TradableLogEntry.parseFrom(record);
-            } catch (InvalidProtocolBufferException e) {
-                // Records are HMAC-authenticated, so a parse failure is a schema/version fault, not
-                // corruption; fail loudly rather than silently drop a trade.
-                throw new RuntimeException("Could not parse an authenticated TradableLogEntry from " + LOG_FILE_NAME, e);
-            }
-            switch (entry.getEntryCase()) {
-                case UPSERT:
-                    Tradable tradable = TradableList.tradableFromProto(entry.getUpsert(), protoResolver, xmrWalletService.get());
-                    byId.put(tradable.getId(), tradable);
-                    break;
-                case DELETE_ID:
-                    byId.remove(entry.getDeleteId());
-                    break;
-                default:
-                    log.warn("Ignoring {} record with no entry set", LOG_FILE_NAME);
+                protobuf.TradableLogEntry entry = protobuf.TradableLogEntry.parseFrom(record);
+                switch (entry.getEntryCase()) {
+                    case UPSERT:
+                        Tradable tradable = TradableList.tradableFromProto(entry.getUpsert(), protoResolver, xmrWalletService.get());
+                        byId.put(tradable.getId(), tradable);
+                        seenIds.add(tradable.getId());
+                        break;
+                    case DELETE_ID:
+                        byId.remove(entry.getDeleteId());
+                        seenIds.add(entry.getDeleteId());
+                        break;
+                    default:
+                        // An authenticated record with no known entry set is most likely a new entry
+                        // type written by a newer version; keep it on disk and continue.
+                        log.warn("Skipping {} record with unknown entry type", LOG_FILE_NAME);
+                        skipped++;
+                }
+            } catch (OutOfMemoryError e) {
+                throw e;
+            } catch (Throwable t) {
+                // Authenticated but undecodable (e.g. written by a newer version). Skip just this
+                // record instead of hiding the whole history; it stays on disk for recovery.
+                log.error("Skipping an undecodable record in {}", LOG_FILE_NAME, t);
+                skipped++;
             }
         }
+        if (skipped > 0) {
+            log.error("Skipped {} undecodable record(s) while loading {}. They remain on disk; compaction is suppressed.",
+                    skipped, LOG_FILE_NAME);
+            corruptedStorageFileHandler.addFile(LOG_FILE_NAME);
+        }
+
+        maybeMergeLegacy(byId, seenIds);
 
         List<Tradable> result = new ArrayList<>(byId.values());
-        maybeCompact(records.size(), result);
+        // Never compact while undecodable records exist - a rewrite from the decoded trades would
+        // permanently drop them.
+        if (skipped == 0) maybeCompact(records.size(), result);
         return result;
     }
 
@@ -176,49 +245,58 @@ public class ClosedTradesStore {
         return recordsRead > Math.max((long) liveTrades * COMPACTION_RATIO, MIN_RECORDS_FOR_COMPACTION);
     }
 
-    private static byte[] upsertBytes(Tradable tradable) {
-        return protobuf.TradableLogEntry.newBuilder()
-                .setUpsert((protobuf.Tradable) tradable.toProtoMessage())
-                .build()
-                .toByteArray();
-    }
-
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Migration
     ///////////////////////////////////////////////////////////////////////////////////////////
 
-    // One-time migration: if the legacy monolithic ClosedTrades exists and no log does yet, read the
-    // legacy file once (reusing PersistenceManager's streaming decrypt), write its trades into a fresh
-    // log, and freeze the legacy file as a backup. The log is created via an atomic rename, so its
-    // existence means migration finished; a crash mid-migration simply re-runs it next start.
-    private void maybeMigrateLegacy() {
-        File logFile = new File(dir, LOG_FILE_NAME);
+    // Merges a legacy monolithic ClosedTrades file into the log whenever one is present - not only
+    // on first run. Gating on the log's existence would permanently orphan legacy history whenever a
+    // legacy file (re)appears after the log was created, e.g. after a downgrade/upgrade cycle (the
+    // old build recreates "ClosedTrades" for trades closed while downgraded) or after a deferred
+    // first migration in a session that already appended. Only trades whose id the log has never
+    // mentioned are merged, so tombstoned or updated trades are not resurrected. The legacy file is
+    // renamed to a backup only after the merge is durably appended; a failure defers to a later start.
+    private void maybeMergeLegacy(LinkedHashMap<String, Tradable> byId, Set<String> seenIds) {
         File legacyFile = new File(dir, LEGACY_FILE_NAME);
-        if (logFile.exists() || !legacyFile.exists()) return;
+        if (!legacyFile.exists()) return;
 
-        log.info("Migrating legacy monolithic {} to append-only {}", LEGACY_FILE_NAME, LOG_FILE_NAME);
+        log.info("Merging legacy monolithic {} into append-only {}", LEGACY_FILE_NAME, LOG_FILE_NAME);
         TradableList<Tradable> legacy = legacyPersistenceManager.getPersisted(LEGACY_FILE_NAME);
         if (legacy == null) {
-            // The read failed. Either it was transient (key ring not ready / shutting down) — in which
-            // case we must retry on a later start — or the file was genuinely corrupt, in which case
+            // The read failed. Either it was transient (key ring not ready / shutting down) - in which
+            // case we must retry on a later start - or the file was genuinely corrupt, in which case
             // getPersisted has already moved it to backup_of_corrupted_data (so legacyFile no longer
-            // exists and the next start skips migration). In neither case may we create an empty log and
-            // rename the legacy file to a backup: that would strand real history and block the retry.
+            // exists and the next start skips the merge). In neither case may we rename the legacy
+            // file: that would strand real history and block the retry.
             log.warn("Legacy {} present but could not be read; deferring migration", LEGACY_FILE_NAME);
             return;
         }
-        List<byte[]> records = new ArrayList<>();
+        List<byte[]> entries = new ArrayList<>();
+        List<Tradable> merged = new ArrayList<>();
         synchronized (legacy.getList()) {
-            for (Tradable tradable : legacy.getList()) records.add(upsertBytes(tradable));
-        }
-        appendLog().rewrite(records);
-
-        if (legacyFile.exists()) {
-            try {
-                FileUtil.renameFile(legacyFile, new File(dir, LEGACY_BACKUP_NAME));
-            } catch (IOException e) {
-                log.warn("Could not rename legacy {} to {}; leaving it in place", LEGACY_FILE_NAME, LEGACY_BACKUP_NAME, e);
+            for (Tradable tradable : legacy.getList()) {
+                if (seenIds.contains(tradable.getId())) continue; // already migrated, superseded, or deliberately deleted
+                entries.add(upsertBytes(tradable));
+                merged.add(tradable);
             }
+        }
+        try {
+            appendLog().appendAll(entries);
+        } catch (OutOfMemoryError e) {
+            throw e;
+        } catch (Throwable t) {
+            log.warn("Could not append legacy {} trades to {}; deferring migration", LEGACY_FILE_NAME, LOG_FILE_NAME, t);
+            return;
+        }
+        for (Tradable tradable : merged) byId.put(tradable.getId(), tradable);
+
+        try {
+            File backupFile = new File(dir, LEGACY_BACKUP_NAME);
+            // Keep any earlier backup (it may hold the original pre-migration history).
+            if (backupFile.exists()) backupFile = new File(dir, LEGACY_BACKUP_NAME + "." + System.currentTimeMillis());
+            FileUtil.renameFile(legacyFile, backupFile);
+        } catch (IOException e) {
+            log.warn("Could not rename legacy {} to a backup; leaving it in place", LEGACY_FILE_NAME, e);
         }
     }
 }

--- a/core/src/main/java/haveno/core/trade/TradableList.java
+++ b/core/src/main/java/haveno/core/trade/TradableList.java
@@ -63,29 +63,37 @@ public final class TradableList<T extends Tradable> extends PersistableListAsObs
                                                    CoreProtoResolver coreProtoResolver,
                                                    XmrWalletService xmrWalletService) {
         List<Tradable> list = proto.getTradableList().stream()
-                .map(tradable -> {
-                    switch (tradable.getMessageCase()) {
-                        case OPEN_OFFER:
-                            return OpenOffer.fromProto(tradable.getOpenOffer());
-                        case BUYER_AS_MAKER_TRADE:
-                            return BuyerAsMakerTrade.fromProto(tradable.getBuyerAsMakerTrade(), xmrWalletService, coreProtoResolver);
-                        case BUYER_AS_TAKER_TRADE:
-                            return BuyerAsTakerTrade.fromProto(tradable.getBuyerAsTakerTrade(), xmrWalletService, coreProtoResolver);
-                        case SELLER_AS_MAKER_TRADE:
-                            return SellerAsMakerTrade.fromProto(tradable.getSellerAsMakerTrade(), xmrWalletService, coreProtoResolver);
-                        case SELLER_AS_TAKER_TRADE:
-                            return SellerAsTakerTrade.fromProto(tradable.getSellerAsTakerTrade(), xmrWalletService, coreProtoResolver);
-                        case ARBITRATOR_TRADE:
-                            return ArbitratorTrade.fromProto(tradable.getArbitratorTrade(), xmrWalletService, coreProtoResolver);
-                        default:
-                            log.error("Unknown messageCase. tradable.getMessageCase() = " + tradable.getMessageCase());
-                            throw new ProtobufferRuntimeException("Unknown messageCase. tradable.getMessageCase() = " +
-                                    tradable.getMessageCase());
-                    }
-                })
+                .map(tradable -> tradableFromProto(tradable, coreProtoResolver, xmrWalletService))
                 .collect(Collectors.toList());
 
         return new TradableList<>(list);
+    }
+
+    /**
+     * Reconstructs a single {@link Tradable} from its proto. Shared by {@link #fromProto} and the
+     * append-only ClosedTrades log so both decode records through one switch.
+     */
+    public static Tradable tradableFromProto(protobuf.Tradable tradable,
+                                             CoreProtoResolver coreProtoResolver,
+                                             XmrWalletService xmrWalletService) {
+        switch (tradable.getMessageCase()) {
+            case OPEN_OFFER:
+                return OpenOffer.fromProto(tradable.getOpenOffer());
+            case BUYER_AS_MAKER_TRADE:
+                return BuyerAsMakerTrade.fromProto(tradable.getBuyerAsMakerTrade(), xmrWalletService, coreProtoResolver);
+            case BUYER_AS_TAKER_TRADE:
+                return BuyerAsTakerTrade.fromProto(tradable.getBuyerAsTakerTrade(), xmrWalletService, coreProtoResolver);
+            case SELLER_AS_MAKER_TRADE:
+                return SellerAsMakerTrade.fromProto(tradable.getSellerAsMakerTrade(), xmrWalletService, coreProtoResolver);
+            case SELLER_AS_TAKER_TRADE:
+                return SellerAsTakerTrade.fromProto(tradable.getSellerAsTakerTrade(), xmrWalletService, coreProtoResolver);
+            case ARBITRATOR_TRADE:
+                return ArbitratorTrade.fromProto(tradable.getArbitratorTrade(), xmrWalletService, coreProtoResolver);
+            default:
+                log.error("Unknown messageCase. tradable.getMessageCase() = " + tradable.getMessageCase());
+                throw new ProtobufferRuntimeException("Unknown messageCase. tradable.getMessageCase() = " +
+                        tradable.getMessageCase());
+        }
     }
 
     @Override

--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -1948,7 +1948,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
         
         // clear process data and shut down trade
         ThreadUtils.execute(() -> {
-            clearProcessData();
+            if (clearProcessData()) maybePersistClearedClosedTrade();
             onShutDownStarted();
             ThreadUtils.submitToPool(() -> { // run off trade thread
                 try {
@@ -1965,7 +1965,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
     private void clearAndShutDownBeforeInitialized() {
         if (isShutDown) return; // ignore if already shut down
         onShutDownStarted();
-        clearProcessData();
+        if (clearProcessData()) maybePersistClearedClosedTrade();
         onShutDownStarted();
         removeDecryptedDirectMessageListener();
         xmrConnectionService.removeConnectionListener(this);
@@ -1975,11 +1975,18 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
         isShutDown = true;
     }
 
-    private void clearProcessData() {
+    /**
+     * Clears process data (trade wallet and peer tx/message fields) once the trade is finished.
+     *
+     * @return true if it cleared this call (false if already cleared), so callers can persist the
+     *         cleared state to the closed-trades log — the append-only store does not otherwise
+     *         capture in-place mutations of an already-closed trade.
+     */
+    private boolean clearProcessData() {
 
         // delete trade wallet
         synchronized (walletLock) {
-            if (!walletExists()) return; // done if already cleared
+            if (!walletExists()) return false; // done if already cleared
             deleteWallet();
         }
 
@@ -1994,6 +2001,14 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
             if (peer.isPaymentReceivedMessageAckedOrNacked() || isPayoutFinalized()) peer.setUnsignedPayoutTxHex(null);
             if (peer.isPaymentReceivedMessageAckedOrNacked()) peer.setPaymentReceivedMessage(null);
         }
+        return true;
+    }
+
+    // Persist the just-cleared state if this trade lives in the closed-trades log; a no-op otherwise
+    // (pending trades are persisted via TradeManager's whole-list flush).
+    private void maybePersistClearedClosedTrade() {
+        TradeManager tradeManager = processModel.getTradeManager();
+        if (tradeManager != null) tradeManager.persistClosedTrade(this);
     }
 
     private void removeDecryptedDirectMessageListener() {

--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -2001,7 +2001,12 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
         getProcessModel().getP2PService().removeDecryptedDirectMessageListener(getProtocol());
     }
 
-    public void maybeClearSensitiveData() {
+    /**
+     * Clears any sensitive data still held by this trade.
+     *
+     * @return true if anything was actually changed, so callers can persist only the trades that changed.
+     */
+    public boolean maybeClearSensitiveData() {
         String change = "";
         if (contract != null && contract.maybeClearSensitiveData()) {
             change += "contract;";
@@ -2022,6 +2027,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
         if (change.length() > 0) {
             log.info("Cleared sensitive data from {} of {} {}", change, getClass().getSimpleName(), getShortId());
         }
+        return change.length() > 0;
     }
 
     public void onShutDownStarted() {

--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -910,12 +910,12 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
 
     // TODO: throw if trade manager is null
     public void requestPersistence() {
-        if (processModel.getTradeManager() != null) processModel.getTradeManager().requestPersistence();
+        if (processModel.getTradeManager() != null) processModel.getTradeManager().requestPersistence(this);
     }
 
     // TODO: throw if trade manager is null
     public void persistNow(@Nullable Runnable completeHandler) {
-        if (processModel.getTradeManager() != null) processModel.getTradeManager().persistNow(completeHandler);
+        if (processModel.getTradeManager() != null) processModel.getTradeManager().persistNow(this, completeHandler);
     }
 
     public TradeProtocol getProtocol() {
@@ -1948,7 +1948,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
         
         // clear process data and shut down trade
         ThreadUtils.execute(() -> {
-            if (clearProcessData()) maybePersistClearedClosedTrade();
+            if (clearProcessData()) requestPersistence(); // routes to the closed-trades log if closed
             onShutDownStarted();
             ThreadUtils.submitToPool(() -> { // run off trade thread
                 try {
@@ -1965,7 +1965,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
     private void clearAndShutDownBeforeInitialized() {
         if (isShutDown) return; // ignore if already shut down
         onShutDownStarted();
-        if (clearProcessData()) maybePersistClearedClosedTrade();
+        if (clearProcessData()) requestPersistence(); // routes to the closed-trades log if closed
         onShutDownStarted();
         removeDecryptedDirectMessageListener();
         xmrConnectionService.removeConnectionListener(this);
@@ -1979,8 +1979,8 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
      * Clears process data (trade wallet and peer tx/message fields) once the trade is finished.
      *
      * @return true if it cleared this call (false if already cleared), so callers can persist the
-     *         cleared state to the closed-trades log — the append-only store does not otherwise
-     *         capture in-place mutations of an already-closed trade.
+     *         cleared state via {@link #requestPersistence()}, which routes to whichever container
+     *         (pending store or closed-trades log) owns this trade.
      */
     private boolean clearProcessData() {
 
@@ -2002,13 +2002,6 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
             if (peer.isPaymentReceivedMessageAckedOrNacked()) peer.setPaymentReceivedMessage(null);
         }
         return true;
-    }
-
-    // Persist the just-cleared state if this trade lives in the closed-trades log; a no-op otherwise
-    // (pending trades are persisted via TradeManager's whole-list flush).
-    private void maybePersistClearedClosedTrade() {
-        TradeManager tradeManager = processModel.getTradeManager();
-        if (tradeManager != null) tradeManager.persistClosedTrade(this);
     }
 
     private void removeDecryptedDirectMessageListener() {

--- a/core/src/main/java/haveno/core/trade/TradeManager.java
+++ b/core/src/main/java/haveno/core/trade/TradeManager.java
@@ -1061,6 +1061,12 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         closedTradableManager.removeTrade(trade);
     }
 
+    // Re-persist a closed trade whose in-place state changed (e.g. process data cleared on shut down).
+    // No-op if the trade is not in the closed list, so callers need not check first.
+    public void persistClosedTrade(Trade trade) {
+        closedTradableManager.persistClosedTrade(trade);
+    }
+
     private void removeFailedTrade(Trade trade) {
         failedTradesManager.removeTrade(trade);
     }

--- a/core/src/main/java/haveno/core/trade/TradeManager.java
+++ b/core/src/main/java/haveno/core/trade/TradeManager.java
@@ -561,6 +561,29 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         persistenceManager.persistNow(completeHandler);
     }
 
+    /**
+     * Persists a mutation of the given trade to whichever container owns it: a trade that was moved
+     * to the closed list is no longer in this manager's pending store, so its post-close mutations
+     * (payout/dispute state, ack state) go to the closed-trades log instead. The old model captured
+     * those implicitly by re-serializing the whole closed list at shutdown.
+     */
+    public void requestPersistence(Trade trade) {
+        if (closedTradableManager.getTradableById(trade.getId()).isPresent()) {
+            closedTradableManager.persistClosedTrade(trade);
+        } else {
+            requestPersistence();
+        }
+    }
+
+    public void persistNow(Trade trade, @Nullable Runnable completeHandler) {
+        if (closedTradableManager.getTradableById(trade.getId()).isPresent()) {
+            closedTradableManager.persistClosedTrade(trade); // durable (or queued for retry) on return
+            if (completeHandler != null) completeHandler.run();
+        } else {
+            persistNow(completeHandler);
+        }
+    }
+
     private void handleInitTradeRequest(DecryptedMessageWithPubKey decryptedMessageWithPubKey, InitTradeRequest request, NodeAddress sender) {
         log.info("TradeManager handling InitTradeRequest for tradeId={}, sender={}, uid={}", request.getOfferId(), sender, request.getUid());
 
@@ -1059,12 +1082,6 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         trade.setCompleted(false);
         addTradeToPendingTrades(trade);
         closedTradableManager.removeTrade(trade);
-    }
-
-    // Re-persist a closed trade whose in-place state changed (e.g. process data cleared on shut down).
-    // No-op if the trade is not in the closed list, so callers need not check first.
-    public void persistClosedTrade(Trade trade) {
-        closedTradableManager.persistClosedTrade(trade);
     }
 
     private void removeFailedTrade(Trade trade) {

--- a/core/src/main/java/haveno/core/trade/TradeManager.java
+++ b/core/src/main/java/haveno/core/trade/TradeManager.java
@@ -935,8 +935,11 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
     // If trade was completed (closed without fault but might be closed by a dispute) we move it to the closed trades
     public void onTradeCompleted(Trade trade) {
         if (trade.isCompleted()) throw new RuntimeException("Trade " + trade.getId() + " was already completed");
-        closedTradableManager.add(trade);
+        // Mark completed BEFORE adding to closed trades: ClosedTradableManager.add() appends a snapshot
+        // of the trade to the append-only log synchronously, so isCompleted (a persisted flag that is
+        // not re-derived on startup) must already be set or it would persist as false. Do not reorder.
         trade.setCompleted(true);
+        closedTradableManager.add(trade);
         removeTrade(trade);
         xmrWalletService.swapPayoutAddressEntryToAvailable(trade.getId()); // TODO The address entry should have been removed already. Check and if its the case remove that.
         requestPersistence();

--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -700,7 +700,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
                                         },
                                         (errorMessage) -> {
                                             log.warn("Error processing payment sent message: " + errorMessage);
-                                            processModel.getTradeManager().requestPersistence();
+                                            trade.requestPersistence();
                                             if (trade.isShutDownStarted()) {
                                                 log.warn("Skipping error handling for PaymentSentMessage for {} {} because trade is shutting down", trade.getClass().getSimpleName(), trade.getId());
                                                 unlatchTrade();
@@ -817,7 +817,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
                                     },
                                     errorMessage -> {
                                         log.warn("Error processing payment received message: " + errorMessage);
-                                        processModel.getTradeManager().requestPersistence();
+                                        trade.requestPersistence();
                                         if (trade.isShutDownStarted()) {
                                             log.warn("Skipping error handling for PaymentReceivedMessage for {} {} because trade is shutting down", trade.getClass().getSimpleName(), trade.getId());
                                             unlatchTrade();
@@ -974,14 +974,14 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
                     return;
                 }
                 trade.setStateIfValidTransitionTo(Trade.State.PUBLISH_DEPOSIT_TX_REQUEST_FAILED);
-                processModel.getTradeManager().requestPersistence();
+                trade.requestPersistence();
             }
         }
 
         // handle ack message for DepositsConfirmedMessage, which automatically re-sends if not ACKed in a certain time
         if (ackMessage.getSourceMsgClassName().equals(DepositsConfirmedMessage.class.getSimpleName())) {
             verifiedPeer.setDepositsConfirmedAckMessage(ackMessage);
-            processModel.getTradeManager().requestPersistence();
+            trade.requestPersistence();
         }
 
         // handle ack message for PaymentSentMessage, which automatically re-sends if not ACKed in a certain time
@@ -994,10 +994,10 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
                 trade.getSeller().setPaymentSentAckMessage(ackMessage);
                 if (ackMessage.isSuccess()) trade.setStateIfValidTransitionTo(Trade.State.SELLER_RECEIVED_PAYMENT_SENT_MSG);
                 else trade.setState(Trade.State.BUYER_SEND_FAILED_PAYMENT_SENT_MSG);
-                processModel.getTradeManager().requestPersistence();
+                trade.requestPersistence();
             } else if (verifiedPeer == trade.getArbitrator()) {
                 trade.getArbitrator().setPaymentSentAckMessage(ackMessage);
-                processModel.getTradeManager().requestPersistence();
+                trade.requestPersistence();
             } else {
                 log.warn("Received AckMessage from unexpected peer. Sender={}, trade={} {}, state={}, success={}, error={}, messageUid={}", sender, trade.getClass().getSimpleName(), trade.getId(), trade.getState(), ackMessage.isSuccess(), ackMessage.getErrorMessage(), ackMessage.getSourceUid());
                 return;
@@ -1012,7 +1012,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             // ack message from buyer
             if (verifiedPeer == trade.getBuyer()) {
                 trade.getBuyer().setPaymentReceivedAckMessage(ackMessage);
-                processModel.getTradeManager().persistNow(null);
+                trade.persistNow(null);
 
                 // handle successful ack
                 if (ackMessage.isSuccess()) {
@@ -1024,7 +1024,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
                     }
 
                     trade.setStateIfValidTransitionTo(Trade.State.BUYER_RECEIVED_PAYMENT_RECEIVED_MSG);
-                    processModel.getTradeManager().persistNow(null);
+                    trade.persistNow(null);
                 }
                 
                 // handle nack
@@ -1034,7 +1034,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
                     // nack includes updated multisig hex since v1.1.1
                     if (ackMessage.getUpdatedMultisigHex() != null) {
                         trade.getBuyer().setUpdatedMultisigHex(ackMessage.getUpdatedMultisigHex());
-                        processModel.getTradeManager().persistNow(null);
+                        trade.persistNow(null);
                         onPaymentReceivedNack(true, verifiedPeer, ackMessage);
                         return; // skip remaining processing
                     }
@@ -1044,7 +1044,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
             // ack message from arbitrator
             else if (verifiedPeer == trade.getArbitrator()) {
                 trade.getArbitrator().setPaymentReceivedAckMessage(ackMessage);
-                processModel.getTradeManager().persistNow(null);
+                trade.persistNow(null);
 
                 // handle nack
                 if (!ackMessage.isSuccess()) {
@@ -1053,7 +1053,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
                     // nack includes updated multisig hex since v1.1.1
                     if (ackMessage.getUpdatedMultisigHex() != null) {
                         trade.getArbitrator().setUpdatedMultisigHex(ackMessage.getUpdatedMultisigHex());
-                        processModel.getTradeManager().persistNow(null);
+                        trade.persistNow(null);
                         onPaymentReceivedNack(true, verifiedPeer, ackMessage);
                         return; // skip remaining processing
                     }
@@ -1308,7 +1308,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
         stopTimeout();
         log.error(errorMessage);
         if (setTradeError) trade.setErrorMessage(errorMessage);
-        processModel.getTradeManager().requestPersistence();
+        trade.requestPersistence();
         unlatchTrade();
         if (errorMessageHandler != null) errorMessageHandler.handleErrorMessage(errorMessage);
         errorMessageHandler = null;

--- a/core/src/test/java/haveno/core/trade/ClosedTradesStoreTest.java
+++ b/core/src/test/java/haveno/core/trade/ClosedTradesStoreTest.java
@@ -1,0 +1,166 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.trade;
+
+import com.google.inject.Provider;
+import haveno.common.crypto.Encryption;
+import haveno.common.crypto.KeyRing;
+import haveno.common.crypto.KeyStorage;
+import haveno.common.file.FileUtil;
+import haveno.common.persistence.PersistenceManager;
+import haveno.core.offer.Offer;
+import haveno.core.offer.OfferDirection;
+import haveno.core.offer.OfferPayload;
+import haveno.core.offer.OpenOffer;
+import haveno.core.proto.persistable.CorePersistenceProtoResolver;
+import haveno.core.xmr.wallet.BtcWalletService;
+import haveno.core.xmr.wallet.XmrWalletService;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ClosedTradesStoreTest {
+
+    private File dir;
+    private KeyRing keyRing;
+    private CorePersistenceProtoResolver resolver;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        PersistenceManager.reset(); // clear static registry/flags leaked by other tests in this JVM
+        dir = File.createTempFile("closed_trades_store_test", "");
+        assertTrue(dir.delete());
+        assertTrue(dir.mkdir());
+        keyRing = new KeyRing(new KeyStorage(dir), null, true);
+        // OpenOffer reconstruction needs neither wallet nor network resolver, so null providers are fine.
+        Provider<BtcWalletService> btc = () -> null;
+        Provider<XmrWalletService> xmr = () -> null;
+        resolver = new CorePersistenceProtoResolver(btc, xmr, null);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        PersistenceManager.reset();
+        FileUtil.deleteDirectory(dir);
+    }
+
+    private ClosedTradesStore newStore() {
+        Provider<XmrWalletService> xmr = () -> null;
+        return new ClosedTradesStore(dir, keyRing, resolver, xmr,
+                new PersistenceManager<>(dir, resolver, null, keyRing));
+    }
+
+    // Builds a real, fully-serializable OpenOffer (with a real PubKeyRing so toProtoMessage/fromProto
+    // round-trip), so the store test exercises genuine proto encode/decode, not stubs.
+    private OpenOffer openOffer(String id, long triggerPrice) {
+        OfferPayload payload = new OfferPayload(id,
+                0L, null, keyRing.getPubKeyRing(), OfferDirection.BUY, 100000L, 0.0, false, 100000L, 100000L,
+                0.0, 0.0, 0.0, 0.0, 0.0, "XMR", "USD", "SEPA", "", null, null, null, null,
+                "1.0.0", 0L, 0L, 0L, false, false, 0L, 0L, false, null, null, 0, null, null, null, "extra");
+        return new OpenOffer(new Offer(payload), triggerPrice, false);
+    }
+
+    private static List<String> ids(List<Tradable> tradables) {
+        return tradables.stream().map(Tradable::getId).collect(Collectors.toList());
+    }
+
+    @Test
+    public void testEmptyStoreLoadsEmpty() {
+        assertTrue(newStore().load().isEmpty());
+    }
+
+    @Test
+    public void testRoundTripPreservesOrderAndIds() {
+        ClosedTradesStore store = newStore();
+        store.appendUpsert(openOffer("a", 0));
+        store.appendUpsert(openOffer("b", 0));
+        store.appendUpsert(openOffer("c", 0));
+        // Reload with a fresh store to prove durability across a "restart".
+        assertEquals(List.of("a", "b", "c"), ids(newStore().load()));
+    }
+
+    @Test
+    public void testDeleteRemovesTrade() {
+        ClosedTradesStore store = newStore();
+        store.appendUpsert(openOffer("a", 0));
+        store.appendUpsert(openOffer("b", 0));
+        store.appendUpsert(openOffer("c", 0));
+        store.appendDelete("b");
+        assertEquals(List.of("a", "c"), ids(newStore().load()));
+    }
+
+    @Test
+    public void testUpsertReplacesInPlaceKeepingPosition() {
+        ClosedTradesStore store = newStore();
+        store.appendUpsert(openOffer("a", 11));
+        store.appendUpsert(openOffer("b", 22));
+        store.appendUpsert(openOffer("a", 99)); // update a in place
+
+        List<Tradable> loaded = newStore().load();
+        assertEquals(List.of("a", "b"), ids(loaded), "updating must keep first-seen position");
+        OpenOffer a = (OpenOffer) loaded.get(0);
+        assertEquals(99, a.getTriggerPrice(), "latest write must win");
+    }
+
+    @Test
+    public void testDeleteThenReAddMovesToEnd() {
+        ClosedTradesStore store = newStore();
+        store.appendUpsert(openOffer("a", 0));
+        store.appendUpsert(openOffer("b", 0));
+        store.appendDelete("a");
+        store.appendUpsert(openOffer("a", 0));
+        assertEquals(List.of("b", "a"), ids(newStore().load()));
+    }
+
+    @Test
+    public void testMigrationFromLegacyMonolithicFile() throws Exception {
+        // Write a legacy monolithic ClosedTrades file in the exact on-disk format PersistenceManager uses.
+        TradableList<Tradable> legacy = new TradableList<>();
+        legacy.add(openOffer("legacy-1", 0));
+        legacy.add(openOffer("legacy-2", 0));
+        byte[] payload = ((protobuf.PersistableEnvelope) legacy.toProtoMessage()).toByteArray();
+        byte[] encrypted = Encryption.encryptPayloadWithHmac(payload, keyRing.getSymmetricKey());
+        Files.write(new File(dir, ClosedTradesStore.LEGACY_FILE_NAME).toPath(), encrypted);
+
+        List<Tradable> loaded = newStore().load();
+
+        assertEquals(List.of("legacy-1", "legacy-2"), ids(loaded));
+        assertTrue(new File(dir, ClosedTradesStore.LOG_FILE_NAME).exists(), "log should be created");
+        assertTrue(new File(dir, ClosedTradesStore.LEGACY_BACKUP_NAME).exists(), "legacy file should be frozen as backup");
+        assertFalse(new File(dir, ClosedTradesStore.LEGACY_FILE_NAME).exists(), "legacy file should be moved");
+        // A second start does not re-migrate (log already present) and reads identically.
+        assertEquals(List.of("legacy-1", "legacy-2"), ids(newStore().load()));
+    }
+
+    @Test
+    public void testShouldCompactThresholds() {
+        assertFalse(ClosedTradesStore.shouldCompact(512, 1), "at the floor, do not compact");
+        assertTrue(ClosedTradesStore.shouldCompact(513, 1), "just past the floor, compact");
+        assertFalse(ClosedTradesStore.shouldCompact(1000, 600), "ratio not exceeded -> no compaction");
+        assertTrue(ClosedTradesStore.shouldCompact(1300, 600), "ratio exceeded -> compaction");
+    }
+}

--- a/core/src/test/java/haveno/core/trade/ClosedTradesStoreTest.java
+++ b/core/src/test/java/haveno/core/trade/ClosedTradesStoreTest.java
@@ -21,7 +21,9 @@ import com.google.inject.Provider;
 import haveno.common.crypto.Encryption;
 import haveno.common.crypto.KeyRing;
 import haveno.common.crypto.KeyStorage;
+import haveno.common.file.CorruptedStorageFileHandler;
 import haveno.common.file.FileUtil;
+import haveno.common.persistence.EncryptedAppendLog;
 import haveno.common.persistence.PersistenceManager;
 import haveno.core.offer.Offer;
 import haveno.core.offer.OfferDirection;
@@ -48,6 +50,7 @@ public class ClosedTradesStoreTest {
     private File dir;
     private KeyRing keyRing;
     private CorePersistenceProtoResolver resolver;
+    private CorruptedStorageFileHandler corruptedStorageFileHandler;
 
     @BeforeEach
     public void setup() throws Exception {
@@ -60,6 +63,7 @@ public class ClosedTradesStoreTest {
         Provider<BtcWalletService> btc = () -> null;
         Provider<XmrWalletService> xmr = () -> null;
         resolver = new CorePersistenceProtoResolver(btc, xmr, null);
+        corruptedStorageFileHandler = new CorruptedStorageFileHandler();
     }
 
     @AfterEach
@@ -70,7 +74,7 @@ public class ClosedTradesStoreTest {
 
     private ClosedTradesStore newStore() {
         Provider<XmrWalletService> xmr = () -> null;
-        return new ClosedTradesStore(dir, keyRing, resolver, xmr,
+        return new ClosedTradesStore(dir, keyRing, resolver, xmr, corruptedStorageFileHandler,
                 new PersistenceManager<>(dir, resolver, null, keyRing));
     }
 
@@ -136,15 +140,18 @@ public class ClosedTradesStoreTest {
         assertEquals(List.of("b", "a"), ids(newStore().load()));
     }
 
-    @Test
-    public void testMigrationFromLegacyMonolithicFile() throws Exception {
-        // Write a legacy monolithic ClosedTrades file in the exact on-disk format PersistenceManager uses.
+    // Writes a legacy monolithic ClosedTrades file in the exact on-disk format PersistenceManager uses.
+    private void writeLegacyFile(OpenOffer... offers) throws Exception {
         TradableList<Tradable> legacy = new TradableList<>();
-        legacy.add(openOffer("legacy-1", 0));
-        legacy.add(openOffer("legacy-2", 0));
+        for (OpenOffer offer : offers) legacy.add(offer);
         byte[] payload = ((protobuf.PersistableEnvelope) legacy.toProtoMessage()).toByteArray();
         byte[] encrypted = Encryption.encryptPayloadWithHmac(payload, keyRing.getSymmetricKey());
         Files.write(new File(dir, ClosedTradesStore.LEGACY_FILE_NAME).toPath(), encrypted);
+    }
+
+    @Test
+    public void testMigrationFromLegacyMonolithicFile() throws Exception {
+        writeLegacyFile(openOffer("legacy-1", 0), openOffer("legacy-2", 0));
 
         List<Tradable> loaded = newStore().load();
 
@@ -154,6 +161,69 @@ public class ClosedTradesStoreTest {
         assertFalse(new File(dir, ClosedTradesStore.LEGACY_FILE_NAME).exists(), "legacy file should be moved");
         // A second start does not re-migrate (log already present) and reads identically.
         assertEquals(List.of("legacy-1", "legacy-2"), ids(newStore().load()));
+    }
+
+    @Test
+    public void testLegacyFileIsMergedEvenWhenLogAlreadyExists() throws Exception {
+        // A log already exists (e.g. the first migration was deferred and an append created it, or
+        // the user re-upgraded after a downgrade during which the old build recreated ClosedTrades).
+        ClosedTradesStore store = newStore();
+        store.appendUpsert(openOffer("log-a", 0));
+        store.appendUpsert(openOffer("shared", 11));
+        store.appendUpsert(openOffer("tombstoned", 0));
+        store.appendDelete("tombstoned");
+
+        // The legacy file holds a stale copy of "shared", a copy of the deliberately deleted
+        // "tombstoned", and a trade the log has never seen.
+        writeLegacyFile(openOffer("shared", 99), openOffer("tombstoned", 0), openOffer("legacy-only", 0));
+
+        List<Tradable> loaded = newStore().load();
+
+        // Ids the log has ever mentioned are not resurrected or overwritten; unseen ones are merged.
+        assertEquals(List.of("log-a", "shared", "legacy-only"), ids(loaded));
+        assertEquals(11, ((OpenOffer) loaded.get(1)).getTriggerPrice(), "log version must win over stale legacy copy");
+        assertFalse(new File(dir, ClosedTradesStore.LEGACY_FILE_NAME).exists(), "legacy file should be moved after merge");
+        // Durable across restarts.
+        assertEquals(List.of("log-a", "shared", "legacy-only"), ids(newStore().load()));
+    }
+
+    @Test
+    public void testSecondMergeDoesNotOverwriteEarlierLegacyBackup() throws Exception {
+        writeLegacyFile(openOffer("first", 0));
+        newStore().load();
+        assertTrue(new File(dir, ClosedTradesStore.LEGACY_BACKUP_NAME).exists());
+
+        writeLegacyFile(openOffer("second", 0));
+        newStore().load();
+
+        File[] backups = dir.listFiles((d, name) -> name.startsWith(ClosedTradesStore.LEGACY_BACKUP_NAME));
+        assertEquals(2, backups.length, "an earlier legacy backup must never be overwritten");
+    }
+
+    @Test
+    public void testUndecodableRecordIsSkippedAndSurfaced() throws Exception {
+        ClosedTradesStore store = newStore();
+        store.appendUpsert(openOffer("a", 0));
+        store.appendUpsert(openOffer("b", 0));
+
+        // Append two authenticated but undecodable records directly to the log: one that is not a
+        // valid TradableLogEntry at all, and one whose upsert has no known tradable type (as a newer
+        // version would write). Neither may hide the rest of the history.
+        EncryptedAppendLog rawLog = new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME, keyRing.getSymmetricKey(), 3);
+        rawLog.append(new byte[]{0x0a}); // truncated protobuf
+        rawLog.append(protobuf.TradableLogEntry.newBuilder()
+                .setUpsert(protobuf.Tradable.newBuilder().build())
+                .build()
+                .toByteArray());
+
+        List<Tradable> loaded = newStore().load();
+
+        assertEquals(List.of("a", "b"), ids(loaded), "decodable records must survive an undecodable one");
+        assertTrue(corruptedStorageFileHandler.getFiles().isPresent(), "user must be notified of skipped records");
+        assertTrue(corruptedStorageFileHandler.getFiles().get().contains(ClosedTradesStore.LOG_FILE_NAME));
+        // The undecodable records stay on disk (no compaction while they exist): a later read with a
+        // build that understands them would still see them; here we just prove the load is stable.
+        assertEquals(List.of("a", "b"), ids(newStore().load()));
     }
 
     @Test

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1372,6 +1372,16 @@ message TradableList {
     repeated Tradable tradable = 1;
 }
 
+// A single entry in the append-only ClosedTrades log. An "upsert" adds or replaces the tradable
+// with the matching id; a "delete_id" tombstones (removes) the tradable with that id. Replaying the
+// log in order, latest-wins per id, reconstructs the equivalent of a TradableList.
+message TradableLogEntry {
+    oneof entry {
+        Tradable upsert = 1;
+        string delete_id = 2;
+    }
+}
+
 message Offer {
     enum State {
         PB_ERROR = 0;


### PR DESCRIPTION
> **Note:** Supersedes #2391, which was auto-closed by GitHub when my fork was temporarily made private (this detaches the fork from the network and force-closes its PRs). Same branch, same commits (`53e0f5d0`), reopened from a public fork. No code changes from #2391.

## What

Makes the persistence layer safe for large stores and restructures `ClosedTrades` so it no longer rewrites the whole history on every change. Three related fixes to the same store-loss problem, folded into one PR so the commits build on each other and land together (previously split as #2381 write / #2382 read):

1. **Stream persistence encryption** — the write-side OOM that *froze* stores.
2. **Stream persistence decryption** — the read-side OOM that made a valid store look *corrupt/deleted*.
3. **Append-only closed-trades log** — removes the O(n)-per-close whole-list rewrite that was the root cause of the write-side OOM (#2383) for `ClosedTrades` specifically.

Scope of the append-log restructure is **ClosedTrades only**; lazy/paginated loading and migrating other stores are tracked in #2390.

## How

### 1. Streaming encryption — `fix: stream persistence encryption to avoid OOM that freezes stores`

When a store grows large, `writeToDisk` built the entire encrypted blob in memory (`encryptPayloadWithHmac` → `payload || hmac` copied twice, then AES into another full array — ~3× the payload of transient allocation). The resulting `OutOfMemoryError` was caught, the temp→rename step skipped, and the on-disk file left **frozen** at the last good write — trades closed afterward silently never persisted.

- New `Encryption.encryptPayloadWithHmacToStream(...)` AES-encrypts the payload and appended HMAC in fixed-size chunks straight to the stream; `writeToDisk` uses it. Output is **byte-identical** to the array method — existing files stay readable, on-disk format unchanged.
- `getPayloadWithHmac` (still used by network/keystore callers) drops the `ByteArrayOutputStream` double-copy for a single `Arrays.copyOf`.
- Crash-safety unchanged: a failed write still throws before the temp→`storageFile` rename, so `storageFile` is never corrupted.

### 2. Streaming decryption — `fix: stream persistence decryption to avoid OOM/data loss reading large stores`

Reading a large encrypted store could OOM inside `Cipher.doFinal`; that error was wrapped as `CryptoException`, so `getPersisted` treated a **valid** file as corrupt and moved it to `backup_of_corrupted_data/` — the history read as empty on next start.

- New streaming `readEncrypted`: pass 1 (`verifyPayloadWithHmacStream`) decrypts in chunks and verifies the trailing HMAC holding only a 64 KiB buffer + 32-byte window; pass 2 parses the verified payload from a length-limited decrypting stream.
- `OutOfMemoryError` is **never** caught/wrapped on this path, so a valid-but-large file is never mistaken for corruption. Legacy unencrypted fallback and genuine-corruption backup are unchanged.
- `parseFrom` uses an explicit `CodedInputStream` with `setSizeLimit(Integer.MAX_VALUE)`, matching the old array decoder (avoids the 64 MB stream-decoder default rejecting a large valid store).

### 3. Append-only closed-trades log — `core: store closed trades in an append-only encrypted log`

Replaces "serialize the whole `TradableList` and atomically rewrite the `ClosedTrades` file on every change" (O(n) per closed trade, the root cause of the write-side OOM above for this store) with an **append-only encrypted log**. Closing a trade appends one small framed record (O(1)); the full history is only re-encrypted during infrequent compaction. The in-memory `ObservableList` the GUI binds to is unchanged.

- **common:** new `EncryptedAppendLog` — generic crash-safe encrypted log. Each record is framed `[4-byte big-endian length][ciphertext]` (`encryptPayloadWithHmac`, AES + trailing HMAC); the length lives outside the ciphertext so frames can be located and a torn tail truncated without decrypting. fsync per append.
  - **Torn tail** (crash mid-append): truncate back to the last good frame — silent self-repair.
  - **Mid-log corruption** (a full frame that fails HMAC — bit rot/tampering): back the log up to `backup_of_corrupted_data/` (parity with `PersistenceManager`) and rebuild from the valid prefix.
  - `rewrite()` for atomic compaction/migration (temp file + fsync + rename, rolling backup).
- **core:** new `ClosedTradesStore` — `TradableLogEntry` upsert/delete replay (latest-wins per id, first-seen insertion order preserved), one-time migration from the legacy monolithic `ClosedTrades` file (frozen as a backup), startup compaction once the log carries enough superseded/tombstoned records.
- **core:** `ClosedTradableManager` appends per add/remove/clear instead of rewriting; `TradableList.tradableFromProto` extracted for shared decode.
- **proto:** new `TradableLogEntry` message.

### 4. Persist process-data clearing — `core: persist closed trades after clearing process data`

- `onTradeCompleted` now sets `isCompleted` **before** `add()`: the append snapshots state synchronously, and `isCompleted` is a persisted flag not re-derived on startup, so it must be set first.
- Migration aborts (and retries next start) if the legacy file cannot be read, rather than creating an empty log and stranding the history.
- A `load()` decode fault no longer hangs startup; OOM is rethrown to preserve data, other faults proceed with an empty list and leave the on-disk log intact for recovery.
- **Process-data clearing:** the append-only store only captures explicit records, so `Trade.clearProcessData()` (nulling `payoutTxHex` and per-peer deposit tx hex/key, multisig hex, unsigned payout tx hex, payment messages on shut down) — which the old whole-list flush persisted implicitly — is now re-appended. Without this those fields survived on disk and reappeared on restart (a privacy regression). No-op for pending trades, which keep their own whole-list flush. *(The dedicated hook this commit introduced is superseded by the general owner-routing in section 5, which covers all post-close mutations.)*

### 5. Review hardening (second push)

A deep review pass over the branch surfaced ten issues; the four follow-up commits close all of them:

**`fix: write stores with constant memory and authenticate streamed reads`**
- The write path still built the full serialized store via `toByteArray()` before streaming — the base allocation of the original OOM remained for the stores that keep the whole-list model (DisputeLists, FailedTrades, SignedWitness…). A new `PayloadWriter` variant feeds the proto through the HMAC and the cipher in two `writeTo` passes: truly constant memory, byte-identical output.
- Both decrypt passes now read through a 64 KiB `BufferedInputStream` — `CipherInputStream` pulls 512 bytes at a time from the underlying stream, so unbuffered reads cost ~2,000 syscalls/MB per pass.
- Pass 2 of `readEncrypted` re-verifies the trailing HMAC over the bytes it actually parsed (pass 1 verified a *different* read of the file; a file replaced between the two opens by external backup/sync tooling was previously parsed unauthenticated).

**`fix: never drop append-log records without a backup; repair failed appends`**
- A corrupted length prefix mid-log was classified as a torn tail and truncated away **with no backup**, silently destroying every later record. Now a non-positive length is treated as corruption (append only writes positive lengths), and torn-tail truncation first copies the whole file to `backup_of_corrupted_data/` (timestamped, so incidents never overwrite each other).
- A failed append (disk full) could leave a partial frame that the next append buried mid-log, making a later replay drop the whole suffix. The log now tracks its known-good length and truncates any tear away before each append.
- New `appendAll()` writes a batch with a single fsync.

**`core: make closed-trade writes non-throwing and off-lock; merge legacy stores`**
- Appends no longer throw into trade completion / offer cancellation (a disk error could permanently wedge a completed trade behind the `isCompleted` guard, and deadlock offer processing via a skipped `latch.countDown()`). Failed batches are kept and retried in order on the next write.
- Appends moved outside the `closedTradables` monitor (ordering preserved by a dedicated persist lock), and `maybeClearSensitiveData` batches into one fsync — a mass clearing (user first enables the setting with years of history) previously ran thousands of sequential fsyncs while the JavaFX thread blocked on the list lock.
- `load()` skips an authenticated-but-undecodable record instead of hiding the entire history (compaction is suppressed so the record stays on disk), and both that and a whole-load failure surface through `CorruptedStorageFileHandler` — restoring the user-visible warning the old path had. This also keeps `wasOfferAlreadyUsedInTrade`'s closed-trades leg intact.
- The legacy `ClosedTrades` file is **merged** whenever present rather than only when no log exists — gating on log existence permanently orphaned history after a downgrade/upgrade cycle or a deferred first migration. Only ids the log has never mentioned are merged (no resurrection of tombstoned trades), and earlier legacy backups are never overwritten.

**`core: route trade persistence to the container that owns the trade`**
- Post-close mutations (payout state unlocking/finalizing, dispute state, `PaymentReceivedMessage` ACK/NACK state, updated multisig hex) were persisted **nowhere**: `Trade.persistNow()` flushed the pending-trades store, which no longer contains the trade, and the old shutdown whole-list flush that captured these implicitly is gone. `Trade.requestPersistence()/persistNow()` now route through `TradeManager` to the closed-trades log when the trade is closed. This generalizes (and replaces) the process-data-clearing special case from commit 4.

## Tests

- `EncryptionTest` — streaming encryption is byte-identical to the array method and round-trips through decrypt across boundary sizes (0, AES-block ±1, 64 KiB chunk ±1, 5 MB); the `PayloadWriter` variant is byte-identical under protobuf-sized (4 KB) writes; the helper does not close the caller's stream.
- `PersistenceManagerTest` — encrypted write → streaming-read round-trip (now exercising the writer-based constant-memory write and the authenticated pass 2); legacy unencrypted fallback; corrupt file → `backup_of_corrupted_data`; a >64 MB store round-trips (size-limit lift). The fixture writer now uses the production `encryptPayloadWithHmacToStream`, so it can never drift from the real format.
- `EncryptedAppendLogTest` — append/read order, large records across crypto chunk boundaries, torn-tail repair **with pre-truncation backup**, mid-log ciphertext corruption backup + rebuild, corrupted length prefix (negative → corruption path; oversized → truncation with full backup copy), torn frame from a failed append repaired before the next append, `appendAll` batch ordering, atomic rewrite, wrong-key handling.
- `ClosedTradesStoreTest` — round-trip durability, delete, in-place upsert keeps position, delete-then-re-add ordering, legacy migration, merge with an existing log (stale legacy copies and tombstoned ids not resurrected), second merge preserves the earlier legacy backup, undecodable records skipped + surfaced via `CorruptedStorageFileHandler`, compaction thresholds.

Both OOM paths were also verified independently at `-Xmx400m` with a 200 MB payload (old path OOMs, streaming path succeeds).

Tracking / follow-ups: #2383, #2390

🤖 Generated with [Claude Code](https://claude.com/claude-code)


