### PR TITLE
perf: remove O(n) data store scans from gossip handling

### DIFF
--- a/core/src/main/java/haveno/core/provider/price/PriceFeedService.java
+++ b/core/src/main/java/haveno/core/provider/price/PriceFeedService.java
@@ -49,8 +49,6 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -73,6 +71,7 @@ public class PriceFeedService {
     private static final long PERIOD_SEC = 60;
 
     private final Map<String, MarketPrice> cache = new HashMap<>();
+    private final Map<String, Date> latestHavenoMarketPriceDateByCurrencyCode = new HashMap<>();
     private PriceProvider priceProvider;
     @Nullable
     private Consumer<Double> priceConsumer;
@@ -351,27 +350,26 @@ public class PriceFeedService {
     }
 
     public void applyLatestHavenoMarketPrice(List<TradeStatistics3> tradeStatisticsList) {
-        // takes about 10 ms for 5000 items
-        Map<String, List<TradeStatistics3>> mapByCurrencyCode = new HashMap<>();
-        tradeStatisticsList.forEach(e -> {
-            List<TradeStatistics3> list;
-            String currencyCode = e.getCurrency();
-            if (mapByCurrencyCode.containsKey(currencyCode)) {
-                list = mapByCurrencyCode.get(currencyCode);
-            } else {
-                list = new ArrayList<>();
-                mapByCurrencyCode.put(currencyCode, list);
-            }
-            list.add(e);
-        });
+        Map<String, TradeStatistics3> latestByCurrencyCode = new HashMap<>();
+        tradeStatisticsList.forEach(e -> latestByCurrencyCode.merge(e.getCurrency(), e,
+                (oldValue, newValue) -> newValue.getDate().before(oldValue.getDate()) ? oldValue : newValue));
+        latestByCurrencyCode.values().forEach(this::applyHavenoMarketPrice);
+    }
 
-        mapByCurrencyCode.values().stream()
-                .filter(list -> !list.isEmpty())
-                .forEach(list -> {
-                    list.sort(Comparator.comparing(TradeStatistics3::getDate));
-                    TradeStatistics3 tradeStatistics = list.get(list.size() - 1);
-                    setHavenoMarketPrice(tradeStatistics.getCurrency(), tradeStatistics.getTradePrice());
-                });
+    // Applies a single trade statistic without scanning the full list. Ignored if we already applied a
+    // more recent trade for that currency.
+    public void applyHavenoMarketPrice(TradeStatistics3 tradeStatistics) {
+        String currencyCode = tradeStatistics.getCurrency();
+        synchronized (latestHavenoMarketPriceDateByCurrencyCode) {
+            Date latestDate = latestHavenoMarketPriceDateByCurrencyCode.get(currencyCode);
+            if (latestDate != null && tradeStatistics.getDate().before(latestDate)) {
+                return;
+            }
+            latestHavenoMarketPriceDateByCurrencyCode.put(currencyCode, tradeStatistics.getDate());
+
+            // Keep the price update inside the lock so concurrent applies enqueue their cache updates in date order.
+            setHavenoMarketPrice(currencyCode, tradeStatistics.getTradePrice());
+        }
     }
 
     /**

--- a/core/src/main/java/haveno/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/haveno/core/trade/statistics/TradeStatisticsManager.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -57,7 +58,10 @@ public class TradeStatisticsManager {
     private final boolean dumpStatistics;
     private final ObservableList<TradeStatistics3> observableTradeStatisticsList = FXCollections.observableArrayList();
     private JsonFileManager jsonFileManager;
+    private final AtomicBoolean dumpStatisticsScheduled = new AtomicBoolean();
+    private volatile boolean shutDownRequested;
     public static final int PUBLISH_STATS_RANDOM_DELAY_HOURS = 24;
+    private static final int DUMP_STATISTICS_DELAY_SEC = 60;
 
     @Inject
     public TradeStatisticsManager(P2PService p2PService,
@@ -77,6 +81,7 @@ public class TradeStatisticsManager {
     }
 
     public void shutDown() {
+        shutDownRequested = true;
         if (jsonFileManager != null) {
             jsonFileManager.shutDown();
         }
@@ -91,8 +96,8 @@ public class TradeStatisticsManager {
                 }
                 synchronized (observableTradeStatisticsList) {
                     observableTradeStatisticsList.add(tradeStatistics);
-                    priceFeedService.applyLatestHavenoMarketPrice(observableTradeStatisticsList);
                 }
+                priceFeedService.applyHavenoMarketPrice(tradeStatistics);
                 maybeDumpStatistics();
             }
         });
@@ -210,6 +215,20 @@ public class TradeStatisticsManager {
             return;
         }
 
+        // Dumping serializes the whole statistics list, so we batch frequent updates into one dump per interval.
+        if (!dumpStatisticsScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        UserThread.runAfter(() -> {
+            dumpStatisticsScheduled.set(false);
+            if (shutDownRequested) {
+                return;
+            }
+            dumpStatistics();
+        }, DUMP_STATISTICS_DELAY_SEC);
+    }
+
+    private void dumpStatistics() {
         if (jsonFileManager == null) {
             jsonFileManager = new JsonFileManager(storageDir);
 

--- a/p2p/src/main/java/haveno/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/haveno/network/p2p/storage/P2PDataStorage.java
@@ -756,7 +756,7 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         }
 
         ByteArray hashAsByteArray = new ByteArray(payload.getHash());
-        boolean payloadHashAlreadyInStore = appendOnlyDataStoreService.getMap(payload).containsKey(hashAsByteArray);
+        boolean payloadHashAlreadyInStore = appendOnlyDataStoreService.containsKey(payload, hashAsByteArray);
 
         // Store already knows about this payload. Ignore it unless the caller specifically requests a republish.
         if (payloadHashAlreadyInStore && !reBroadcast) {

--- a/p2p/src/main/java/haveno/network/p2p/storage/persistence/AppendOnlyDataStoreService.java
+++ b/p2p/src/main/java/haveno/network/p2p/storage/persistence/AppendOnlyDataStoreService.java
@@ -83,6 +83,14 @@ public class AppendOnlyDataStoreService {
                 .orElse(new HashMap<>());
     }
 
+    // Checks for the hash without merging the data stores into a new map like getMap does. The historical
+    // data stores can hold a large number of entries, so creating that merged map on every lookup is expensive.
+    public boolean containsKey(PersistableNetworkPayload payload, P2PDataStorage.ByteArray hash) {
+        return findService(payload)
+                .map(service -> service.containsKey(hash))
+                .orElse(false);
+    }
+
     public boolean put(P2PDataStorage.ByteArray hashAsByteArray, PersistableNetworkPayload payload) {
         Optional<MapStoreService<? extends PersistableNetworkPayloadStore<? extends PersistableNetworkPayload>, PersistableNetworkPayload>> optionalService = findService(payload);
         optionalService.ifPresent(service -> service.putIfAbsent(hashAsByteArray, payload));

--- a/p2p/src/main/java/haveno/network/p2p/storage/persistence/HistoricalDataStoreService.java
+++ b/p2p/src/main/java/haveno/network/p2p/storage/persistence/HistoricalDataStoreService.java
@@ -114,6 +114,11 @@ public abstract class HistoricalDataStoreService<T extends PersistableNetworkPay
     }
 
     @Override
+    boolean containsKey(P2PDataStorage.ByteArray hash) {
+        return anyMapContainsKey(hash);
+    }
+
+    @Override
     protected void put(P2PDataStorage.ByteArray hash, PersistableNetworkPayload payload) {
         if (anyMapContainsKey(hash)) {
             return;


### PR DESCRIPTION
Fixes #2406.

Removes three O(n) hot spots that run on **every gossiped network payload**, where n = all trade statistics + account age witness entries ever recorded. All three costs grow with the network's history and are paid continuously by every client, daemon, and seed node. Total diff is ~75 lines; no trade protocol code is touched.

## How

**Commit 1 — p2p: check payload hash without copying the whole data store**

`P2PDataStorage.addPersistableNetworkPayload` called `appendOnlyDataStoreService.getMap(payload)`, which for `HistoricalDataStoreService`-backed stores merges the entire store into a **new `HashMap`** — only to answer a single `containsKey`. This adds a `containsKey(payload, hash)` to `AppendOnlyDataStoreService` that delegates to the existing package-private `MapStoreService.containsKey`, overridden in `HistoricalDataStoreService` to check the live and historical maps directly (same logic its own `put`/`putIfAbsent` already use). Semantics are identical, including the `false` result when no service handles the payload.

**Commit 2 — core: make per-trade-statistic work constant time**

The `TradeStatisticsManager` listener did two full-history passes per gossiped trade statistic:

- `PriceFeedService.applyLatestHavenoMarketPrice(wholeList)` grouped all statistics by currency and **sorted each group by date** to find the latest price. `PriceFeedService` now tracks the latest applied trade date per currency, so a new statistic is applied in O(1) (`applyHavenoMarketPrice`). The startup full-list pass is reduced from sort-per-currency (O(n log n)) to a single max scan (O(n)). Tie-breaking behavior is preserved (latest-or-equal date wins, matching the old stable sort taking the last element).
- With `--dumpStatistics` enabled, `maybeDumpStatistics()` re-serialized **all** statistics to JSON on every added statistic. Dumps are now batched to at most one per minute, with a shutdown guard so a pending dump can't run against the shut-down `JsonFileManager` executor (that race pre-existed; the debounce would otherwise widen it).

## Impact

Standalone benchmark of the replaced code shapes (per received payload):

| store size | duplicate check (old → new) | price apply (old → new) |
|---:|---:|---:|
| 10,000 | 0.4 ms → ~0 | 2.3 ms → ~0 |
| 50,000 | 2.5 ms → ~0 | 6.7 ms → ~0 |
| 200,000 | 10.0 ms → ~0 | 31.5 ms → ~0 |

The duplicate check additionally allocated a full copy of the store (multiple MB) per message, which is constant GC pressure at idle; that allocation is gone entirely.

## Testing

- `./gradlew compileJava` (all modules), `:p2p:checkstyleMain`, `:core:checkstyleMain` — clean
- `./gradlew :p2p:test :core:test` — all suites pass, 0 failures/errors (the p2p storage suite exercises `addPersistableNetworkPayload` duplicate/broadcast behavior extensively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
