### PR TITLE
perf: debounce offer book JSON dump and fix temp file deleteOnExit leak

### DIFF
--- a/common/src/main/java/haveno/common/file/JsonFileManager.java
+++ b/common/src/main/java/haveno/common/file/JsonFileManager.java
@@ -27,6 +27,7 @@ import java.io.PrintWriter;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
 @Slf4j
@@ -72,7 +73,13 @@ public class JsonFileManager {
     }
 
     public void writeToDiscThreaded(String json, String fileName) {
-        getExecutor().execute(() -> writeToDisc(json, fileName));
+        try {
+            getExecutor().execute(() -> writeToDisc(json, fileName));
+        } catch (RejectedExecutionException e) {
+            // Depending on shutdown ordering, a write scheduled before shutdown can arrive after
+            // the executor has been shut down. Losing that write is fine; propagating is not.
+            log.warn("Skipping JSON write of {} because the executor has been shut down", fileName);
+        }
     }
 
     public void writeToDisc(String json, String fileName) {
@@ -80,8 +87,12 @@ public class JsonFileManager {
         File tempFile = null;
         PrintWriter printWriter = null;
         try {
+            // We must not use tempFile.deleteOnExit() here: every write creates a temp file with a
+            // new unique name, and each deleteOnExit call adds a path to a JVM-global set which is
+            // never purged, growing without bound over the lifetime of the process. The temp file
+            // is renamed on success and deleted in the finally block on failure, and deleteOnExit
+            // would not run on an abnormal termination anyway.
             tempFile = File.createTempFile("temp", null, dir);
-            tempFile.deleteOnExit();
 
             printWriter = new PrintWriter(tempFile);
             printWriter.println(json);

--- a/core/src/main/java/haveno/core/offer/OfferBookService.java
+++ b/core/src/main/java/haveno/core/offer/OfferBookService.java
@@ -70,6 +70,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import monero.daemon.model.MoneroKeyImageSpentStatus;
@@ -82,6 +83,7 @@ public class OfferBookService {
 
     private final static long INVALID_OFFERS_TIMEOUT_MINS = 5 * 60 * 1000; // 5 minutes
     private final static int DELAY_LOG_INVALID_OFFER_SEC = 10;
+    private static final int DUMP_STATISTICS_DELAY_SEC = 60;
 
     private final P2PService p2PService;
     private final PriceFeedService priceFeedService;
@@ -92,6 +94,8 @@ public class OfferBookService {
     private final List<Offer> validOffers = new ArrayList<Offer>();
     private final List<Offer> invalidOffers = new ArrayList<Offer>();
     private final Map<String, Timer> invalidOfferTimers = new HashMap<>();
+    private final AtomicBoolean dumpStatisticsScheduled = new AtomicBoolean();
+    private volatile boolean shutDownRequested;
 
     public interface OfferBookChangedListener {
         void onAdded(Offer offer);
@@ -176,17 +180,17 @@ public class OfferBookService {
                     addOfferBookChangedListener(new OfferBookChangedListener() {
                         @Override
                         public void onAdded(Offer offer) {
-                            doDumpStatistics();
+                            maybeDumpStatistics();
                         }
 
                         @Override
                         public void onRemoved(Offer offer) {
-                            doDumpStatistics();
+                            maybeDumpStatistics();
                         }
 
                         @Override
                         public void onRefresh(Offer offer) {
-                            doDumpStatistics();
+                            maybeDumpStatistics();
                         }
                     });
                     UserThread.runAfter(OfferBookService.this::doDumpStatistics, 1);
@@ -295,6 +299,7 @@ public class OfferBookService {
     }
 
     public void shutDown() {
+        shutDownRequested = true;
         xmrConnectionService.getKeyImagePoller().removeKeyImages(OfferBookService.class.getName());
     }
 
@@ -482,6 +487,21 @@ public class OfferBookService {
                 offer.setReservedFundsSpent(true);
             }
         }
+    }
+
+    private void maybeDumpStatistics() {
+        // Dumping serializes the whole offer book, and offer refresh messages arrive frequently
+        // from the whole network, so we batch frequent updates into one dump per interval.
+        if (!dumpStatisticsScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        UserThread.runAfter(() -> {
+            dumpStatisticsScheduled.set(false);
+            if (shutDownRequested) {
+                return;
+            }
+            doDumpStatistics();
+        }, DUMP_STATISTICS_DELAY_SEC);
     }
 
     private void doDumpStatistics() {


### PR DESCRIPTION
## What

Three fixes for the offer book JSON dump path (all outside the trade protocol):

1. **Debounce the offer book JSON dump.** On nodes running with `--dumpStatistics`, `OfferBookService` re-serialized the *entire* offer book to JSON and wrote it to disk on every offer add, remove and **refresh**. Refresh messages arrive continuously from the whole network (every live offer refreshes its TTL every few minutes), so dump nodes performed an O(offers) serialization + temp-file disk write many times per minute. Dumps are now batched to at most one per 60 seconds — the same approach as the trade statistics dump debounce in #2407.
2. **Fix an unbounded `deleteOnExit` leak in `JsonFileManager.writeToDisc`.** Every write creates a temp file with a new unique name and registered it with `File.deleteOnExit()`. The JVM's delete-on-exit hook is an add-only global set that is never purged, so long-running dump nodes leaked memory linearly with the number of writes.
3. **Harden `writeToDiscThreaded` against a shutdown race.** `JsonFileManager.shutDownAllInstances()` runs *before* `OfferBookService.shutDown()` / `TradeStatisticsManager.shutDown()` in the shutdown routines (`HavenoExecutable`, `ExecutableForAppWithP2p`), so a dump scheduled shortly before shutdown could call `execute()` on the already shut-down executor and propagate a `RejectedExecutionException` into the calling thread. This race predates this PR (any offer event arriving in that window triggered it); it is now caught and logged — losing a JSON dump during shutdown is harmless, propagating an exception is not.

## How

- `OfferBookService`: the `--dumpStatistics` listener callbacks now go through `maybeDumpStatistics()`, which coalesces bursts via an `AtomicBoolean` + `UserThread.runAfter(60s)`. The flag is reset *before* the dump runs, so an update racing with an in-flight dump always schedules a follow-up dump — the final state is never missed. The initial dump 1s after bootstrap is unchanged. A `shutDownRequested` guard (set in the existing `shutDown()`) prevents delayed dumps after shutdown begins.
- `JsonFileManager`: drop the `tempFile.deleteOnExit()` call. It provided no cleanup the code doesn't already do: the temp file is renamed on success, deleted in the `finally` block on failure, and `deleteOnExit` never runs on abnormal termination anyway. A comment explains why it must not be reintroduced.
  - Note `PersistenceManager` is *not* affected by this leak and is untouched: it deliberately reuses one temp file path per store, so its `deleteOnExit` registrations deduplicate (the hook set is a `LinkedHashSet`). `JsonFileManager` can't use that trick because `writeToDiscThreaded` runs on a thread pool and writes could race on a shared temp path.
- `writeToDiscThreaded`: catch `RejectedExecutionException` around `execute()` and log a warning instead.

## Testing

- `:common:compileJava`, `:core:compileJava`, `:common:checkstyleMain`, `:core:checkstyleMain`, `:common:test`, `:core:test` all green.

Related to the same effort as #2407 / #2409 / #2418 (cutting wasted work from hot paths without touching the trade protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
