### PR TITLE
Chat popup: sensible default + min size, and let the WM show min/max buttons

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -527,7 +527,11 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         chatPopupStage.setTitle(Res.get("tradeChat.chatWindowTitle", trade.getShortId()));
         StackPane owner = MainView.getRootContainer();
         Scene rootScene = owner.getScene();
-        chatPopupStage.initOwner(rootScene.getWindow());
+        // initOwner makes the Stage a transient child of the main window - most
+        // Linux WMs (GNOME/Mutter, KFW) then drop the minimise/maximise buttons
+        // for that window and only render the close 'X'. Skip owner so chat is
+        // a top-level Stage with full WM decoration. The price is a separate
+        // entry in the alt-tab list, which is fine for a persistent chat.
         chatPopupStage.initModality(Modality.NONE);
         chatPopupStage.initStyle(StageStyle.DECORATED);
         chatPopupStage.setOnHiding(event -> {
@@ -563,6 +567,14 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         });
         chatPopupStage.setScene(scene);
 
+        // Without explicit sizing the Stage opens at the Scene's preferred size
+        // (tiny - ChatView's intrinsic minHeight is 150 + textarea 70), and the
+        // WM maximize button stays inert because there's no geometry hint. Match
+        // the dispute chat popup sizing so trade + mediation chats look the same.
+        chatPopupStage.setWidth(700);
+        chatPopupStage.setHeight(800);
+        chatPopupStage.setMinWidth(450);
+        chatPopupStage.setMinHeight(500);
         chatPopupStage.setOpacity(0);
         chatPopupStage.show();
 

--- a/desktop/src/main/java/haveno/desktop/main/support/dispute/DisputeChatPopup.java
+++ b/desktop/src/main/java/haveno/desktop/main/support/dispute/DisputeChatPopup.java
@@ -136,7 +136,11 @@ public class DisputeChatPopup {
                 + " " + selectedDispute.getRoleString());
         StackPane owner = MainView.getRootContainer();
         Scene rootScene = owner.getScene();
-        chatPopupStage.initOwner(rootScene.getWindow());
+        // initOwner makes the Stage a transient child of the main window - most
+        // Linux WMs (GNOME/Mutter, KFW) then drop the minimise/maximise buttons
+        // for that window and only render the close 'X'. Skip owner so chat is
+        // a top-level Stage with full WM decoration. The price is a separate
+        // entry in the alt-tab list, which is fine for a persistent chat.
         chatPopupStage.initModality(Modality.NONE);
         chatPopupStage.initStyle(StageStyle.DECORATED);
         chatPopupStage.setOnHiding(event -> {
@@ -156,6 +160,15 @@ public class DisputeChatPopup {
             }
         });
         chatPopupStage.setScene(scene);
+        // Without explicit sizing the Stage opens at the Scene's preferred size,
+        // which for ChatView is ~200x300 px (and the maximize button stays inert
+        // because the WM has no usable geometry hint). Set sensible defaults +
+        // minimums; resizable stays at the JavaFX default (true), so the user
+        // can grow further with edge-drag or the maximize button.
+        chatPopupStage.setWidth(700);
+        chatPopupStage.setHeight(800);
+        chatPopupStage.setMinWidth(450);
+        chatPopupStage.setMinHeight(500);
         chatPopupStage.setOpacity(0);
         chatPopupStage.show();
 


### PR DESCRIPTION
## Problem

The trade and dispute chat popups open tiny (~250x300) and the maximise button does nothing, so the conversation is hard to read. Two causes:

1. No explicit Stage size, so JavaFX opens the window at the Scene's tiny preferred size, and the maximise button has no geometry to work from.
2. `initOwner(rootScene.getWindow())` marks the popup as a transient child, so GNOME/Mutter and most Linux WMs strip the minimise/maximise buttons regardless of `StageStyle.DECORATED`.

## Fix

Both in `PendingTradesView` and `DisputeChatPopup`:

1. Set a default and minimum size before `show()`:
   ```java
   chatPopupStage.setWidth(700);
   chatPopupStage.setHeight(800);
   chatPopupStage.setMinWidth(450);
   chatPopupStage.setMinHeight(500);
   ```
   `resizable` stays at the JavaFX default (`true`), so the user can still grow the window by edge-drag - and now, with a geometry hint present, by the maximise button too.

2. Drop `initOwner(...)` so the chat is a normal top-level window with full WM decoration (min/max/close). `rootScene` is still used for the centring math below; only the owner relationship is removed. Trade-off: the chat becomes its own alt-tab entry, which suits a persistent conversation window.

## Files

- `desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java`
- `desktop/src/main/java/haveno/desktop/main/support/dispute/DisputeChatPopup.java`
