### PR TITLE
perf: skip eager trace-log serialization in buildGetDataResponse

### DIFF
--- a/p2p/src/main/java/haveno/network/p2p/storage/P2PDataStorage.java
+++ b/p2p/src/main/java/haveno/network/p2p/storage/P2PDataStorage.java
@@ -324,10 +324,12 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         log.info("{} PersistableNetworkPayload entries remained after filtered by excluded keys. " +
                 "Original map had {} entries.",
                 filteredPersistableNetworkPayloads.size(), mapForDataResponse.size());
-        log.trace("## buildGetDataResponse filteredPersistableNetworkPayloadHashes={}",
-                filteredPersistableNetworkPayloads.stream()
-                        .map(e -> Utilities.encodeToHex(e.getHash()))
-                        .toArray());
+        if (log.isTraceEnabled()) {
+            log.trace("## buildGetDataResponse filteredPersistableNetworkPayloadHashes={}",
+                    filteredPersistableNetworkPayloads.stream()
+                            .map(e -> Utilities.encodeToHex(e.getHash()))
+                            .toArray());
+        }
 
         // We give 75% space to ProtectedStorageEntries as they contain MailBoxMessages and those can be larger.
         limit = Math.round(maxSize * 0.75);
@@ -343,10 +345,12 @@ public class P2PDataStorage implements MessageListener, ConnectionListener, Pers
         log.info("{} ProtectedStorageEntry entries remained after filtered by excluded keys. " +
                         "Original map had {} entries.",
                 filteredProtectedStorageEntries.size(), map.size());
-        log.trace("## buildGetDataResponse filteredProtectedStorageEntryHashes={}",
-                filteredProtectedStorageEntries.stream()
-                        .map(e -> get32ByteHashAsByteArray((e.getProtectedStoragePayload())))
-                        .toArray());
+        if (log.isTraceEnabled()) {
+            log.trace("## buildGetDataResponse filteredProtectedStorageEntryHashes={}",
+                    filteredProtectedStorageEntries.stream()
+                            .map(e -> get32ByteHashAsByteArray((e.getProtectedStoragePayload())))
+                            .toArray());
+        }
 
         boolean wasTruncated = wasPersistableNetworkPayloadsTruncated.get() || wasProtectedStorageEntriesTruncated.get();
         return new GetDataResponse(


### PR DESCRIPTION
## What

Guards the two `log.trace` calls in `P2PDataStorage.buildGetDataResponse` with `log.isTraceEnabled()`.

## Why

slf4j only defers the `{}` **formatting** of log arguments — the arguments themselves are evaluated eagerly. Both trace calls build their argument with `.stream()...toArray()`, so the work runs on **every GetDataResponse served, even with trace logging disabled** (the default everywhere):

- `buildGetDataResponse` line 327: hex-encodes the stored hash of every filtered `PersistableNetworkPayload` in the response.
- Line 346 (the expensive one): calls `get32ByteHashAsByteArray` on every `ProtectedStorageEntry` payload in the response, which **re-serializes the payload via `toProtoMessage().toByteArray()` and SHA-256 hashes it** — then throws the result away.

Offers and especially mailbox entries can be kilobytes each, and seed nodes serve these responses constantly, so this is pure wasted CPU and garbage on one of the hottest seed-node paths.

## How

Wrap both calls in `if (log.isTraceEnabled())`. When trace logging is actually enabled, output is byte-for-byte identical to before. No other behavior change.

## Testing

- `:p2p:compileJava`, `:p2p:checkstyleMain`, `:p2p:test` all green.

Related to the same effort as #2407 / #2409 (cutting wasted work from p2p hot paths without touching the trade protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
