### PR TITLE
perf: serialize outbound network envelopes only once

### DIFF
--- a/p2p/src/main/java/haveno/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/Connection.java
@@ -362,7 +362,9 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
             log.debug("Capability for networkEnvelope is required but not supported");
             return;
         }
-        int networkEnvelopeSize = networkEnvelope.toProtoNetworkEnvelope().getSerializedSize();
+        // Convert to the proto envelope only once; it is reused for the actual send below.
+        protobuf.NetworkEnvelope proto = networkEnvelope.toProtoNetworkEnvelope();
+        int networkEnvelopeSize = proto.getSerializedSize();
         try {
             // Throttle outbound network_messages
             long now = System.currentTimeMillis();
@@ -379,7 +381,7 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
             lastSendTimeStamp = now;
 
             if (!stopped) {
-                protoOutputStream.writeEnvelope(networkEnvelope);
+                protoOutputStream.writeEnvelope(networkEnvelope, proto);
                 ThreadUtils.execute(() -> messageListeners.forEach(e -> e.onMessageSent(networkEnvelope, this)), THREAD_ID);
                 ThreadUtils.execute(() -> connectionStatistics.addSendMsgMetrics(System.currentTimeMillis() - ts, networkEnvelopeSize), THREAD_ID);
             }

--- a/p2p/src/main/java/haveno/network/p2p/network/ProtoOutputStream.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/ProtoOutputStream.java
@@ -49,11 +49,11 @@ class ProtoOutputStream {
         this.statistic = statistic;
     }
 
-    void writeEnvelope(NetworkEnvelope envelope) {
+    void writeEnvelope(NetworkEnvelope envelope, protobuf.NetworkEnvelope proto) {
         lock.lock();
 
         try {
-            writeEnvelopeOrThrow(envelope);
+            writeEnvelopeOrThrow(envelope, proto);
         } catch (IOException e) {
             if (!isConnectionActive.get()) {
                 // Connection was closed by us.
@@ -86,9 +86,9 @@ class ProtoOutputStream {
         }
     }
 
-    private void writeEnvelopeOrThrow(NetworkEnvelope envelope) throws IOException {
+    // The caller already converted the envelope for its size metrics, so we take the proto to avoid a second conversion.
+    private void writeEnvelopeOrThrow(NetworkEnvelope envelope, protobuf.NetworkEnvelope proto) throws IOException {
         long ts = System.currentTimeMillis();
-        protobuf.NetworkEnvelope proto = envelope.toProtoNetworkEnvelope();
         proto.writeDelimitedTo(outputStream);
         outputStream.flush();
         long duration = System.currentTimeMillis() - ts;


### PR DESCRIPTION
Fixes #2408.

Every outbound P2P message was converted to its proto form twice: once in `Connection.sendMessage` just to read the serialized size for the send metrics, and again in `ProtoOutputStream.writeEnvelopeOrThrow` for the actual send. `toProtoNetworkEnvelope()` builds the entire proto message tree, so this doubled the CPU cost and transient allocations of every send — most pronounced for large messages (`GetDataResponse` initial-sync responses served by seed nodes can be many MB) and for broadcasts, which repeat the send per connection.

## How

`Connection.sendMessage` now converts the envelope once, takes the size from that proto, and passes it to `ProtoOutputStream.writeEnvelope`, which writes it directly instead of re-converting. Notes:

- The conversion still happens **after** `testCapability`, which can trim a `BundleOfEnvelopes`, so the trimmed bundle is what gets serialized — same as before. Passing the proto down also guarantees the bytes written are exactly the bytes that were measured, where previously the two conversions were separate snapshots.
- protobuf memoizes `getSerializedSize()` per message instance, so the size read in `sendMessage` is reused by `writeDelimitedTo` and by the `statistic.addSentBytes` call — no repeated tree walks either.
- `ProtoOutputStream.writeEnvelope` is package-private with `Connection.sendMessage` as its only caller, so the signature change is contained.

## Testing

- `./gradlew :p2p:compileJava :p2p:checkstyleMain :p2p:test` — clean, all tests pass.
- Byte-level equivalence is by construction: the same `writeDelimitedTo` on a proto built by the same `toProtoNetworkEnvelope()` call path; only the number of conversions changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
