### PR TITLE
migrate to v2 encryption (2-phase transition w/ mandatory updates)

### DIFF
--- a/common/src/main/java/haveno/common/app/Version.java
+++ b/common/src/main/java/haveno/common/app/Version.java
@@ -132,6 +132,12 @@ public class Version {
     // Version = 1.2.0 -> TRADE_PROTOCOL_VERSION = 3
     // Do not change trade fees and bump the version in the same release; separate them (bump first so offers re-sign, change fees later so they grandfather) to avoid cancelling all offers.
     public static final int TRADE_PROTOCOL_VERSION = 3;
+
+    // Encryption format version for sent network payloads (message seals, payment account
+    // payloads): 1 = legacy AES-ECB, 2 = AES-CTR + HMAC. Old nodes cannot read newer formats,
+    // so bump only once the network has updated (filter-enforced minimum version).
+    public static final int NETWORK_ENCRYPTION_VERSION = 1;
+
     private static String p2pMessageVersion;
 
     public static String getP2PMessageVersion() {

--- a/common/src/main/java/haveno/common/crypto/Encryption.java
+++ b/common/src/main/java/haveno/common/crypto/Encryption.java
@@ -22,6 +22,7 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -30,6 +31,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -40,10 +42,14 @@ import javax.crypto.CipherOutputStream;
 import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
+import org.bouncycastle.crypto.params.HKDFParameters;
 
 @Slf4j
 public class Encryption {
@@ -71,9 +77,11 @@ public class Encryption {
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
-    // Symmetric
+    // Symmetric (legacy v1: AES-ECB, no IV)
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    // v1 is retained to read pre-v2 data and for network messages to peers without v2 support;
+    // new at-rest data uses the v2 methods below.
     public static byte[] encrypt(byte[] payload, SecretKey secretKey) throws CryptoException {
         try {
             Cipher cipher = Cipher.getInstance(SYM_CIPHER);
@@ -136,7 +144,7 @@ public class Encryption {
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
-    // Symmetric with Hmac
+    // Symmetric with Hmac (legacy v1: AES-ECB, hmac keyed with the encryption key)
     ///////////////////////////////////////////////////////////////////////////////////////////
 
 
@@ -227,7 +235,8 @@ public class Encryption {
 
     public static byte[] decryptPayloadWithHmac(byte[] encryptedPayloadWithHmac, SecretKey secretKey) throws CryptoException {
         byte[] payloadWithHmac = decrypt(encryptedPayloadWithHmac, secretKey);
-        // HMAC-SHA256 is always 32 bytes; split directly to avoid hex-encoding memory amplification
+        // HMAC-SHA256 is always 32 bytes; a shorter result is malformed, not merely unauthenticated
+        if (payloadWithHmac.length < 32) throw new CryptoException(HMAC_ERROR_MSG);
         int payloadLen = payloadWithHmac.length - 32;
         byte[] payload = Arrays.copyOfRange(payloadWithHmac, 0, payloadLen);
         byte[] hmac = Arrays.copyOfRange(payloadWithHmac, payloadLen, payloadWithHmac.length);
@@ -312,6 +321,377 @@ public class Encryption {
             throw e; // never mistake a heap-constrained read for a corrupt file
         } catch (Throwable e) {
             throw new CryptoException(e);
+        }
+    }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // V2 authenticated encryption (AES-256-CTR + HMAC-SHA256 encrypt-then-MAC)
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    // Blob layout: magic "HVN2" (4) || random IV (16) || AES-CTR ciphertext || HMAC-SHA256 tag (32).
+    // The tag covers magic || IV || ciphertext. Enc and MAC keys are derived from the master key via
+    // HKDF-SHA256, so the master key is never used directly for either primitive (unlike v1, which
+    // used one key for AES-ECB and HMAC). CTR+HMAC is used instead of GCM so large payloads can be
+    // streamed with constant memory in two passes (JCE GCM buffers the whole payload on decrypt).
+    public static final byte[] V2_MAGIC = {'H', 'V', 'N', '2'};
+    private static final String V2_CIPHER = "AES/CTR/NoPadding";
+    private static final int V2_IV_LENGTH = 16;
+    private static final int V2_TAG_LENGTH = 32;
+    private static final int V2_MIN_LENGTH = V2_MAGIC.length + V2_IV_LENGTH + V2_TAG_LENGTH;
+    private static final byte[] V2_HKDF_INFO_ENC = "haveno.crypto.v2.enc".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] V2_HKDF_INFO_MAC = "haveno.crypto.v2.mac".getBytes(StandardCharsets.UTF_8);
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public static boolean isV2Format(byte[] blob) {
+        if (blob == null || blob.length < V2_MIN_LENGTH) return false;
+        for (int i = 0; i < V2_MAGIC.length; i++) {
+            if (blob[i] != V2_MAGIC[i]) return false;
+        }
+        return true;
+    }
+
+    // Peeks the magic without consuming; the stream must support mark/reset.
+    public static boolean isV2Format(InputStream markSupportedStream) throws IOException {
+        markSupportedStream.mark(V2_MAGIC.length);
+        byte[] head = markSupportedStream.readNBytes(V2_MAGIC.length);
+        markSupportedStream.reset();
+        return head.length == V2_MAGIC.length && Arrays.equals(head, V2_MAGIC);
+    }
+
+    // At-rest blobs are versioned by the last magic byte ("HVN" + version). To add a v3: add the
+    // HVN3 cipher pair, detect it here and in the auto/dispatch paths, and bump this constant -
+    // consumers re-encrypt anything older than the current version on first read (like v1 -> v2).
+    public static final int CURRENT_BLOB_VERSION = 2;
+
+    /** Returns the at-rest format version of the blob: 0 for legacy/unversioned (AES-ECB era), 2 for v2. */
+    public static int blobVersion(byte[] blob) {
+        return isV2Format(blob) ? 2 : 0;
+    }
+
+    /** Stream variant of {@link #blobVersion(byte[])}; peeks without consuming (stream must support mark/reset). */
+    public static int blobVersion(InputStream markSupportedStream) throws IOException {
+        return isV2Format(markSupportedStream) ? 2 : 0;
+    }
+
+    private static byte[] hkdf(byte[] masterKeyBytes, byte[] info) {
+        HKDFBytesGenerator hkdf = new HKDFBytesGenerator(new SHA256Digest());
+        hkdf.init(new HKDFParameters(masterKeyBytes, null, info));
+        byte[] out = new byte[32];
+        hkdf.generateBytes(out, 0, 32);
+        return out;
+    }
+
+    private static SecretKey deriveV2EncKey(SecretKey masterKey) {
+        return new SecretKeySpec(hkdf(masterKey.getEncoded(), V2_HKDF_INFO_ENC), SYM_KEY_ALGO);
+    }
+
+    private static SecretKey deriveV2MacKey(SecretKey masterKey) {
+        return new SecretKeySpec(hkdf(masterKey.getEncoded(), V2_HKDF_INFO_MAC), HMAC);
+    }
+
+    public static byte[] encryptV2(byte[] payload, SecretKey masterKey) throws CryptoException {
+        try {
+            byte[] iv = new byte[V2_IV_LENGTH];
+            RANDOM.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(V2_CIPHER);
+            cipher.init(Cipher.ENCRYPT_MODE, deriveV2EncKey(masterKey), new IvParameterSpec(iv));
+            byte[] ciphertext = cipher.doFinal(payload);
+
+            Mac mac = createHmac(deriveV2MacKey(masterKey));
+            mac.update(V2_MAGIC);
+            mac.update(iv);
+            mac.update(ciphertext);
+            byte[] tag = mac.doFinal();
+
+            byte[] blob = new byte[V2_MAGIC.length + V2_IV_LENGTH + ciphertext.length + V2_TAG_LENGTH];
+            System.arraycopy(V2_MAGIC, 0, blob, 0, V2_MAGIC.length);
+            System.arraycopy(iv, 0, blob, V2_MAGIC.length, V2_IV_LENGTH);
+            System.arraycopy(ciphertext, 0, blob, V2_MAGIC.length + V2_IV_LENGTH, ciphertext.length);
+            System.arraycopy(tag, 0, blob, blob.length - V2_TAG_LENGTH, V2_TAG_LENGTH);
+            return blob;
+        } catch (OutOfMemoryError e) {
+            throw e; // never mistake a heap-constrained encrypt for a write failure callers would retry
+        } catch (Throwable e) {
+            log.error("error in encryptV2", e);
+            throw new CryptoException(e);
+        }
+    }
+
+    public static byte[] decryptV2(byte[] blob, SecretKey masterKey) throws CryptoException {
+        try {
+            if (!isV2Format(blob)) throw new CryptoException("Not a v2 encrypted blob");
+            int ciphertextLen = blob.length - V2_MIN_LENGTH;
+
+            Mac mac = createHmac(deriveV2MacKey(masterKey));
+            mac.update(blob, 0, blob.length - V2_TAG_LENGTH);
+            byte[] tag = Arrays.copyOfRange(blob, blob.length - V2_TAG_LENGTH, blob.length);
+            if (!MessageDigest.isEqual(mac.doFinal(), tag)) throw new CryptoException(HMAC_ERROR_MSG);
+
+            byte[] iv = Arrays.copyOfRange(blob, V2_MAGIC.length, V2_MAGIC.length + V2_IV_LENGTH);
+            Cipher cipher = Cipher.getInstance(V2_CIPHER);
+            cipher.init(Cipher.DECRYPT_MODE, deriveV2EncKey(masterKey), new IvParameterSpec(iv));
+            return cipher.doFinal(blob, V2_MAGIC.length + V2_IV_LENGTH, ciphertextLen);
+        } catch (CryptoException e) {
+            throw e;
+        } catch (OutOfMemoryError e) {
+            throw e; // never mistake a heap-constrained decrypt for a corrupt blob
+        } catch (Throwable e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    // Decrypts v2 or legacy v1 (AES-ECB) blobs, detected by the magic prefix. A magic-colliding
+    // legacy blob (p = 2^-32) falls back to v1 after failing the tag check. The v1 path carries
+    // no MAC, so callers must authenticate the result themselves (all current callers do).
+    public static byte[] decryptAuto(byte[] blob, SecretKey masterKey) throws CryptoException {
+        if (isV2Format(blob)) {
+            try {
+                return decryptV2(blob, masterKey);
+            } catch (CryptoException e) {
+                // log before falling back so a real v2 tag failure is not misdiagnosed as a v1 error
+                log.warn("v2 decrypt failed ({}); attempting legacy v1 decrypt", e.getMessage());
+                return decrypt(blob, masterKey);
+            }
+        }
+        return decrypt(blob, masterKey);
+    }
+
+    // Decrypts v2 or legacy v1 (AES-ECB with trailing HMAC) blobs, detected by the magic prefix,
+    // with the same magic-collision fallback as decryptAuto (the v1 path verifies its own hmac).
+    public static byte[] decryptPayloadWithHmacAuto(byte[] blob, SecretKey masterKey) throws CryptoException {
+        if (isV2Format(blob)) {
+            try {
+                return decryptV2(blob, masterKey);
+            } catch (CryptoException e) {
+                // log before falling back so a real v2 tag failure is not misdiagnosed as a v1 error
+                log.warn("v2 decrypt failed ({}); attempting legacy v1 decrypt", e.getMessage());
+                return decryptPayloadWithHmac(blob, masterKey);
+            }
+        }
+        return decryptPayloadWithHmac(blob, masterKey);
+    }
+
+    /**
+     * Streams a v2 blob to {@code outputStream} with constant memory in a single payload pass
+     * (ciphertext teed into the hmac). Does not close {@code outputStream}.
+     */
+    public static void encryptV2ToStream(PayloadWriter payloadWriter, SecretKey masterKey, OutputStream outputStream) throws CryptoException {
+        try {
+            byte[] iv = new byte[V2_IV_LENGTH];
+            RANDOM.nextBytes(iv);
+            Mac mac = createHmac(deriveV2MacKey(masterKey));
+            mac.update(V2_MAGIC);
+            mac.update(iv);
+            outputStream.write(V2_MAGIC);
+            outputStream.write(iv);
+
+            Cipher cipher = Cipher.getInstance(V2_CIPHER);
+            cipher.init(Cipher.ENCRYPT_MODE, deriveV2EncKey(masterKey), new IvParameterSpec(iv));
+            try (CipherOutputStream cipherOutputStream = new CipherOutputStream(
+                    new MacTeeOutputStream(new CloseShieldOutputStream(outputStream), mac), cipher)) {
+                payloadWriter.writeTo(cipherOutputStream);
+            }
+            outputStream.write(mac.doFinal());
+        } catch (OutOfMemoryError e) {
+            throw e; // never mistake a heap-constrained encrypt for a write failure callers would retry
+        } catch (Throwable e) {
+            log.error("error in encryptV2ToStream", e);
+            throw new CryptoException(e);
+        }
+    }
+
+    /**
+     * Pass 1 of a two-pass v2 read: verifies the tag over the raw stream (no decryption needed with
+     * encrypt-then-MAC) and returns the payload length. Throws {@link CryptoException} if the stream
+     * is not a valid v2 blob for this key.
+     */
+    public static long verifyV2Stream(InputStream encryptedInput, SecretKey masterKey) throws CryptoException {
+        try {
+            byte[] head = encryptedInput.readNBytes(V2_MAGIC.length);
+            if (head.length != V2_MAGIC.length || !Arrays.equals(head, V2_MAGIC)) throw new CryptoException("Not a v2 encrypted stream");
+            byte[] iv = encryptedInput.readNBytes(V2_IV_LENGTH);
+            if (iv.length != V2_IV_LENGTH) throw new CryptoException("Truncated v2 stream");
+
+            Mac mac = createHmac(deriveV2MacKey(masterKey));
+            mac.update(head);
+            mac.update(iv);
+
+            // Feed all bytes except the trailing 32 (the tag) into the mac; CTR has no padding, so
+            // ciphertext length == payload length.
+            byte[] hold = new byte[V2_TAG_LENGTH];
+            int holdLen = 0;
+            long payloadLen = 0;
+            byte[] readBuf = new byte[64 * 1024];
+            int read;
+            while ((read = encryptedInput.read(readBuf)) != -1) {
+                int emit = holdLen + read - V2_TAG_LENGTH;
+                if (emit <= 0) {
+                    System.arraycopy(readBuf, 0, hold, holdLen, read);
+                    holdLen += read;
+                    continue;
+                }
+                int fromHold = Math.min(emit, holdLen);
+                if (fromHold > 0) {
+                    mac.update(hold, 0, fromHold);
+                    payloadLen += fromHold;
+                }
+                int fromBuf = emit - fromHold;
+                if (fromBuf > 0) {
+                    mac.update(readBuf, 0, fromBuf);
+                    payloadLen += fromBuf;
+                }
+                int remHold = holdLen - fromHold;
+                if (remHold > 0) System.arraycopy(hold, fromHold, hold, 0, remHold);
+                int tail = read - fromBuf;
+                System.arraycopy(readBuf, fromBuf, hold, remHold, tail);
+                holdLen = remHold + tail; // == 32
+            }
+            if (holdLen != V2_TAG_LENGTH) throw new CryptoException(HMAC_ERROR_MSG);
+            if (!MessageDigest.isEqual(mac.doFinal(), hold)) throw new CryptoException(HMAC_ERROR_MSG);
+            return payloadLen;
+        } catch (OutOfMemoryError | CryptoException e) {
+            throw e;
+        } catch (Throwable e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    /**
+     * Pass 2 of a two-pass v2 read: returns a plaintext stream that re-verifies the tag over the
+     * bytes actually read, throwing {@link IOException} on mismatch before signaling EOF, so fully
+     * consumed data is always authenticated. Callers must read to EOF; closing before the tag was
+     * verified throws. Closing it closes {@code encryptedInput}.
+     */
+    public static InputStream decryptV2Stream(InputStream encryptedInput, SecretKey masterKey) throws CryptoException {
+        try {
+            byte[] head = encryptedInput.readNBytes(V2_MAGIC.length);
+            if (head.length != V2_MAGIC.length || !Arrays.equals(head, V2_MAGIC)) throw new CryptoException("Not a v2 encrypted stream");
+            byte[] iv = encryptedInput.readNBytes(V2_IV_LENGTH);
+            if (iv.length != V2_IV_LENGTH) throw new CryptoException("Truncated v2 stream");
+
+            Mac mac = createHmac(deriveV2MacKey(masterKey));
+            mac.update(head);
+            mac.update(iv);
+
+            Cipher cipher = Cipher.getInstance(V2_CIPHER);
+            cipher.init(Cipher.DECRYPT_MODE, deriveV2EncKey(masterKey), new IvParameterSpec(iv));
+            return new V2DecryptingInputStream(encryptedInput, cipher, mac);
+        } catch (OutOfMemoryError | CryptoException e) {
+            throw e; // never mistake a heap-constrained read for a corrupt file
+        } catch (Throwable e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    private static class MacTeeOutputStream extends FilterOutputStream {
+        private final Mac mac;
+
+        private MacTeeOutputStream(OutputStream out, Mac mac) {
+            super(out);
+            this.mac = mac;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            mac.update((byte) b);
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            mac.update(b, off, len);
+            out.write(b, off, len);
+        }
+    }
+
+    // Decrypts ciphertext while holding back the trailing 32 bytes as the candidate tag; at EOF the
+    // tag is compared against the mac over everything decrypted (header and IV are fed by the caller).
+    private static class V2DecryptingInputStream extends InputStream {
+        private final InputStream in;
+        private final Cipher cipher;
+        private final Mac mac;
+        private final byte[] hold = new byte[V2_TAG_LENGTH];
+        private int holdLen = 0;
+        private final byte[] readBuf = new byte[64 * 1024];
+        private byte[] outBuf = new byte[0];
+        private int outPos = 0;
+        private boolean finished = false;
+
+        private V2DecryptingInputStream(InputStream in, Cipher cipher, Mac mac) {
+            this.in = in;
+            this.cipher = cipher;
+            this.mac = mac;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] one = new byte[1];
+            int n = read(one, 0, 1);
+            return n == -1 ? -1 : one[0] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (len == 0) return 0;
+            while (outPos >= outBuf.length) {
+                if (finished) return -1;
+                fill();
+            }
+            int n = Math.min(len, outBuf.length - outPos);
+            System.arraycopy(outBuf, outPos, b, off, n);
+            outPos += n;
+            return n;
+        }
+
+        private void fill() throws IOException {
+            int read = in.read(readBuf);
+            if (read == -1) {
+                if (holdLen != V2_TAG_LENGTH || !MessageDigest.isEqual(mac.doFinal(), Arrays.copyOf(hold, holdLen))) {
+                    throw new IOException(HMAC_ERROR_MSG);
+                }
+                try {
+                    byte[] last = cipher.doFinal();
+                    outBuf = last != null ? last : new byte[0];
+                } catch (Exception e) {
+                    throw new IOException(e);
+                }
+                outPos = 0;
+                finished = true;
+                return;
+            }
+            int emit = holdLen + read - V2_TAG_LENGTH;
+            if (emit <= 0) {
+                System.arraycopy(readBuf, 0, hold, holdLen, read);
+                holdLen += read;
+                outBuf = new byte[0];
+                outPos = 0;
+                return;
+            }
+            byte[] ciphertext = new byte[emit];
+            int fromHold = Math.min(emit, holdLen);
+            if (fromHold > 0) System.arraycopy(hold, 0, ciphertext, 0, fromHold);
+            int fromBuf = emit - fromHold;
+            if (fromBuf > 0) System.arraycopy(readBuf, 0, ciphertext, fromHold, fromBuf);
+            int remHold = holdLen - fromHold;
+            if (remHold > 0) System.arraycopy(hold, fromHold, hold, 0, remHold);
+            int tail = read - fromBuf;
+            System.arraycopy(readBuf, fromBuf, hold, remHold, tail);
+            holdLen = remHold + tail; // == 32
+            mac.update(ciphertext);
+            byte[] plaintext = cipher.update(ciphertext);
+            outBuf = plaintext != null ? plaintext : new byte[0];
+            outPos = 0;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                // enforce the read-to-EOF contract so partially consumed plaintext is never trusted
+                if (!finished) throw new IOException("Stream closed before its authentication tag was verified");
+            } finally {
+                in.close();
+            }
         }
     }
 

--- a/common/src/main/java/haveno/common/crypto/KeyRing.java
+++ b/common/src/main/java/haveno/common/crypto/KeyRing.java
@@ -98,6 +98,13 @@ public final class KeyRing {
             signatureKeyPair = keyStorage.loadKeyPair(KeyStorage.KeyEntry.MSG_SIGNATURE, symmetricKey);
             encryptionKeyPair = keyStorage.loadKeyPair(KeyStorage.KeyEntry.MSG_ENCRYPTION, symmetricKey);
             if (signatureKeyPair != null && encryptionKeyPair != null) pubKeyRing = new PubKeyRing(signatureKeyPair.getPublic(), encryptionKeyPair.getPublic());
+            if (isUnlocked() && keyStorage.needsFormatUpgrade()) {
+                try {
+                    keyStorage.saveKeyRing(this, password);
+                } catch (Exception e) {
+                    log.error("Failed to upgrade key storage format, will retry on next unlock", e);
+                }
+            }
         } else if (generateKeys) {
             generateKeys(password);
         }
@@ -115,7 +122,7 @@ public final class KeyRing {
         signatureKeyPair = Sig.generateKeyPair();
         encryptionKeyPair = Encryption.generateKeyPair();
         pubKeyRing = new PubKeyRing(signatureKeyPair.getPublic(), encryptionKeyPair.getPublic());
-        keyStorage.saveKeyRing(this, null, password);
+        keyStorage.saveKeyRing(this, password);
     }
 
     // Don't print keys for security reasons

--- a/common/src/main/java/haveno/common/crypto/KeyRing.java
+++ b/common/src/main/java/haveno/common/crypto/KeyRing.java
@@ -117,9 +117,9 @@ public final class KeyRing {
             if (signatureKeyPair != null && encryptionKeyPair != null) pubKeyRing = new PubKeyRing(signatureKeyPair.getPublic(), encryptionKeyPair.getPublic());
             if (isUnlocked() && keyStorage.needsFormatUpgrade()) {
                 try {
-                    // durably record unmigrated plaintext stores before replacing the legacy key
-                    // files, whose presence is what authorizes reading plaintext (see PersistenceManager)
-                    if (storageDir != null) PlaintextMigration.record(storageDir, symmetricKey);
+                    // encrypt all plaintext stores before replacing the legacy key files, whose
+                    // presence is what authorizes reading plaintext (see PersistenceManager)
+                    if (storageDir != null) PlaintextMigration.migrate(storageDir, symmetricKey);
                     keyStorage.saveKeyRing(this, password);
                 } catch (Exception e) {
                     log.error("Failed to upgrade key storage format, will retry on next unlock", e);
@@ -138,6 +138,13 @@ public final class KeyRing {
      */
     public void generateKeys(String password) {
         if (isUnlocked()) throw new IllegalStateException("Current keyring must be closed to generate new keys");
+        try {
+            // key material left by a previous (unopenable) account may be its only remaining key
+            // copy; move it out of the way so the new account's saves can never purge it
+            keyStorage.preserveLostAccountKeys();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not preserve a previous account's key files", e);
+        }
         symmetricKey = Encryption.generateSecretKey(256);
         signatureKeyPair = Sig.generateKeyPair();
         encryptionKeyPair = Encryption.generateKeyPair();

--- a/common/src/main/java/haveno/common/crypto/KeyRing.java
+++ b/common/src/main/java/haveno/common/crypto/KeyRing.java
@@ -19,6 +19,10 @@ package haveno.common.crypto;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import haveno.common.config.Config;
+import haveno.common.persistence.PlaintextMigration;
+import java.io.File;
 import java.security.KeyPair;
 import javax.annotation.Nullable;
 import javax.crypto.SecretKey;
@@ -33,6 +37,9 @@ import lombok.extern.slf4j.Slf4j;
 public final class KeyRing {
 
     private final KeyStorage keyStorage;
+    // Persisted-store dir, used to record unmigrated plaintext stores before key migration.
+    @Nullable
+    private final File storageDir;
 
     private SecretKey symmetricKey;
     private KeyPair signatureKeyPair;
@@ -43,10 +50,15 @@ public final class KeyRing {
      * Creates the KeyRing. Unlocks if not encrypted. Does not generate keys.
      *
      * @param keyStorage Persisted storage
+     * @param storageDir Directory of the persisted stores
      */
     @Inject
+    public KeyRing(KeyStorage keyStorage, @Named(Config.STORAGE_DIR) File storageDir) {
+        this(keyStorage, storageDir, null, false);
+    }
+
     public KeyRing(KeyStorage keyStorage) {
-        this(keyStorage, null, false);
+        this(keyStorage, null, null, false);
     }
 
     /**
@@ -57,7 +69,12 @@ public final class KeyRing {
      * @param generateKeys Generate new keys with password if not created yet.
      */
     public KeyRing(KeyStorage keyStorage, String password, boolean generateKeys) {
+        this(keyStorage, null, password, generateKeys);
+    }
+
+    public KeyRing(KeyStorage keyStorage, @Nullable File storageDir, String password, boolean generateKeys) {
         this.keyStorage = keyStorage;
+        this.storageDir = storageDir;
         try {
             unlockKeys(password, generateKeys);
         } catch(IncorrectPasswordException ex) {
@@ -100,6 +117,9 @@ public final class KeyRing {
             if (signatureKeyPair != null && encryptionKeyPair != null) pubKeyRing = new PubKeyRing(signatureKeyPair.getPublic(), encryptionKeyPair.getPublic());
             if (isUnlocked() && keyStorage.needsFormatUpgrade()) {
                 try {
+                    // durably record unmigrated plaintext stores before replacing the legacy key
+                    // files, whose presence is what authorizes reading plaintext (see PersistenceManager)
+                    if (storageDir != null) PlaintextMigration.record(storageDir, symmetricKey);
                     keyStorage.saveKeyRing(this, password);
                 } catch (Exception e) {
                     log.error("Failed to upgrade key storage format, will retry on next unlock", e);

--- a/common/src/main/java/haveno/common/crypto/KeyStorage.java
+++ b/common/src/main/java/haveno/common/crypto/KeyStorage.java
@@ -23,6 +23,10 @@ import com.google.inject.name.Named;
 import haveno.common.config.Config;
 import haveno.common.file.FileUtil;
 import static haveno.common.util.Preconditions.checkDir;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -46,7 +50,11 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
 import javax.crypto.SecretKey;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -66,11 +74,17 @@ public class KeyStorage {
     private static final byte[] SYM_FILE_MAGIC = {'H', 'V', 'N', 'K'};
     private static final byte SYM_FILE_VERSION = 1;
     private static final String LEGACY_SYM_FILE_NAME = "sym.p12";
+    // Present only during a password change: a second sym.key wrapper under the new password plus
+    // an authenticated journal of both passwords, so a crash leaves the account unlockable with either.
+    private static final String PENDING_SYM_FILE_NAME = "sym.key.new";
+    private static final String PASSWORD_CHANGE_JOURNAL_FILE_NAME = "password_change";
     // The header is unauthenticated, so bound KDF cost and file size before any allocation.
     private static final int MAX_MEM_KIB = 256 * 1024;
     private static final int MAX_ITERATIONS = 10;
     private static final int MAX_PARALLELISM = 4;
     private static final int MAX_SYM_FILE_SIZE = 4096;
+    // bounds the extra key derivations spent probing distinct backups of a corrupt key file
+    private static final int MAX_KEY_BACKUP_PROBES = 3;
     // Generous for a PKCS#8 RSA/DSA private key in a v2 blob; anything larger is corruption.
     private static final int MAX_KEY_FILE_SIZE = 64 * 1024;
 
@@ -124,7 +138,13 @@ public class KeyStorage {
 
     public boolean allKeyFilesExist() {
         return fileExists(KeyEntry.MSG_SIGNATURE) && fileExists(KeyEntry.MSG_ENCRYPTION)
-                && (fileExists(KeyEntry.SYM_ENCRYPTION) || legacySymFile().exists());
+                && (fileExists(KeyEntry.SYM_ENCRYPTION) || legacySymFile().exists() || hasRecoverablePendingWrapper());
+    }
+
+    // A journaled pending wrapper can recover the account even if the live wrapper was lost to a
+    // crash during a non-atomic replacement, so it must count as an existing account.
+    private boolean hasRecoverablePendingWrapper() {
+        return hasPasswordChangeJournal() && new File(storageDir, PENDING_SYM_FILE_NAME).exists();
     }
 
     public boolean needsFormatUpgrade() {
@@ -202,12 +222,76 @@ public class KeyStorage {
      * @param password Optional password that protects the key
      */
     public SecretKey loadSecretKey(KeyEntry keyEntry, String password) throws IncorrectPasswordException {
+        // stale transaction temps from a crash can hold a master-key wrapper or a journal of both
+        // passwords; they are never valid at unlock and must not survive into backups
+        for (String staleName : new String[]{KeyEntry.SYM_ENCRYPTION.getFileName() + ".tmp",
+                PENDING_SYM_FILE_NAME + ".tmp", PASSWORD_CHANGE_JOURNAL_FILE_NAME + ".tmp"}) {
+            try {
+                deleteStrict(new File(storageDir, staleName));
+            } catch (IOException e) {
+                throw new RuntimeException("Could not delete stale key file " + staleName, e);
+            }
+        }
+        // an orphan pending wrapper (no journal) from a failed transaction initialization is
+        // unused, but still wraps the master key under an abandoned password: remove it strictly
+        File orphanPendingFile = new File(storageDir, PENDING_SYM_FILE_NAME);
+        if (orphanPendingFile.exists() && !hasPasswordChangeJournal()) {
+            try {
+                deleteStrict(orphanPendingFile);
+                log.warn("Removed orphan pending key wrapper from an interrupted password change");
+            } catch (IOException e) {
+                throw new RuntimeException("Could not delete orphan pending key wrapper", e);
+            }
+        }
         File keyFile = new File(storageDir + "/" + keyEntry.getFileName());
         if (keyFile.exists()) {
-            SecretKey key = loadSecretKeyV2(keyFile, password);
-            // backup only after a successful load, so retries against a corrupt file cannot rotate out good backups
-            FileUtil.rollingBackup(storageDir, keyEntry.getFileName(), 20);
+            SecretKey key;
+            boolean keyFromPendingWrapper = false;
+            try {
+                key = loadSecretKeyV2(keyFile, password);
+            } catch (IncorrectPasswordException e) {
+                // during an interrupted password change the other password unlocks via the pending
+                // wrapper; while a journal exists the recovery machinery owns the state and the
+                // backup probe must not run (backups may still wrap the retiring password)
+                if (hasPasswordChangeJournal()) {
+                    File pendingFile = new File(storageDir, PENDING_SYM_FILE_NAME);
+                    if (!pendingFile.exists()) throw e;
+                    key = loadSecretKeyV2(pendingFile, password);
+                    keyFromPendingWrapper = true;
+                } else {
+                    // rotation is done inside the probe only after the live file is restored, so
+                    // a corrupt file cannot be copied over the good backups
+                    return recoverSecretKeyFromBackups(keyFile, password, e);
+                }
+            } catch (RuntimeException e) {
+                // structural corruption (bad header, truncation) must not lock the user out
+                // while the pending wrapper or a good backup can still unlock; while a journal
+                // exists the backup probe must not run (backups may still wrap the retiring
+                // password), but the pending wrapper is part of the transaction and safe to try
+                if (hasPasswordChangeJournal()) {
+                    File pendingFile = new File(storageDir, PENDING_SYM_FILE_NAME);
+                    if (!pendingFile.exists()) throw e;
+                    key = loadSecretKeyV2(pendingFile, password);
+                    keyFromPendingWrapper = true;
+                } else {
+                    return recoverSecretKeyFromBackups(keyFile, password, e);
+                }
+            }
+            // backup only after a successful load, so retries against a corrupt file cannot rotate
+            // out good backups. When the pending wrapper supplied the key the live wrapper did not
+            // authenticate (counterpart password or bit rot - indistinguishable here), so neither
+            // rotate it into the backups nor purge legacy material; recovery rewraps it shortly
+            if (!keyFromPendingWrapper) {
+                FileUtil.rollingBackup(storageDir, keyEntry.getFileName(), 20);
+                purgeStaleLegacyWrapper(keyEntry.getFileName());
+            }
             return key;
+        }
+        // a crash during a non-atomic replacement of the live wrapper can lose it while the
+        // transaction's pending wrapper remains; unlock from it so recovery can recommit
+        if (hasRecoverablePendingWrapper()) {
+            log.warn("{} is missing but a journaled pending wrapper exists; unlocking from the pending wrapper", keyEntry.getFileName());
+            return loadSecretKeyV2(new File(storageDir, PENDING_SYM_FILE_NAME), password);
         }
         legacyFormatLoaded = legacyFormatEverLoaded = true;
         SecretKey key = loadSecretKeyLegacy(keyEntry, password);
@@ -215,10 +299,95 @@ public class KeyStorage {
         return key;
     }
 
+    // Removes a legacy PKCS#12 wrapper (and its backups) left behind by a failed purge; it is
+    // never current once the v2 file unlocks, but stays brute-forceable (weak KDF). A fresh
+    // verified backup of the live wrapper is taken first, so the purge can never leave it as
+    // the only copy. Failures are logged and retried on the next unlock.
+    private void purgeStaleLegacyWrapper(String liveFileName) {
+        if (!legacySymFile().exists() && !FileUtil.hasBackups(storageDir, LEGACY_SYM_FILE_NAME)) return;
+        try {
+            FileUtil.rollingBackupStrict(storageDir, liveFileName, 20);
+            FileUtil.deleteFileIfExists(legacySymFile(), false);
+            FileUtil.deleteRollingBackupStrict(storageDir, LEGACY_SYM_FILE_NAME);
+        } catch (IOException e) {
+            log.error("Could not remove the stale legacy key file; it remains brute-forceable until deleted", e);
+        }
+    }
+
+    // Distinguishes a corrupted live wrapper from a genuinely wrong password by probing recent
+    // backups: byte-identical copies are skipped, so a wrong password costs no extra key
+    // derivations; a backup that unlocks is restored over the corrupt file.
+    private SecretKey recoverSecretKeyFromBackups(File keyFile, String password, Exception original) throws IncorrectPasswordException {
+        byte[] liveBytes;
+        try {
+            liveBytes = Files.readAllBytes(keyFile.toPath());
+        } catch (IOException e) {
+            throw rethrow(original);
+        }
+        List<File> backups = new ArrayList<>(FileUtil.getBackupFiles(storageDir, keyFile.getName()));
+        backups.sort(Comparator.comparing(File::getName).reversed()); // <epoch millis>_<name>, newest first
+        List<byte[]> probed = new ArrayList<>();
+        probed.add(liveBytes);
+        for (File backup : backups) {
+            if (probed.size() > MAX_KEY_BACKUP_PROBES) break;
+            if (backup.length() == 0 || backup.length() > MAX_SYM_FILE_SIZE) continue;
+            byte[] backupBytes;
+            try {
+                backupBytes = Files.readAllBytes(backup.toPath());
+            } catch (IOException e) {
+                continue;
+            }
+            // an identical wrapper fails the same way; probe each distinct one only once
+            if (probed.stream().anyMatch(seen -> Arrays.equals(seen, backupBytes))) continue;
+            probed.add(backupBytes);
+            SecretKey key;
+            try {
+                // authenticate exactly the bytes that would be restored
+                key = loadSecretKeyV2(backupBytes, password, backup.getName());
+            } catch (Exception e) {
+                continue;
+            }
+            log.warn("{} did not unlock but backup {} did; restoring the backup over the corrupt file", keyFile.getName(), backup.getName());
+            try {
+                File tempFile = new File(storageDir, keyFile.getName() + ".tmp");
+                try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                    fos.write(backupBytes);
+                    fos.flush();
+                    fos.getFD().sync();
+                }
+                FileUtil.atomicReplace(tempFile, keyFile);
+                // rotate a backup of the restored file only now, so a failed restore cannot
+                // copy the corrupt live file over the good generations
+                FileUtil.rollingBackup(storageDir, keyFile.getName(), 20);
+                purgeStaleLegacyWrapper(keyFile.getName());
+            } catch (IOException e) {
+                log.warn("Could not restore key backup over {}; unlocking anyway", keyFile.getName(), e);
+            }
+            return key;
+        }
+        throw rethrow(original);
+    }
+
+    private static RuntimeException rethrow(Exception original) throws IncorrectPasswordException {
+        if (original instanceof IncorrectPasswordException e) throw e;
+        return (RuntimeException) original;
+    }
+
     private SecretKey loadSecretKeyV2(File keyFile, String password) throws IncorrectPasswordException {
         try {
             if (keyFile.length() > MAX_SYM_FILE_SIZE) throw new IOException("Key file too large: " + keyFile.length());
-            ByteBuffer buf = ByteBuffer.wrap(Files.readAllBytes(keyFile.toPath()));
+            return loadSecretKeyV2(Files.readAllBytes(keyFile.toPath()), password, keyFile.getName());
+        } catch (IOException e) {
+            log.error("Could not load key " + keyFile.getName(), e);
+            throw new RuntimeException("Could not load key " + keyFile.getName(), e);
+        }
+    }
+
+    // Byte-based so a caller can authenticate exactly the bytes it goes on to use.
+    private SecretKey loadSecretKeyV2(byte[] fileBytes, String password, String name) throws IncorrectPasswordException {
+        try {
+            if (fileBytes.length > MAX_SYM_FILE_SIZE) throw new IOException("Key file too large: " + fileBytes.length);
+            ByteBuffer buf = ByteBuffer.wrap(fileBytes);
             byte[] magic = new byte[SYM_FILE_MAGIC.length];
             buf.get(magic);
             if (!Arrays.equals(magic, SYM_FILE_MAGIC)) throw new IOException("Invalid key file magic");
@@ -248,8 +417,8 @@ public class KeyStorage {
         } catch (IncorrectPasswordException e) {
             throw e;
         } catch (Exception e) {
-            log.error("Could not load key " + keyFile.getName(), e);
-            throw new RuntimeException("Could not load key " + keyFile.getName(), e);
+            log.error("Could not load key " + name, e);
+            throw new RuntimeException("Could not load key " + name, e);
         }
     }
 
@@ -280,6 +449,40 @@ public class KeyStorage {
     }
 
     /**
+     * Moves any leftover key material of a previous account (live files, legacy wrapper,
+     * transaction artifacts and all rolling backups) into a timestamped folder before fresh keys
+     * are generated over it, e.g. after a partial key-file loss made the account unopenable. The
+     * material may be that account's only remaining key copy, so it must leave the rolling-backup
+     * machinery entirely - the replacement account's saves, password changes and backup rotation
+     * would otherwise eventually purge it. Throws on failure, aborting the account creation.
+     */
+    public void preserveLostAccountKeys() throws IOException {
+        List<String> names = new ArrayList<>();
+        for (KeyEntry keyEntry : KeyEntry.values()) {
+            names.add(keyEntry.getFileName());
+            names.add(keyEntry.getFileName() + ".tmp"); // a crash-left temp may be the only usable copy
+        }
+        names.addAll(List.of(LEGACY_SYM_FILE_NAME, PENDING_SYM_FILE_NAME, PASSWORD_CHANGE_JOURNAL_FILE_NAME,
+                PENDING_SYM_FILE_NAME + ".tmp", PASSWORD_CHANGE_JOURNAL_FILE_NAME + ".tmp"));
+        List<File> artifacts = new ArrayList<>();
+        for (String name : names) {
+            File file = new File(storageDir, name);
+            if (file.exists()) artifacts.add(file);
+        }
+        File backupDir = FileUtil.getBackupRoot(storageDir);
+        if (artifacts.isEmpty() && !backupDir.exists()) return;
+        File preserveDir = new File(storageDir, "lost_account_" + new Date().getTime());
+        Files.createDirectory(preserveDir.toPath());
+        for (File artifact : artifacts) FileUtil.renameFile(artifact, new File(preserveDir, artifact.getName()));
+        if (backupDir.exists()) FileUtil.renameFile(backupDir, new File(preserveDir, backupDir.getName()));
+        // best effort: sync the destination's new entries before the source removals, so a power
+        // loss cannot durably remove the material without its preserved copy
+        FileUtil.syncDir(preserveDir);
+        FileUtil.syncDir(storageDir);
+        log.warn("Moved key material of a previous account to {}; it may be that account's only remaining key copy", preserveDir.getName());
+    }
+
+    /**
      * Saves the key ring to the key storage directory.
      *
      * @param keyRing  The key ring
@@ -289,12 +492,137 @@ public class KeyStorage {
         SecretKey symmetric = keyRing.getSymmetricKey();
 
         // password protect the symmetric key
-        saveSecretKey(symmetric, KeyEntry.SYM_ENCRYPTION.getFileName(), password);
+        saveSecretKey(symmetric, KeyEntry.SYM_ENCRYPTION.getFileName(), password, true);
 
         // use symmetric encryption to encrypt the key pairs
         saveKey(keyRing.getSignatureKeyPair().getPrivate(), KeyEntry.MSG_SIGNATURE.getFileName(), symmetric);
         saveKey(keyRing.getEncryptionKeyPair().getPrivate(), KeyEntry.MSG_ENCRYPTION.getFileName(), symmetric);
         legacyFormatLoaded = false;
+    }
+
+    /**
+     * Durably begins a password change: writes an authenticated journal of both passwords and a
+     * second sym.key wrapper under the new password. sym.key itself stays on the old password, so
+     * a crash at any point leaves the account unlockable with either password.
+     */
+    public void beginPasswordChange(KeyRing keyRing, String oldPassword, String newPassword) {
+        // write the pending wrapper first: without the journal it is inert, so a failure at any
+        // point here leaves no durable transaction behind
+        saveSecretKey(keyRing.getSymmetricKey(), PENDING_SYM_FILE_NAME, newPassword, false);
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            DataOutputStream out = new DataOutputStream(bos);
+            writeNullableUtf(out, oldPassword);
+            writeNullableUtf(out, newPassword);
+            byte[] blob = Encryption.encryptV2(bos.toByteArray(), keyRing.getSymmetricKey());
+            File journalFile = new File(storageDir, PASSWORD_CHANGE_JOURNAL_FILE_NAME);
+            File tempFile = new File(storageDir, PASSWORD_CHANGE_JOURNAL_FILE_NAME + ".tmp");
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                fos.write(blob);
+                fos.flush();
+                fos.getFD().sync();
+            }
+            FileUtil.atomicReplace(tempFile, journalFile);
+        } catch (Exception e) {
+            RuntimeException ex = new RuntimeException("Could not journal password change", e);
+            for (String name : new String[]{PENDING_SYM_FILE_NAME, PASSWORD_CHANGE_JOURNAL_FILE_NAME + ".tmp"}) {
+                try {
+                    deleteStrict(new File(storageDir, name));
+                } catch (Exception e2) {
+                    ex.addSuppressed(e2);
+                }
+            }
+            throw ex;
+        }
+    }
+
+    /**
+     * Returns [oldPassword, newPassword] from the password change journal, or null if there is none
+     * or it cannot be authenticated.
+     */
+    public String[] readPasswordChangeJournal(SecretKey masterKey) {
+        File journalFile = new File(storageDir, PASSWORD_CHANGE_JOURNAL_FILE_NAME);
+        if (!journalFile.exists()) return null;
+        try {
+            byte[] plain = Encryption.decryptV2(Files.readAllBytes(journalFile.toPath()), masterKey);
+            DataInputStream in = new DataInputStream(new ByteArrayInputStream(plain));
+            return new String[]{readNullableUtf(in), readNullableUtf(in)};
+        } catch (Exception e) {
+            log.error("Could not read password change journal", e);
+            return null;
+        }
+    }
+
+    public boolean hasPasswordChangeJournal() {
+        return new File(storageDir, PASSWORD_CHANGE_JOURNAL_FILE_NAME).exists();
+    }
+
+    /** Whether any password-change transaction file exists, including crash-left temps. */
+    public boolean hasPasswordChangeArtifacts() {
+        for (String name : new String[]{PASSWORD_CHANGE_JOURNAL_FILE_NAME, PASSWORD_CHANGE_JOURNAL_FILE_NAME + ".tmp",
+                PENDING_SYM_FILE_NAME, PENDING_SYM_FILE_NAME + ".tmp", KeyEntry.SYM_ENCRYPTION.getFileName() + ".tmp"}) {
+            if (new File(storageDir, name).exists()) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Commits a password change: rewraps sym.key under the given password, then removes the
+     * pending wrapper and journal.
+     */
+    public void commitPasswordChange(KeyRing keyRing, String password) {
+        saveSecretKey(keyRing.getSymmetricKey(), KeyEntry.SYM_ENCRYPTION.getFileName(), password, false);
+    }
+
+    /**
+     * Completes a committed password change: purges stale sym.key artifacts with verification,
+     * takes a fresh backup and removes the pending wrapper and journal. On failure the journal
+     * remains, keeping the transaction visibly pending for recovery to retry.
+     */
+    public void finishPasswordChange() {
+        String fileName = KeyEntry.SYM_ENCRYPTION.getFileName();
+        try {
+            // fresh verified backup first, then purge the stale generations, so a failure can
+            // never leave the committed wrapper as the only copy
+            FileUtil.replaceRollingBackups(storageDir, fileName);
+            FileUtil.deleteFileIfExists(legacySymFile());
+            FileUtil.deleteRollingBackup(storageDir, LEGACY_SYM_FILE_NAME);
+            // the deletion helpers tolerate failures, so verify the stale wrappers are gone
+            if (legacySymFile().exists() || FileUtil.hasBackups(storageDir, LEGACY_SYM_FILE_NAME)) {
+                throw new IOException("Could not remove stale key file backups");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Could not clean up after password change", e);
+        }
+        clearPasswordChange();
+    }
+
+    /**
+     * Removes the pending wrapper and journal. The wrapper is deleted strictly and first, so an
+     * abandoned-password wrapper can never silently outlive the transaction; on failure the
+     * journal is retained and the transaction stays visibly pending.
+     */
+    public void clearPasswordChange() {
+        try {
+            deleteStrict(new File(storageDir, PENDING_SYM_FILE_NAME));
+            deleteStrict(new File(storageDir, PASSWORD_CHANGE_JOURNAL_FILE_NAME));
+        } catch (IOException e) {
+            throw new RuntimeException("Could not clear password change journal", e);
+        }
+    }
+
+    private static void deleteStrict(File file) throws IOException {
+        FileUtil.deleteFileIfExists(file, false);
+        if (file.exists()) throw new IOException("Could not delete " + file.getName());
+    }
+
+    private static void writeNullableUtf(DataOutputStream out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) out.writeUTF(value);
+    }
+
+    private static String readNullableUtf(DataInputStream in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
     }
 
     /**
@@ -325,9 +653,19 @@ public class KeyStorage {
             byte[] readBack = Encryption.decryptV2(Files.readAllBytes(tempFile.toPath()), secretKey);
             if (!Arrays.equals(readBack, keyBytes)) throw new IOException("Key file verification failed");
             FileUtil.atomicReplace(tempFile, keyFile);
+
+            // replace backups, which may still hold the key in a legacy format; fresh verified
+            // backup first, so a failure can never leave the key file as the only copy
+            FileUtil.replaceRollingBackups(storageDir, fileName);
         } catch (Exception e) {
             log.error("Could not save key " + fileName, e);
-            throw new RuntimeException("Could not save key " + fileName, e);
+            RuntimeException ex = new RuntimeException("Could not save key " + fileName, e);
+            try {
+                deleteStrict(tempFile);
+            } catch (Exception e2) {
+                ex.addSuppressed(e2);
+            }
+            throw ex;
         }
     }
 
@@ -335,11 +673,12 @@ public class KeyStorage {
      * Saves the symmetric key wrapped with a key derived from the password, then verifies the
      * write and removes legacy PKCS#12 artifacts and stale password-wrapped backups.
      *
-     * @param key      The symmetric key
-     * @param fileName Filename of the key file
-     * @param password Optional password protecting the key
+     * @param key             The symmetric key
+     * @param fileName        Filename of the key file
+     * @param password        Optional password protecting the key
+     * @param manageArtifacts Whether to purge legacy files and stale backups and keep a fresh one
      */
-    private void saveSecretKey(SecretKey key, String fileName, String password) {
+    private void saveSecretKey(SecretKey key, String fileName, String password, boolean manageArtifacts) {
         if (!storageDir.exists())
             //noinspection ResultOfMethodCallIgnored
             storageDir.mkdirs();
@@ -349,6 +688,7 @@ public class KeyStorage {
         int iterations = unprotected ? PasswordKdf.UNPROTECTED_ITERATIONS : PasswordKdf.DEFAULT_ITERATIONS;
         int parallelism = PasswordKdf.DEFAULT_PARALLELISM;
         byte[] salt = PasswordKdf.generateSalt();
+        File tempFile = new File(storageDir, fileName + ".tmp");
         try {
             SecretKey kek = Encryption.getSecretKeyFromBytes(PasswordKdf.deriveKey(password, salt, memKib, iterations, parallelism));
             byte[] blob = Encryption.encryptV2(key.getEncoded(), kek);
@@ -359,7 +699,6 @@ public class KeyStorage {
             // write to a temp file, verify the round trip, then atomically swap it in, so a failed
             // or unverified write can never replace the existing key file
             File keyFile = new File(storageDir, fileName);
-            File tempFile = new File(storageDir, fileName + ".tmp");
             try (FileOutputStream fos = new FileOutputStream(tempFile)) {
                 fos.write(buf.array());
                 fos.flush();
@@ -372,13 +711,26 @@ public class KeyStorage {
             FileUtil.atomicReplace(tempFile, keyFile);
 
             // remove the legacy PKCS#12 file and backups still unlockable with weak KDF or old
-            // passwords, then keep a fresh backup so the wrapped key never exists as a single copy
-            FileUtil.deleteRollingBackup(storageDir, fileName);
-            FileUtil.deleteFileIfExists(legacySymFile());
-            FileUtil.deleteRollingBackup(storageDir, LEGACY_SYM_FILE_NAME);
-            FileUtil.rollingBackup(storageDir, fileName, 20);
+            // passwords; the fresh verified backup is taken first, so a purge failure can never
+            // leave the wrapped key as a single copy (the purge is retried on the next save)
+            if (manageArtifacts) {
+                FileUtil.replaceRollingBackups(storageDir, fileName);
+                FileUtil.deleteFileIfExists(legacySymFile());
+                FileUtil.deleteRollingBackup(storageDir, LEGACY_SYM_FILE_NAME);
+                // the deletion helpers tolerate failures, so verify the stale wrappers are gone
+                if (legacySymFile().exists() || FileUtil.hasBackups(storageDir, LEGACY_SYM_FILE_NAME)) {
+                    throw new IOException("Could not remove stale key file backups");
+                }
+            }
         } catch (Exception e) {
-            throw new RuntimeException("Could not save key " + fileName, e);
+            // the temp wraps the master key under an abandoned password; it must not linger
+            RuntimeException ex = new RuntimeException("Could not save key " + fileName, e);
+            try {
+                deleteStrict(tempFile);
+            } catch (Exception e2) {
+                ex.addSuppressed(e2);
+            }
+            throw ex;
         }
     }
 

--- a/common/src/main/java/haveno/common/crypto/KeyStorage.java
+++ b/common/src/main/java/haveno/common/crypto/KeyStorage.java
@@ -28,8 +28,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -46,22 +46,36 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+import java.util.Arrays;
 import javax.crypto.SecretKey;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * KeyStorage uses password protection to save a symmetric key in PKCS#12 format.
- * The symmetric key is used to encrypt and decrypt other keys in the key ring and other types of persistence.
+ * KeyStorage saves the symmetric key (sym.key) wrapped with an Argon2id-derived key from the account
+ * password, replacing the legacy PKCS#12 store whose fast KDF allowed cheap brute force. Legacy
+ * files are read transparently and upgraded on the next save.
  */
 @Singleton
 public class KeyStorage {
 
     private static final Logger log = LoggerFactory.getLogger(KeyStorage.class);
 
+    // sym.key layout: magic || format version || kdf id || mem KiB || iterations || parallelism || salt || v2 blob of the key.
+    private static final byte[] SYM_FILE_MAGIC = {'H', 'V', 'N', 'K'};
+    private static final byte SYM_FILE_VERSION = 1;
+    private static final String LEGACY_SYM_FILE_NAME = "sym.p12";
+    // The header is unauthenticated, so bound KDF cost and file size before any allocation.
+    private static final int MAX_MEM_KIB = 256 * 1024;
+    private static final int MAX_ITERATIONS = 10;
+    private static final int MAX_PARALLELISM = 4;
+    private static final int MAX_SYM_FILE_SIZE = 4096;
+    // Generous for a PKCS#8 RSA/DSA private key in a v2 blob; anything larger is corruption.
+    private static final int MAX_KEY_FILE_SIZE = 64 * 1024;
+
     public enum KeyEntry {
-        SYM_ENCRYPTION("sym.p12", Encryption.SYM_KEY_ALGO, "sym"), // symmetric encryption for persistence
+        SYM_ENCRYPTION("sym.key", Encryption.SYM_KEY_ALGO, "sym"), // symmetric encryption for persistence
         MSG_SIGNATURE("sig.key", Sig.KEY_ALGO, "sig"),
         MSG_ENCRYPTION("enc.key", Encryption.ASYM_KEY_ALGO, "enc");
 
@@ -98,6 +112,10 @@ public class KeyStorage {
     }
 
     private final File storageDir;
+    // Set when any key file was read in a pre-v2 format, so callers can trigger a re-save.
+    private boolean legacyFormatLoaded = false;
+    // Like legacyFormatLoaded but never reset: gates acceptance of not-yet-migrated plaintext stores.
+    private boolean legacyFormatEverLoaded = false;
 
     @Inject
     public KeyStorage(@Named(Config.KEY_STORAGE_DIR) File storageDir) {
@@ -105,21 +123,34 @@ public class KeyStorage {
     }
 
     public boolean allKeyFilesExist() {
-        return fileExists(KeyEntry.MSG_SIGNATURE) && fileExists(KeyEntry.MSG_ENCRYPTION) && fileExists(KeyEntry.SYM_ENCRYPTION);
+        return fileExists(KeyEntry.MSG_SIGNATURE) && fileExists(KeyEntry.MSG_ENCRYPTION)
+                && (fileExists(KeyEntry.SYM_ENCRYPTION) || legacySymFile().exists());
+    }
+
+    public boolean needsFormatUpgrade() {
+        return legacyFormatLoaded;
+    }
+
+    // Whether any key material was ever read in a pre-v2 format during this process lifetime.
+    public boolean hasLegacyFormatEverLoaded() {
+        return legacyFormatEverLoaded;
     }
 
     private boolean fileExists(KeyEntry keyEntry) {
         return new File(storageDir + "/" + keyEntry.getFileName()).exists();
     }
 
+    private File legacySymFile() {
+        return new File(storageDir + "/" + LEGACY_SYM_FILE_NAME);
+    }
+
     private byte[] loadKeyBytes(KeyEntry keyEntry, SecretKey secretKey) {
         File keyFile = new File(storageDir + "/" + keyEntry.getFileName());
-        try (FileInputStream fis = new FileInputStream(keyFile.getPath())) {
-            byte[] encodedKey = new byte[(int) keyFile.length()];
-            //noinspection ResultOfMethodCallIgnored
-            fis.read(encodedKey);
-            encodedKey = Encryption.decryptPayloadWithHmac(encodedKey, secretKey);
-            return encodedKey;
+        try {
+            if (keyFile.length() > MAX_KEY_FILE_SIZE) throw new IOException("Key file too large: " + keyFile.length());
+            byte[] encodedKey = Files.readAllBytes(keyFile.toPath());
+            if (Encryption.blobVersion(encodedKey) < Encryption.CURRENT_BLOB_VERSION) legacyFormatLoaded = legacyFormatEverLoaded = true;
+            return Encryption.decryptPayloadWithHmacAuto(encodedKey, secretKey);
         } catch (IOException | CryptoException e) {
             log.error("Could not load key " + keyEntry.toString(), e.getMessage());
             throw new RuntimeException("Could not load key " + keyEntry.toString(), e);
@@ -133,7 +164,6 @@ public class KeyStorage {
      * @param secretKey  The symmetric key that protects the key entry file
      */
     public KeyPair loadKeyPair(KeyEntry keyEntry, SecretKey secretKey) {
-        FileUtil.rollingBackup(storageDir, keyEntry.getFileName(), 20);
         try {
             KeyFactory keyFactory = KeyFactory.getInstance(keyEntry.getAlgorithm());
             byte[] encodedPrivateKey = loadKeyBytes(keyEntry, secretKey);
@@ -156,6 +186,8 @@ public class KeyStorage {
             } else {
                 throw new RuntimeException("Unsupported key algo" + keyEntry.getAlgorithm());
             }
+            // backup only after a successful load, so retries against a corrupt file cannot rotate out good backups
+            FileUtil.rollingBackup(storageDir, keyEntry.getFileName(), 20);
             return new KeyPair(publicKey, privateKey);
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
             log.error("Could not load key " + keyEntry.toString(), e);
@@ -170,12 +202,63 @@ public class KeyStorage {
      * @param password Optional password that protects the key
      */
     public SecretKey loadSecretKey(KeyEntry keyEntry, String password) throws IncorrectPasswordException {
-        FileUtil.rollingBackup(storageDir, keyEntry.getFileName(), 20);
+        File keyFile = new File(storageDir + "/" + keyEntry.getFileName());
+        if (keyFile.exists()) {
+            SecretKey key = loadSecretKeyV2(keyFile, password);
+            // backup only after a successful load, so retries against a corrupt file cannot rotate out good backups
+            FileUtil.rollingBackup(storageDir, keyEntry.getFileName(), 20);
+            return key;
+        }
+        legacyFormatLoaded = legacyFormatEverLoaded = true;
+        SecretKey key = loadSecretKeyLegacy(keyEntry, password);
+        FileUtil.rollingBackup(storageDir, LEGACY_SYM_FILE_NAME, 20);
+        return key;
+    }
+
+    private SecretKey loadSecretKeyV2(File keyFile, String password) throws IncorrectPasswordException {
+        try {
+            if (keyFile.length() > MAX_SYM_FILE_SIZE) throw new IOException("Key file too large: " + keyFile.length());
+            ByteBuffer buf = ByteBuffer.wrap(Files.readAllBytes(keyFile.toPath()));
+            byte[] magic = new byte[SYM_FILE_MAGIC.length];
+            buf.get(magic);
+            if (!Arrays.equals(magic, SYM_FILE_MAGIC)) throw new IOException("Invalid key file magic");
+            byte version = buf.get();
+            if (version != SYM_FILE_VERSION) throw new IOException("Unsupported key file version " + version);
+            byte kdf = buf.get();
+            if (kdf != PasswordKdf.KDF_ARGON2ID) throw new IOException("Unsupported kdf " + kdf);
+            int memKib = buf.getInt();
+            int iterations = buf.getInt();
+            int parallelism = buf.getInt();
+            if (memKib < 1 || memKib > MAX_MEM_KIB || iterations < 1 || iterations > MAX_ITERATIONS
+                    || parallelism < 1 || parallelism > MAX_PARALLELISM) {
+                throw new IOException("KDF parameters out of bounds");
+            }
+            byte[] salt = new byte[PasswordKdf.SALT_LENGTH];
+            buf.get(salt);
+            byte[] blob = new byte[buf.remaining()];
+            buf.get(blob);
+            // a mangled wrapped blob is corruption, not a wrong password
+            if (!Encryption.isV2Format(blob)) throw new IOException("Corrupt key file");
+            SecretKey kek = Encryption.getSecretKeyFromBytes(PasswordKdf.deriveKey(password, salt, memKib, iterations, parallelism));
+            try {
+                return Encryption.getSecretKeyFromBytes(Encryption.decryptV2(blob, kek));
+            } catch (CryptoException e) {
+                throw new IncorrectPasswordException("Incorrect password");
+            }
+        } catch (IncorrectPasswordException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Could not load key " + keyFile.getName(), e);
+            throw new RuntimeException("Could not load key " + keyFile.getName(), e);
+        }
+    }
+
+    private SecretKey loadSecretKeyLegacy(KeyEntry keyEntry, String password) throws IncorrectPasswordException {
         char[] passwordChars = password == null ? new char[0] : password.toCharArray();
         try {
             KeyStore keyStore = KeyStore.getInstance("PKCS12");
 
-            try (FileInputStream fileInputStream = new FileInputStream(storageDir + "/" + keyEntry.getFileName())) {
+            try (FileInputStream fileInputStream = new FileInputStream(legacySymFile())) {
                 keyStore.load(fileInputStream, passwordChars);
             }
 
@@ -202,15 +285,16 @@ public class KeyStorage {
      * @param keyRing  The key ring
      * @param password Optional password
      */
-    public void saveKeyRing(KeyRing keyRing, String oldPassword, String password) {
+    public void saveKeyRing(KeyRing keyRing, String password) {
         SecretKey symmetric = keyRing.getSymmetricKey();
 
         // password protect the symmetric key
-        saveKey(symmetric, KeyEntry.SYM_ENCRYPTION.getAlias(), KeyEntry.SYM_ENCRYPTION.getFileName(), oldPassword, password);
+        saveSecretKey(symmetric, KeyEntry.SYM_ENCRYPTION.getFileName(), password);
 
         // use symmetric encryption to encrypt the key pairs
         saveKey(keyRing.getSignatureKeyPair().getPrivate(), KeyEntry.MSG_SIGNATURE.getFileName(), symmetric);
         saveKey(keyRing.getEncryptionKeyPair().getPrivate(), KeyEntry.MSG_ENCRYPTION.getFileName(), symmetric);
+        legacyFormatLoaded = false;
     }
 
     /**
@@ -227,9 +311,20 @@ public class KeyStorage {
 
         PKCS8EncodedKeySpec pkcs8EncodedKeySpec = new PKCS8EncodedKeySpec(key.getEncoded());
         byte[] keyBytes = pkcs8EncodedKeySpec.getEncoded();
-        try (FileOutputStream fos = new FileOutputStream(storageDir + "/" + fileName)) {
-            keyBytes = Encryption.encryptPayloadWithHmac(keyBytes, secretKey);
-            fos.write(keyBytes);
+        File keyFile = new File(storageDir, fileName);
+        File tempFile = new File(storageDir, fileName + ".tmp");
+        try {
+            // write to a temp file, verify the round trip, then atomically swap it in, so a failed
+            // or unverified write can never replace the existing key file
+            byte[] encrypted = Encryption.encryptV2(keyBytes, secretKey);
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                fos.write(encrypted);
+                fos.flush();
+                fos.getFD().sync();
+            }
+            byte[] readBack = Encryption.decryptV2(Files.readAllBytes(tempFile.toPath()), secretKey);
+            if (!Arrays.equals(readBack, keyBytes)) throw new IOException("Key file verification failed");
+            FileUtil.atomicReplace(tempFile, keyFile);
         } catch (Exception e) {
             log.error("Could not save key " + fileName, e);
             throw new RuntimeException("Could not save key " + fileName, e);
@@ -237,49 +332,54 @@ public class KeyStorage {
     }
 
     /**
-     * Saves a SecretKey to a PKCS12 file.
+     * Saves the symmetric key wrapped with a key derived from the password, then verifies the
+     * write and removes legacy PKCS#12 artifacts and stale password-wrapped backups.
      *
-     * @param key         The symmetric key
-     * @param alias       Alias of the key entry in the key store
-     * @param fileName    Filename of the key store
-     * @param oldPassword Optional password to decrypt existing key store
-     * @param password    Optional password to encrypt the key store
+     * @param key      The symmetric key
+     * @param fileName Filename of the key file
+     * @param password Optional password protecting the key
      */
-    private void saveKey(SecretKey key, String alias, String fileName, String oldPassword, String password) {
+    private void saveSecretKey(SecretKey key, String fileName, String password) {
         if (!storageDir.exists())
             //noinspection ResultOfMethodCallIgnored
             storageDir.mkdirs();
 
-        // password must be ascii
-        if (password != null && !password.matches("\\p{ASCII}*")) {
-            throw new IllegalArgumentException("Password must be ASCII.");
-        }
-
-        var oldPasswordChars = oldPassword == null ? new char[0] : oldPassword.toCharArray();
-        var passwordChars = password == null ? new char[0] : password.toCharArray();
+        boolean unprotected = password == null;
+        int memKib = unprotected ? PasswordKdf.UNPROTECTED_MEM_KIB : PasswordKdf.DEFAULT_MEM_KIB;
+        int iterations = unprotected ? PasswordKdf.UNPROTECTED_ITERATIONS : PasswordKdf.DEFAULT_ITERATIONS;
+        int parallelism = PasswordKdf.DEFAULT_PARALLELISM;
+        byte[] salt = PasswordKdf.generateSalt();
         try {
-            var path = storageDir + "/" + fileName;
-            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            SecretKey kek = Encryption.getSecretKeyFromBytes(PasswordKdf.deriveKey(password, salt, memKib, iterations, parallelism));
+            byte[] blob = Encryption.encryptV2(key.getEncoded(), kek);
+            ByteBuffer buf = ByteBuffer.allocate(SYM_FILE_MAGIC.length + 2 + 12 + salt.length + blob.length);
+            buf.put(SYM_FILE_MAGIC).put(SYM_FILE_VERSION).put((byte) PasswordKdf.KDF_ARGON2ID)
+                    .putInt(memKib).putInt(iterations).putInt(parallelism).put(salt).put(blob);
 
-            // load from existing file or initialize new
-            if (Files.exists(Path.of(path))) {
-                try (FileInputStream fileInputStream = new FileInputStream(path)) {
-                    keyStore.load(fileInputStream, oldPasswordChars);
-                }
+            // write to a temp file, verify the round trip, then atomically swap it in, so a failed
+            // or unverified write can never replace the existing key file
+            File keyFile = new File(storageDir, fileName);
+            File tempFile = new File(storageDir, fileName + ".tmp");
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                fos.write(buf.array());
+                fos.flush();
+                fos.getFD().sync();
             }
-            else {
-                keyStore.load(null, null);
+            SecretKey readBack = loadSecretKeyV2(tempFile, password);
+            if (!Arrays.equals(readBack.getEncoded(), key.getEncoded())) {
+                throw new IOException("Key file verification failed");
             }
+            FileUtil.atomicReplace(tempFile, keyFile);
 
-            // store in the keystore
-            keyStore.setKeyEntry(alias, key, passwordChars, null);
-
-            try (FileOutputStream fileOutputStream = new FileOutputStream(path)) {
-                // save the keystore
-                keyStore.store(fileOutputStream, passwordChars);
-            }
+            // remove the legacy PKCS#12 file and backups still unlockable with weak KDF or old
+            // passwords, then keep a fresh backup so the wrapped key never exists as a single copy
+            FileUtil.deleteRollingBackup(storageDir, fileName);
+            FileUtil.deleteFileIfExists(legacySymFile());
+            FileUtil.deleteRollingBackup(storageDir, LEGACY_SYM_FILE_NAME);
+            FileUtil.rollingBackup(storageDir, fileName, 20);
         } catch (Exception e) {
-            throw new RuntimeException("Could not save key " + alias, e);
+            throw new RuntimeException("Could not save key " + fileName, e);
         }
     }
+
 }

--- a/common/src/main/java/haveno/common/crypto/PasswordKdf.java
+++ b/common/src/main/java/haveno/common/crypto/PasswordKdf.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.crypto;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.text.Normalizer;
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
+import org.bouncycastle.crypto.params.Argon2Parameters;
+
+/**
+ * Memory-hard password-based key derivation (Argon2id) for protecting keys at rest,
+ * so brute-forcing the account password costs real time and memory per guess.
+ */
+public class PasswordKdf {
+
+    public static final int KDF_ARGON2ID = 1;
+
+    // ~0.5-1 s and 64 MiB per guess on typical hardware.
+    public static final int DEFAULT_MEM_KIB = 65536;
+    public static final int DEFAULT_ITERATIONS = 3;
+    public static final int DEFAULT_PARALLELISM = 1;
+
+    // Cheap cost when no password is set; hardening adds nothing without a secret.
+    public static final int UNPROTECTED_MEM_KIB = 64;
+    public static final int UNPROTECTED_ITERATIONS = 1;
+
+    public static final int SALT_LENGTH = 16;
+    public static final int KEY_LENGTH = 32;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public static byte[] generateSalt() {
+        byte[] salt = new byte[SALT_LENGTH];
+        RANDOM.nextBytes(salt);
+        return salt;
+    }
+
+    public static byte[] deriveKey(String password, byte[] salt, int memKib, int iterations, int parallelism) {
+        Argon2Parameters params = new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+                .withVersion(Argon2Parameters.ARGON2_VERSION_13)
+                .withMemoryAsKB(memKib)
+                .withIterations(iterations)
+                .withParallelism(parallelism)
+                .withSalt(salt)
+                .build();
+        Argon2BytesGenerator generator = new Argon2BytesGenerator();
+        generator.init(params);
+        byte[] key = new byte[KEY_LENGTH];
+        // NFC-normalize so visually identical Unicode passwords derive the same key
+        String normalized = password == null ? "" : Normalizer.normalize(password, Normalizer.Form.NFC);
+        generator.generateBytes(normalized.getBytes(StandardCharsets.UTF_8), key, 0, KEY_LENGTH);
+        return key;
+    }
+}

--- a/common/src/main/java/haveno/common/file/FileUtil.java
+++ b/common/src/main/java/haveno/common/file/FileUtil.java
@@ -36,12 +36,17 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class FileUtil {
@@ -51,7 +56,12 @@ public class FileUtil {
     public static final String CORRUPTED_BACKUP_FOLDER = "backup_of_corrupted_data";
 
     private static final String BACKUP_DIR = "backup";
-    
+
+    /** The root directory holding a directory's rolling backups. */
+    public static File getBackupRoot(File dir) {
+        return new File(dir, BACKUP_DIR);
+    }
+
     // Backup subdirectory name for a file, e.g. "backups_sym_key" for "sym.key".
     private static String backupDirName(String fileName) {
         return ("backups_" + fileName).replace(".", "_");
@@ -82,6 +92,89 @@ public class FileUtil {
                     log.error("Backup key failed: {}\n", e.getMessage(), e);
                 }
             }
+        }
+    }
+
+    /**
+     * Rolling backup for critical files (key material, wallets): creates the directories, streams
+     * the copy with fsync and verifies it by content hash, throwing on any failure instead of
+     * logging it. Returns the created backup file.
+     */
+    public static File rollingBackupStrict(File dir, String fileName, int numMaxBackupFiles) throws IOException {
+        File origFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
+        if (!origFile.isFile()) throw new IOException("Cannot back up missing file " + origFile.getAbsolutePath());
+        File backupFileDir = new File(Paths.get(dir.getAbsolutePath(), BACKUP_DIR, backupDirName(fileName)).toString());
+        java.nio.file.Files.createDirectories(backupFileDir.toPath());
+        File backupFile = new File(Paths.get(backupFileDir.getAbsolutePath(), new Date().getTime() + "_" + fileName).toString());
+        byte[] sourceHash;
+        try (InputStream in = new FileInputStream(origFile);
+             FileOutputStream fos = new FileOutputStream(backupFile)) {
+            MessageDigest digest = newSha256();
+            byte[] buf = new byte[64 * 1024];
+            int read;
+            while ((read = in.read(buf)) != -1) {
+                digest.update(buf, 0, read);
+                fos.write(buf, 0, read);
+            }
+            fos.flush();
+            fos.getFD().sync();
+            sourceHash = digest.digest();
+        }
+        if (!MessageDigest.isEqual(sourceHash, sha256(backupFile))) {
+            throw new IOException("Backup verification failed for " + backupFile.getAbsolutePath());
+        }
+        // best effort: make the new file entry, and the backup dir entry if it was just created,
+        // power-loss durable
+        syncParentDir(backupFile);
+        syncParentDir(backupFileDir);
+        pruneBackup(backupFileDir, numMaxBackupFiles);
+        return backupFile;
+    }
+
+    /**
+     * Replaces a file's rolling backups with a single fresh verified copy, for content that must
+     * not survive in backups (e.g. credentials under a retired password or a deprecated format).
+     * The fresh backup is created and verified first, so a failure can never leave the file
+     * without a usable backup; only then are the stale generations purged, with verification.
+     * Returns the fresh backup, or null if the file does not exist (backups are still purged).
+     */
+    public static File replaceRollingBackups(File dir, String fileName) throws IOException {
+        File source = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
+        File freshBackup = source.isFile() ? rollingBackupStrict(dir, fileName, Integer.MAX_VALUE) : null;
+        List<File> backups = getBackupFiles(dir, fileName);
+        // an unlistable backup dir reads as empty; the just-created backup proves listability
+        if (freshBackup != null && !backups.contains(freshBackup)) throw new IOException("Backup directory of " + fileName + " is not listable");
+        boolean deleted = false;
+        for (File backup : backups) {
+            if (!backup.equals(freshBackup)) {
+                deleteFileIfExists(backup, false);
+                deleted = true;
+            }
+        }
+        for (File backup : getBackupFiles(dir, fileName)) {
+            if (!backup.equals(freshBackup)) throw new IOException("Could not delete stale backups of " + fileName);
+        }
+        // best effort: make the deletions power-loss durable, so purged generations (e.g. under a
+        // retired password) cannot resurrect
+        if (deleted) syncParentDir(freshBackup != null ? freshBackup : backups.get(0));
+        return freshBackup;
+    }
+
+    private static byte[] sha256(File file) throws IOException {
+        MessageDigest digest = newSha256();
+        try (InputStream in = new FileInputStream(file)) {
+            byte[] buf = new byte[64 * 1024];
+            int read;
+            while ((read = in.read(buf)) != -1) digest.update(buf, 0, read);
+        }
+        return digest.digest();
+    }
+
+    private static MessageDigest newSha256() throws IOException {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException(e);
         }
     }
 
@@ -131,6 +224,30 @@ public class FileUtil {
         } catch (IOException e) {
             log.error("Delete backup key failed: {}\n", e.getMessage(), e);
         }
+    }
+
+    /** Like {@link #deleteRollingBackup} but verifies the deletion and propagates failure. */
+    public static void deleteRollingBackupStrict(File dir, String fileName) throws IOException {
+        File backupDir = new File(Paths.get(dir.getAbsolutePath(), BACKUP_DIR).toString());
+        if (!backupDir.exists()) return;
+        File backupFileDir = new File(Paths.get(backupDir.getAbsolutePath(), backupDirName(fileName)).toString());
+        if (!backupFileDir.exists()) return;
+        FileUtils.deleteDirectory(backupFileDir);
+        if (backupFileDir.exists()) throw new IOException("Failed to delete backup directory " + backupFileDir.getAbsolutePath());
+        syncParentDir(backupFileDir); // best effort: make the removal power-loss durable
+    }
+
+    /**
+     * The rolling-backup directories under dir not belonging to any of the given file names,
+     * e.g. backups of wallets that no longer exist; throws if the backup root is unlistable.
+     */
+    public static List<File> getRollingBackupDirsExcept(File dir, Collection<String> fileNamesToKeep) throws IOException {
+        Set<String> keep = fileNamesToKeep.stream().map(FileUtil::backupDirName).collect(Collectors.toSet());
+        List<File> staleDirs = new ArrayList<>();
+        for (File backupFileDir : getRollingBackupDirs(dir)) {
+            if (!keep.contains(backupFileDir.getName())) staleDirs.add(backupFileDir);
+        }
+        return staleDirs;
     }
 
     private static void pruneBackup(File backupDir, int numMaxBackupFiles) {
@@ -270,8 +387,12 @@ public class FileUtil {
     // Fsyncs a file's directory entry; a no-op where directories cannot be opened (e.g. Windows).
     public static void syncParentDir(File file) {
         File parent = file.getParentFile();
-        if (parent == null) return;
-        try (FileChannel channel = FileChannel.open(parent.toPath(), StandardOpenOption.READ)) {
+        if (parent != null) syncDir(parent);
+    }
+
+    // Fsyncs a directory's entries; a no-op where directories cannot be opened (e.g. Windows).
+    public static void syncDir(File dir) {
+        try (FileChannel channel = FileChannel.open(dir.toPath(), StandardOpenOption.READ)) {
             channel.force(true);
         } catch (IOException | UnsupportedOperationException ignore) {
         }

--- a/common/src/main/java/haveno/common/file/FileUtil.java
+++ b/common/src/main/java/haveno/common/file/FileUtil.java
@@ -30,8 +30,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.FileChannel;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -50,6 +52,11 @@ public class FileUtil {
 
     private static final String BACKUP_DIR = "backup";
     
+    // Backup subdirectory name for a file, e.g. "backups_sym_key" for "sym.key".
+    private static String backupDirName(String fileName) {
+        return ("backups_" + fileName).replace(".", "_");
+    }
+
     public static void rollingBackup(File dir, String fileName, int numMaxBackupFiles) {
         if (numMaxBackupFiles <= 0) return;
         if (dir.exists()) {
@@ -60,10 +67,7 @@ public class FileUtil {
 
             File origFile = new File(Paths.get(dir.getAbsolutePath(), fileName).toString());
             if (origFile.exists()) {
-                String dirName = "backups_" + fileName;
-                if (dirName.contains("."))
-                    dirName = dirName.replace(".", "_");
-                File backupFileDir = new File(Paths.get(backupDir.getAbsolutePath(), dirName).toString());
+                File backupFileDir = new File(Paths.get(backupDir.getAbsolutePath(), backupDirName(fileName)).toString());
                 if (!backupFileDir.exists())
                     if (!backupFileDir.mkdir())
                         log.warn("make backupFileDir failed.\nBackupFileDir=" + backupFileDir.getAbsolutePath());
@@ -84,12 +88,14 @@ public class FileUtil {
     public static List<File> getBackupFiles(File dir, String fileName) {
         File backupDir = new File(Paths.get(dir.getAbsolutePath(), BACKUP_DIR).toString());
         if (!backupDir.exists()) return new ArrayList<File>();
-        String dirName = "backups_" + fileName;
-        if (dirName.contains(".")) dirName = dirName.replace(".", "_");
-        File backupFileDir = new File(Paths.get(backupDir.getAbsolutePath(), dirName).toString());
+        File backupFileDir = new File(Paths.get(backupDir.getAbsolutePath(), backupDirName(fileName)).toString());
         if (!backupFileDir.exists()) return new ArrayList<File>();
         File[] files = backupFileDir.listFiles();
-        return Arrays.asList(files);
+        return files == null ? new ArrayList<File>() : Arrays.asList(files);
+    }
+
+    public static boolean hasBackups(File dir, String fileName) {
+        return !getBackupFiles(dir, fileName).isEmpty();
     }
 
     public static File getLatestBackupFile(File dir, String fileName) {
@@ -102,9 +108,7 @@ public class FileUtil {
     public static void deleteRollingBackup(File dir, String fileName) {
         File backupDir = new File(Paths.get(dir.getAbsolutePath(), BACKUP_DIR).toString());
         if (!backupDir.exists()) return;
-        String dirName = "backups_" + fileName;
-        if (dirName.contains(".")) dirName = dirName.replace(".", "_");
-        File backupFileDir = new File(Paths.get(backupDir.getAbsolutePath(), dirName).toString());
+        File backupFileDir = new File(Paths.get(backupDir.getAbsolutePath(), backupDirName(fileName)).toString());
         try {
             FileUtils.deleteDirectory(backupFileDir);
         } catch (IOException e) {
@@ -232,14 +236,27 @@ public class FileUtil {
 
     /**
      * Replaces target with source atomically where the filesystem supports it, so no crash window
-     * exists with neither file in place ({@link #renameFile} deletes the target first on Windows).
+     * exists with neither file in place; the non-atomic fallback still replaces in a single move
+     * (unlike {@link #renameFile}, which deletes the target first on Windows). The directory entry
+     * is fsynced afterwards where the platform supports it, for power-loss durability.
      */
     public static void atomicReplace(File source, File target) throws IOException {
         try {
             java.nio.file.Files.move(source.toPath(), target.toPath(),
                     StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
         } catch (AtomicMoveNotSupportedException e) {
-            renameFile(source, target);
+            java.nio.file.Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+        syncParentDir(target);
+    }
+
+    // Fsyncs a file's directory entry; a no-op where directories cannot be opened (e.g. Windows).
+    private static void syncParentDir(File file) {
+        File parent = file.getParentFile();
+        if (parent == null) return;
+        try (FileChannel channel = FileChannel.open(parent.toPath(), StandardOpenOption.READ)) {
+            channel.force(true);
+        } catch (IOException | UnsupportedOperationException ignore) {
         }
     }
 

--- a/common/src/main/java/haveno/common/file/FileUtil.java
+++ b/common/src/main/java/haveno/common/file/FileUtil.java
@@ -95,7 +95,24 @@ public class FileUtil {
     }
 
     public static boolean hasBackups(File dir, String fileName) {
-        return !getBackupFiles(dir, fileName).isEmpty();
+        File backupDir = new File(Paths.get(dir.getAbsolutePath(), BACKUP_DIR).toString());
+        File backupFileDir = new File(Paths.get(backupDir.getAbsolutePath(), backupDirName(fileName)).toString());
+        if (!backupFileDir.exists()) return false;
+        File[] files = backupFileDir.listFiles();
+        return files == null || files.length > 0; // an unlistable directory counts as present (fail closed)
+    }
+
+    /** The rolling-backup directories under dir, i.e. backup/backups_*; throws if unlistable. */
+    public static List<File> getRollingBackupDirs(File dir) throws IOException {
+        File backupDir = new File(Paths.get(dir.getAbsolutePath(), BACKUP_DIR).toString());
+        List<File> dirs = new ArrayList<>();
+        if (!backupDir.exists()) return dirs;
+        File[] children = backupDir.listFiles();
+        if (children == null) throw new IOException("Could not list backup directory " + backupDir.getAbsolutePath());
+        for (File child : children) {
+            if (child.isDirectory() && child.getName().startsWith("backups_")) dirs.add(child);
+        }
+        return dirs;
     }
 
     public static File getLatestBackupFile(File dir, String fileName) {
@@ -251,7 +268,7 @@ public class FileUtil {
     }
 
     // Fsyncs a file's directory entry; a no-op where directories cannot be opened (e.g. Windows).
-    private static void syncParentDir(File file) {
+    public static void syncParentDir(File file) {
         File parent = file.getParentFile();
         if (parent == null) return;
         try (FileChannel channel = FileChannel.open(parent.toPath(), StandardOpenOption.READ)) {

--- a/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
+++ b/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
@@ -155,6 +156,115 @@ public class EncryptedAppendLog {
 
     // Called under the instance lock before every append: truncates the file back to the known-good
     // boundary so a partial frame from an earlier failed append is never buried by new writes.
+    // Deletes rolling backups holding any pre-current frame, retrying at every replay until none
+    // remain, so the deprecated format cannot outlive the log's own migration. A well-formed
+    // current-format backup is ensured first, so the safety copies are never reduced to the live
+    // log alone; malformed backups (torn or empty, e.g. from a failed copy) are neither trusted
+    // as that safety copy nor purged here.
+    private void purgeLegacyFormatBackups() {
+        List<File> legacyBackups = new ArrayList<>();
+        boolean hasCurrentBackup = false;
+        for (File backup : FileUtil.getBackupFiles(dir, fileName)) {
+            try {
+                BackupFormat format = backupFormat(backup);
+                if (format == BackupFormat.LEGACY) legacyBackups.add(backup);
+                else if (format == BackupFormat.CURRENT) hasCurrentBackup = true;
+            } catch (IOException e) {
+                log.warn("Could not inspect backup {} of {}", backup.getName(), fileName, e);
+            }
+        }
+        if (legacyBackups.isEmpty()) return;
+        File freshBackup = null;
+        if (!hasCurrentBackup) {
+            try {
+                // unbounded retention: pruning here could drain the very legacy generations this
+                // method is still deciding about; the purge below is the only removal
+                freshBackup = FileUtil.rollingBackupStrict(dir, fileName, Integer.MAX_VALUE);
+                // re-verify the copy is a usable current-format log: a live log truncated empty
+                // by tail repair copies byte-for-byte but must not stand in as the safety copy
+                if (backupFormat(freshBackup) != BackupFormat.CURRENT) {
+                    log.error("Fresh backup of {} is not a usable current-format log; keeping the legacy backups", fileName);
+                    return;
+                }
+            } catch (IOException e) {
+                log.error("Could not take a current-format backup of {}; keeping the legacy backups", fileName, e);
+                return;
+            }
+        }
+        File deletedBackup = null;
+        for (File backup : legacyBackups) {
+            if (backup.equals(freshBackup)) continue; // same-millisecond name collision overwrote this entry
+            try {
+                FileUtil.deleteFileIfExists(backup, false);
+                if (backup.exists()) throw new IOException("could not delete " + backup.getAbsolutePath());
+                log.info("Deleted legacy-format backup {} of {}", backup.getName(), fileName);
+                deletedBackup = backup;
+            } catch (IOException e) {
+                log.error("Could not purge legacy-format backup {} of {}", backup.getName(), fileName, e);
+            }
+        }
+        // best effort: make the deletions power-loss durable so purged weak-format generations
+        // cannot resurrect
+        if (deletedBackup != null) FileUtil.syncParentDir(deletedBackup);
+    }
+
+    private enum BackupFormat { CURRENT, LEGACY, MALFORMED }
+
+    // Walks the frames. Any complete pre-current frame is LEGACY; CURRENT requires at least one
+    // complete frame and every frame well-formed, current AND authenticated under the key, so a
+    // bit-rotted or wrong-key copy can never stand in as the safety backup; anything else (empty,
+    // torn, bad prefix, failed tag) is MALFORMED.
+    private BackupFormat backupFormat(File file) throws IOException {
+        boolean sawFrame = false;
+        long remaining = file.length();
+        try (DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+            while (true) {
+                int len;
+                try {
+                    len = in.readInt();
+                } catch (EOFException e) {
+                    // leftover bytes of a partial length prefix are a torn copy, not a clean end
+                    return sawFrame && remaining == 0 ? BackupFormat.CURRENT : BackupFormat.MALFORMED;
+                }
+                remaining -= 4;
+                if (len <= 0 || len > MAX_FRAME_SIZE) return BackupFormat.MALFORMED;
+                byte[] ciphertext = new byte[len];
+                in.readFully(ciphertext);
+                remaining -= len;
+                if (Encryption.blobVersion(ciphertext) < Encryption.CURRENT_BLOB_VERSION) return BackupFormat.LEGACY;
+                try {
+                    Encryption.decryptV2(ciphertext, secretKey);
+                } catch (Exception e) {
+                    return BackupFormat.MALFORMED;
+                }
+                sawFrame = true;
+            }
+        } catch (EOFException e) {
+            return BackupFormat.MALFORMED;
+        }
+    }
+
+    // The quarantined copy can hold legacy-format frames and an unverifiable tail, so it is
+    // wrapped whole in the current format rather than kept as raw weak ciphertext. Best effort:
+    // the copy itself must survive even if the wrap fails.
+    private void encryptCorruptedBackup(File backupFile) {
+        try {
+            File tempFile = new File(backupFile.getParentFile(), backupFile.getName() + ".tmp");
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                Encryption.encryptV2ToStream(out -> {
+                    try (InputStream in = new BufferedInputStream(new FileInputStream(backupFile))) {
+                        in.transferTo(out);
+                    }
+                }, secretKey, fos);
+                fos.flush();
+                fos.getFD().sync();
+            }
+            FileUtil.atomicReplace(tempFile, backupFile);
+        } catch (Exception e) {
+            log.error("Could not encrypt quarantined copy {}", backupFile.getName(), e);
+        }
+    }
+
     private void repairTailBeforeAppend() {
         if (knownGoodLength < 0) {
             // First write of this session without a prior replay: replay once to validate the tail
@@ -268,6 +378,9 @@ public class EncryptedAppendLog {
                                 fileName, goodLength, records.size(), fileLength - goodLength, backupFile);
                     }
                     FileUtil.copyFile(logFile, backupFile);
+                    // wrap only when this key authenticated at least one frame: under a wrong
+                    // key (e.g. a mismatched key dir) wrapping would seal away the only copy
+                    if (!records.isEmpty()) encryptCorruptedBackup(backupFile);
                     truncateTo(logFile, goodLength);
                     knownGoodLength = goodLength;
                 } else {
@@ -282,12 +395,15 @@ public class EncryptedAppendLog {
                 try {
                     log.info("Rewriting {} to upgrade legacy encrypted frames.", fileName);
                     rewrite(records);
+                    hasLegacyFrames = false;
                 } catch (OutOfMemoryError e) {
                     throw e;
                 } catch (Throwable t) {
                     log.error("Could not rewrite {} to upgrade legacy frames; keeping the existing log.", fileName, t);
                 }
             }
+            // once the live log holds no legacy frames, backups must not keep them either
+            if (!hasLegacyFrames) purgeLegacyFormatBackups();
             return records;
         }
     }
@@ -309,6 +425,8 @@ public class EncryptedAppendLog {
                      DataOutputStream out = new DataOutputStream(new BufferedOutputStream(fos))) {
                     for (byte[] record : records) {
                         byte[] ciphertext = Encryption.encryptV2(record, secretKey);
+                        // same bound as appendAll, or the next replay would reject the frame as corrupt
+                        if (ciphertext.length > MAX_FRAME_SIZE) throw new IllegalArgumentException("Record exceeds max frame size: " + ciphertext.length);
                         writeFrame(out, ciphertext);
                         written += 4L + ciphertext.length;
                     }
@@ -334,6 +452,32 @@ public class EncryptedAppendLog {
                 }
             }
         }
+    }
+
+    /**
+     * Whether the file is a framed encrypted record log: at least one leading frame whose
+     * ciphertext authenticates under the key. Frames are unforgeable without the key, so a match
+     * proves the file is already encrypted; trailing torn or corrupt bytes are the replay
+     * repair's job and do not disqualify the file.
+     */
+    public static boolean isEncryptedFrameLog(File file, SecretKey secretKey) {
+        boolean hasValidFrame = false;
+        try (DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+            long remaining = file.length();
+            while (remaining >= 4) {
+                int len = in.readInt();
+                if (len <= 0 || len > MAX_FRAME_SIZE) break; // corrupt prefix
+                if (len > remaining - 4) break; // torn tail
+                byte[] ciphertext = new byte[len];
+                in.readFully(ciphertext);
+                Encryption.decryptPayloadWithHmacAuto(ciphertext, secretKey);
+                hasValidFrame = true;
+                remaining -= 4L + len;
+            }
+        } catch (Exception e) {
+            // fall through: the authenticated frames read so far decide
+        }
+        return hasValidFrame;
     }
 
     // The single place that knows the on-disk frame encoding: [4-byte big-endian length][ciphertext].

--- a/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
+++ b/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
@@ -40,10 +40,11 @@ import lombok.extern.slf4j.Slf4j;
  * An append-only, encrypted, crash-safe record log.
  *
  * <p>Each record is framed as {@code [4-byte big-endian length][ciphertext]}, with
- * {@code ciphertext = Encryption.encryptPayloadWithHmac(record)}. The length prefix lives outside
- * the ciphertext so frames can be located and a torn tail truncated without decrypting. Appends
- * fsync, so a crash or failed write (e.g. disk full) can only leave a partial trailing frame; the
- * log tracks its known-good length and truncates such a tear away before the next append.
+ * {@code ciphertext = Encryption.encryptV2(record)} (legacy AES-ECB+HMAC frames are still read and
+ * the log is rewritten in the current format after replay). The length prefix lives outside the
+ * ciphertext so frames can be located and a torn tail truncated without decrypting. Appends fsync,
+ * so a crash or failed write (e.g. disk full) can only leave a partial trailing frame; the log
+ * tracks its known-good length and truncates such a tear away before the next append.
  *
  * <p>Replay ({@link #readAllValidRecords()}) self-repairs: a torn tail is truncated back to the
  * last good frame, and mid-log corruption (bad length prefix or hmac) rebuilds the log from the
@@ -57,6 +58,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class EncryptedAppendLog {
 
+    // Sanity bound on a single frame, so a corrupt length prefix cannot force a huge allocation.
+    static final int MAX_FRAME_SIZE = 64 * 1024 * 1024;
+    // Fixed size added by Encryption.encryptV2: magic (4) + IV (16) + tag (32).
+    private static final int V2_FRAME_OVERHEAD = 52;
+
+    /** Whether a record would exceed the maximum frame size once encrypted, so callers can drop it instead of retrying forever. */
+    public static boolean exceedsMaxFrameSize(byte[] record) {
+        return record.length > MAX_FRAME_SIZE - V2_FRAME_OVERHEAD;
+    }
+
     private final File dir;
     private final String fileName;
     private final SecretKey secretKey;
@@ -65,6 +76,9 @@ public class EncryptedAppendLog {
     // File length up to which all frames are known intact (-1 until the first replay establishes
     // it), so a failed append's partial frame is truncated before the next write can bury it.
     private long knownGoodLength = -1;
+    // Set when the log file is created or renamed into place, until its directory entry is synced;
+    // sticky across failed appends so a retry still fsyncs the directory. Guarded by lock.
+    private boolean parentSyncPending;
 
     public EncryptedAppendLog(File dir, String fileName, SecretKey secretKey, int numMaxBackupFiles) {
         this.dir = dir;
@@ -100,9 +114,16 @@ public class EncryptedAppendLog {
     public void appendAll(List<byte[]> records) throws CryptoException {
         if (records.isEmpty()) return;
         List<byte[]> ciphertexts = new ArrayList<>(records.size());
-        for (byte[] record : records) ciphertexts.add(Encryption.encryptPayloadWithHmac(record, secretKey));
+        for (byte[] record : records) {
+            byte[] ciphertext = Encryption.encryptV2(record, secretKey);
+            if (ciphertext.length > MAX_FRAME_SIZE) throw new IllegalArgumentException("Record exceeds max frame size: " + ciphertext.length);
+            ciphertexts.add(ciphertext);
+        }
         synchronized (lock) {
             if (!dir.exists() && !dir.mkdir()) log.warn("make dir failed {}", dir);
+            // checked before the repair, which can itself recover the file from a rewrite temp
+            // with an unsynced rename
+            if (!logFile().exists()) parentSyncPending = true;
             repairTailBeforeAppend();
             long written = 0;
             try (FileOutputStream fos = new FileOutputStream(logFile(), true);
@@ -113,6 +134,11 @@ public class EncryptedAppendLog {
                 }
                 out.flush();
                 fos.getFD().sync();
+                // a freshly created file needs its directory entry synced too to be durable
+                if (parentSyncPending) {
+                    FileUtil.syncParentDir(logFile());
+                    parentSyncPending = false;
+                }
             } catch (IOException e) {
                 // The frame may have partially reached the disk. Truncate the tear away now
                 // (best effort; repairTailBeforeAppend covers us if this fails too).
@@ -172,6 +198,7 @@ public class EncryptedAppendLog {
                     log.warn("{} is missing but its rewrite temp exists; recovering the temp.", fileName);
                     try {
                         FileUtil.renameFile(tempFile, logFile);
+                        parentSyncPending = true; // renameFile does not sync the directory entry
                     } catch (IOException e) {
                         throw new RuntimeException("Could not recover " + fileName + " from its rewrite temp", e);
                     }
@@ -185,6 +212,7 @@ public class EncryptedAppendLog {
             long goodLength = 0;
             boolean tornTail = false;
             boolean corrupt = false;
+            boolean hasLegacyFrames = false;
 
             try (DataInputStream in = new DataInputStream(new BufferedInputStream(new FileInputStream(logFile)))) {
                 while (goodLength < fileLength) {
@@ -194,9 +222,9 @@ public class EncryptedAppendLog {
                         break;
                     }
                     int len = in.readInt();
-                    if (len <= 0) {
-                        // append() only ever writes positive lengths, so a complete non-positive
-                        // prefix cannot be a torn write - it is corruption of the prefix itself.
+                    if (len <= 0 || len > MAX_FRAME_SIZE) {
+                        // append() only ever writes positive lengths within the frame bound, so a
+                        // complete prefix outside it cannot be a torn write - it is corruption.
                         corrupt = true;
                         break;
                     }
@@ -208,7 +236,8 @@ public class EncryptedAppendLog {
                     in.readFully(ciphertext);
                     byte[] record;
                     try {
-                        record = Encryption.decryptPayloadWithHmac(ciphertext, secretKey);
+                        if (Encryption.blobVersion(ciphertext) < Encryption.CURRENT_BLOB_VERSION) hasLegacyFrames = true;
+                        record = Encryption.decryptPayloadWithHmacAuto(ciphertext, secretKey);
                     } catch (CryptoException e) {
                         // A fully-present frame that fails its HMAC is not a torn write -> real corruption.
                         corrupt = true;
@@ -247,6 +276,18 @@ public class EncryptedAppendLog {
             } catch (IOException e) {
                 throw new RuntimeException("Could not repair " + fileName, e);
             }
+            // one-time migration: rewrite legacy frames in the current format. Best effort - the
+            // replayed records must never be lost to a failed rewrite (the log on disk is intact).
+            if (hasLegacyFrames) {
+                try {
+                    log.info("Rewriting {} to upgrade legacy encrypted frames.", fileName);
+                    rewrite(records);
+                } catch (OutOfMemoryError e) {
+                    throw e;
+                } catch (Throwable t) {
+                    log.error("Could not rewrite {} to upgrade legacy frames; keeping the existing log.", fileName, t);
+                }
+            }
             return records;
         }
     }
@@ -267,7 +308,7 @@ public class EncryptedAppendLog {
                 try (FileOutputStream fos = new FileOutputStream(tempFile);
                      DataOutputStream out = new DataOutputStream(new BufferedOutputStream(fos))) {
                     for (byte[] record : records) {
-                        byte[] ciphertext = Encryption.encryptPayloadWithHmac(record, secretKey);
+                        byte[] ciphertext = Encryption.encryptV2(record, secretKey);
                         writeFrame(out, ciphertext);
                         written += 4L + ciphertext.length;
                     }
@@ -276,8 +317,9 @@ public class EncryptedAppendLog {
                 }
                 // Keep a rolling backup of the pre-rewrite log as a safety net against a faulty compaction.
                 if (logFile.exists()) FileUtil.rollingBackup(dir, fileName, numMaxBackupFiles);
-                FileUtil.atomicReplace(tempFile, logFile);
+                FileUtil.atomicReplace(tempFile, logFile); // syncs the directory entry
                 knownGoodLength = written;
+                parentSyncPending = false;
             } catch (IOException | CryptoException e) {
                 throw new RuntimeException("Could not rewrite " + fileName, e);
             } finally {

--- a/common/src/main/java/haveno/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/haveno/common/persistence/PersistenceManager.java
@@ -45,15 +45,16 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.crypto.Mac;
@@ -103,12 +104,14 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         });
     }
 
-    public static void flushAllDataToDiskAtBackup(ResultHandler completeHandler) {
+    // The backup handler receives the first write error (or null), so a failed flush is not
+    // silently backed up as if it were current data.
+    public static void flushAllDataToDiskAtBackup(Consumer<Throwable> completeHandler) {
         flushAllDataToDisk(completeHandler, false);
     }
 
     public static void flushAllDataToDiskAtShutdown(ResultHandler completeHandler) {
-        flushAllDataToDisk(completeHandler, true);
+        flushAllDataToDisk(error -> completeHandler.handleResult(), true);
     }
 
     /**
@@ -118,16 +121,17 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         ALL_PERSISTENCE_MANAGERS.clear();
         flushAtShutdownCalled = false;
         allServicesInitialized.set(false);
+        PlaintextMigration.reset(); // a restored account must not inherit this process's latch
     }
 
     // We require being called only once from the global shutdown routine. As the shutdown routine has a timeout
     // and error condition where we call the method as well beside the standard path and it could be that those
     // alternative code paths call our method after it was called already, so it is a valid but rare case.
     // We add a guard to prevent repeated calls.
-    private static void flushAllDataToDisk(ResultHandler completeHandler, boolean doShutdown) {
+    private static void flushAllDataToDisk(Consumer<Throwable> completeHandler, boolean doShutdown) {
         if (!allServicesInitialized.get()) {
             log.warn("Application has not completed start up yet so we do not flush data to disk.");
-            completeHandler.handleResult();
+            completeHandler.accept(null);
             return;
         }
 
@@ -144,10 +148,11 @@ public class PersistenceManager<T extends PersistableEnvelope> {
 
             log.info("Start flushAllDataToDisk");
             AtomicInteger openInstances = new AtomicInteger(ALL_PERSISTENCE_MANAGERS.size());
+            AtomicReference<Throwable> firstError = new AtomicReference<>();
 
             if (openInstances.get() == 0) {
                 log.info("No PersistenceManager instances have been created yet.");
-                completeHandler.handleResult();
+                completeHandler.accept(null);
             }
 
             new HashSet<>(ALL_PERSISTENCE_MANAGERS.values()).forEach(persistenceManager -> {
@@ -161,35 +166,39 @@ public class PersistenceManager<T extends PersistableEnvelope> {
                         (persistenceManager.source.flushAtShutDown || persistenceManager.persistenceRequested)) {
 
                     // We always get our completeHandler called even if exceptions happen. In case a file write fails
-                    // we still call our shutdown and count down routine as the completeHandler is triggered in any case.
+                    // we record the error so the caller does not treat the flush as successful.
                     // We get our result handler called from the write thread so we map back to user thread.
                     try {
-                        persistenceManager.persistNow(() ->
-                            UserThread.execute(() -> onWriteCompleted(completeHandler, openInstances, persistenceManager, doShutdown)));
+                        persistenceManager.persistNow(null, writeError -> {
+                            if (writeError != null) firstError.compareAndSet(null, writeError);
+                            UserThread.execute(() -> onWriteCompleted(completeHandler, openInstances, persistenceManager, doShutdown, firstError));
+                        }, false);
                     } catch (Exception e) {
-                        if (!doShutdown) throw e; // only complete if shutting down
-                        log.warn("Error flushing data to disk on shut down. Calling completeHandler.");
-                        UserThread.execute(() -> onWriteCompleted(completeHandler, openInstances, persistenceManager, doShutdown));
+                        // a serialization failure must still complete the flush and be reported
+                        log.warn("Error flushing data to disk. Calling completeHandler.", e);
+                        firstError.compareAndSet(null, e);
+                        onWriteCompleted(completeHandler, openInstances, persistenceManager, doShutdown, firstError);
                     }
                 } else {
-                    onWriteCompleted(completeHandler, openInstances, persistenceManager, doShutdown);
+                    onWriteCompleted(completeHandler, openInstances, persistenceManager, doShutdown, firstError);
                 }
             });
         });
     }
 
     // We get called always from user thread here.
-    private static void onWriteCompleted(ResultHandler completeHandler,
+    private static void onWriteCompleted(Consumer<Throwable> completeHandler,
                                          AtomicInteger openInstances,
                                          PersistenceManager<?> persistenceManager,
-                                         boolean doShutdown) {
+                                         boolean doShutdown,
+                                         AtomicReference<Throwable> firstError) {
         if (doShutdown) {
             persistenceManager.shutdown();
         }
 
         if (openInstances.decrementAndGet() == 0) {
             log.info("flushAllDataToDisk completed");
-            completeHandler.handleResult();
+            completeHandler.accept(firstError.get());
         }
     }
 
@@ -236,6 +245,8 @@ public class PersistenceManager<T extends PersistableEnvelope> {
     private String fileName;
     private Source source = Source.PRIVATE_LOW_PRIO;
     private Path usedTempFilePath;
+    // Pending purge of pre-migration backups; only touched on the single-threaded write executor.
+    private boolean legacyBackupPurgePending;
     private volatile boolean persistenceRequested;
     @Nullable
     private Timer timer;
@@ -449,24 +460,10 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         try (InputStream verifyStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
             payloadLength = Encryption.verifyPayloadWithHmacStream(verifyStream, symmetricKey);
         } catch (CryptoException ce) {
-            // plaintext is forgeable, so once the pre-migration inventory exists it is authoritative:
-            // a plaintext store must match its recorded content hash, even in the process that
-            // created the inventory. Only before it exists does legacy key material alone authorize
-            // plaintext, since the legacy era is what the inventory captures.
-            byte[] recordedHash = PlaintextMigration.getRecordedHash(dir, storageFile.getName(), symmetricKey);
-            if (recordedHash != null) {
-                log.warn("Reading pre-migration plaintext store {} recorded in the migration inventory", storageFile.getName());
-                try (InputStream rawStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
-                    DigestInputStream digestStream = new DigestInputStream(rawStream, MessageDigest.getInstance("SHA-256"));
-                    protobuf.PersistableEnvelope proto = protobuf.PersistableEnvelope.parseDelimitedFrom(digestStream);
-                    ByteStreams.exhaust(digestStream);
-                    if (!MessageDigest.isEqual(digestStream.getMessageDigest().digest(), recordedHash)) {
-                        throw new IOException("Plaintext store " + storageFile.getName() + " does not match its recorded pre-migration hash");
-                    }
-                    return proto;
-                }
-            }
-            if (PlaintextMigration.hasInventory(dir) || !keyRing.getKeyStorage().hasLegacyFormatEverLoaded()) throw ce;
+            // plaintext is forgeable, so it is only parsed while unmigrated legacy key material
+            // exists in this process and migration has not completed; migration encrypts every
+            // plaintext store in place, so afterwards no legitimate plaintext store can exist
+            if (PlaintextMigration.hasMarker(dir) || !keyRing.getKeyStorage().hasLegacyFormatEverLoaded()) throw ce;
             log.warn("Expected encrypted persisted file, attempting to getPersisted without decryption");
             try (InputStream rawStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
                 return protobuf.PersistableEnvelope.parseDelimitedFrom(rawStream);
@@ -584,7 +581,42 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         persistNow(completeHandler, false);
     }
 
+    /**
+     * Writes to disk and blocks until the write completed, rethrowing a write failure. Completion
+     * is signaled from the write thread, so this is safe to call from any thread.
+     */
+    public void persistNowSync() {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        persistNow(null, t -> {
+            error.set(t);
+            latch.countDown();
+        }, true);
+        try {
+            if (!latch.await(2, TimeUnit.MINUTES)) throw new RuntimeException("Timed out writing " + fileName + " to disk");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted writing " + fileName + " to disk", e);
+        }
+        if (error.get() != null) throw new RuntimeException("Failed to write " + fileName + " to disk", error.get());
+    }
+
+    /**
+     * Replaces this store's rolling backups with a single fresh verified copy of the current file,
+     * for content that must not survive in backups (e.g. credentials under a retired password).
+     * The fresh backup is created before the stale generations are purged, with verification.
+     */
+    public void refreshBackups() throws IOException {
+        FileUtil.replaceRollingBackups(dir, fileName);
+    }
+
     private synchronized void persistNow(@Nullable Runnable completeHandler, boolean force) {
+        persistNow(completeHandler, null, force);
+    }
+
+    private synchronized void persistNow(@Nullable Runnable completeHandler,
+                                         @Nullable Consumer<Throwable> completionConsumer,
+                                         boolean force) {
         long ts = System.currentTimeMillis();
         try {
             // The serialisation is done on the user thread to avoid threading issue with potential mutations of the
@@ -594,7 +626,7 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             // For the write to disk task we use a thread. We do not have any issues anymore if the persistable objects
             // gets mutated while the thread is running as we have serialized it already and do not operate on the
             // reference to the persistable object.
-            getWriteToDiskExecutor().execute(() -> writeToDisk(serialized, completeHandler, force));
+            getWriteToDiskExecutor().execute(() -> writeToDisk(serialized, completeHandler, completionConsumer, force));
 
             long duration = System.currentTimeMillis() - ts;
             if (duration > 100) {
@@ -607,9 +639,13 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         }
     }
 
-    private void writeToDisk(protobuf.PersistableEnvelope serialized, @Nullable Runnable completeHandler, boolean force) {
+    private void writeToDisk(protobuf.PersistableEnvelope serialized,
+                             @Nullable Runnable completeHandler,
+                             @Nullable Consumer<Throwable> completionConsumer,
+                             boolean force) {
         if (!allServicesInitialized.get() && !force) {
             log.warn("Application has not completed start up yet so we do not permit writing data to disk.");
+            if (completionConsumer != null) completionConsumer.accept(new IllegalStateException("Application has not completed start up yet"));
             if (completeHandler != null) {
                 UserThread.execute(completeHandler);
             }
@@ -617,6 +653,7 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         }
         if (keyRing != null && !keyRing.isUnlocked()) {
             log.warn("Account is not open, ignoring writeToDisk.");
+            if (completionConsumer != null) completionConsumer.accept(new IllegalStateException("Account is not open"));
             if (completeHandler != null) {
                 UserThread.execute(completeHandler);
             }
@@ -626,12 +663,16 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         long ts = System.currentTimeMillis();
         File tempFile = null;
         FileOutputStream fileOutputStream = null;
+        Throwable error = null;
 
         try {
             // Before we write we backup existing file, unless it is still in a pre-v2 format:
             // copying it would preserve a plaintext (or weakly encrypted) backup of the store
             boolean migratingFormat = keyRing != null && !isCurrentFormatOnDisk(storageFile);
-            if (!migratingFormat) FileUtil.rollingBackup(dir, fileName, source.getNumMaxBackupFiles());
+            // sticky: once the store is installed in the current format a retry no longer sees
+            // migratingFormat, so a failed purge must be re-attempted from this flag
+            if (migratingFormat) legacyBackupPurgePending = true;
+            if (!legacyBackupPurgePending) FileUtil.rollingBackup(dir, fileName, source.getNumMaxBackupFiles());
 
             if (!dir.exists() && !dir.mkdir())
                 log.warn("make dir failed {}", fileName);
@@ -663,16 +704,20 @@ public class PersistenceManager<T extends PersistableEnvelope> {
 
             // atomic where supported, so no crash window exists with neither file in place
             FileUtil.atomicReplace(tempFile, storageFile);
-            if (migratingFormat) {
-                // purge pre-migration backups and take the first backup from the encrypted store
-                FileUtil.deleteRollingBackup(dir, fileName);
-                FileUtil.rollingBackup(dir, fileName, source.getNumMaxBackupFiles());
+            if (legacyBackupPurgePending) {
+                // replace pre-migration backups with a fresh verified one of the encrypted store;
+                // the fresh backup is taken first, so a crash or failure between the steps can
+                // never leave the store without any backup, and strict so a failure fails the
+                // write and retries instead of silently keeping deprecated-format backups
+                if (source.getNumMaxBackupFiles() > 0) FileUtil.replaceRollingBackups(dir, fileName);
+                else FileUtil.deleteRollingBackupStrict(dir, fileName);
+                legacyBackupPurgePending = false;
             }
-            if (keyRing != null) PlaintextMigration.markMigrated(dir, fileName, keyRing.getSymmetricKey());
             usedTempFilePath = tempFile.toPath();
         } catch (Throwable t) {
             // If an error occurred, don't attempt to reuse this path again, in case temp file cleanup fails.
             usedTempFilePath = null;
+            error = t;
             log.error("Error at saveToFile, storageFile={}", fileName, t);
         } finally {
             if (tempFile != null && tempFile.exists()) {
@@ -695,7 +740,9 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             if (duration > 100) {
                 log.info("Writing the serialized {} completed in {} msec", fileName, duration);
             }
-            persistenceRequested = false;
+            // a failed write stays requested so shutdown and later flushes retry it
+            if (error == null) persistenceRequested = false;
+            if (completionConsumer != null) completionConsumer.accept(error);
             if (completeHandler != null) {
                 UserThread.execute(completeHandler);
             }

--- a/common/src/main/java/haveno/common/persistence/PersistenceManager.java
+++ b/common/src/main/java/haveno/common/persistence/PersistenceManager.java
@@ -45,6 +45,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -241,6 +242,8 @@ public class PersistenceManager<T extends PersistableEnvelope> {
     private ExecutorService writeToDiskExecutor;
     public final AtomicBoolean initCalled = new AtomicBoolean(false);
     public final AtomicBoolean readCalled = new AtomicBoolean(false);
+    // Set when a read found a pre-v2 (legacy-encrypted or unencrypted) file, to trigger a re-persist.
+    private volatile boolean lastReadWasLegacyFormat;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -342,6 +345,12 @@ public class PersistenceManager<T extends PersistableEnvelope> {
                 UserThread.execute(() -> {
                     resultHandler.accept(persisted);
 
+                    // re-encrypt legacy-format files in the current format once the host applied the data
+                    if (lastReadWasLegacyFormat) {
+                        lastReadWasLegacyFormat = false;
+                        requestPersistence();
+                    }
+
                     GcUtil.maybeReleaseMemory();
                 });
             } else {
@@ -412,20 +421,52 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         return null;
     }
 
-    // Reads an encrypted store in two streaming passes so we never hold the whole decrypted payload in
-    // memory (which previously caused OutOfMemoryError on large stores such as ClosedTrades). Pass 1
-    // verifies the hmac and returns the payload length; pass 2 re-reads and parses only the verified
-    // payload bytes, re-checking the hmac over the bytes it actually parsed (the file could in theory
-    // change between the two opens, e.g. through an external backup/sync tool - pass 1's verification
-    // covered a different read). A file that is not a valid encrypted store (e.g. a legacy unencrypted
-    // one) makes pass 1 throw CryptoException, in which case we fall back to reading it without
-    // decryption. The raw FileInputStreams are buffered because CipherInputStream pulls from the
-    // underlying stream in 512-byte chunks - unbuffered, a large store costs ~2000 read syscalls per MB.
+    // Reads an encrypted store in two streaming passes so the whole decrypted payload is never in
+    // memory: pass 1 verifies, pass 2 re-reads, parses and re-checks over the bytes actually read
+    // (the file could change between the two opens). A file that is not a valid encrypted store
+    // falls back to a plain read only while unmigrated legacy key material exists. Streams are
+    // buffered (CipherInputStream reads 512-byte chunks);
+    // reads in a format older than the current one set a flag so the store is re-persisted.
     private protobuf.PersistableEnvelope readEncrypted(File storageFile, SecretKey symmetricKey) throws Exception {
+        int formatVersion;
+        try (InputStream headStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
+            formatVersion = Encryption.blobVersion(headStream);
+        }
+        if (formatVersion > 0) {
+            try {
+                // versioned formats dispatch here (v2 is the only one so far)
+                protobuf.PersistableEnvelope proto = readEncryptedV2(storageFile, symmetricKey);
+                if (formatVersion < Encryption.CURRENT_BLOB_VERSION) lastReadWasLegacyFormat = true;
+                return proto;
+            } catch (CryptoException e) {
+                // a legacy blob can collide with the magic (p = 2^-32); try the legacy read
+                // before treating the file as corrupt
+                log.warn("Store {} looks like v{} but failed verification, attempting legacy read", storageFile.getName(), formatVersion);
+            }
+        }
+        lastReadWasLegacyFormat = true;
         long payloadLength;
         try (InputStream verifyStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
             payloadLength = Encryption.verifyPayloadWithHmacStream(verifyStream, symmetricKey);
         } catch (CryptoException ce) {
+            // plaintext is forgeable, so once the pre-migration inventory exists it is authoritative:
+            // a plaintext store must match its recorded content hash, even in the process that
+            // created the inventory. Only before it exists does legacy key material alone authorize
+            // plaintext, since the legacy era is what the inventory captures.
+            byte[] recordedHash = PlaintextMigration.getRecordedHash(dir, storageFile.getName(), symmetricKey);
+            if (recordedHash != null) {
+                log.warn("Reading pre-migration plaintext store {} recorded in the migration inventory", storageFile.getName());
+                try (InputStream rawStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
+                    DigestInputStream digestStream = new DigestInputStream(rawStream, MessageDigest.getInstance("SHA-256"));
+                    protobuf.PersistableEnvelope proto = protobuf.PersistableEnvelope.parseDelimitedFrom(digestStream);
+                    ByteStreams.exhaust(digestStream);
+                    if (!MessageDigest.isEqual(digestStream.getMessageDigest().digest(), recordedHash)) {
+                        throw new IOException("Plaintext store " + storageFile.getName() + " does not match its recorded pre-migration hash");
+                    }
+                    return proto;
+                }
+            }
+            if (PlaintextMigration.hasInventory(dir) || !keyRing.getKeyStorage().hasLegacyFormatEverLoaded()) throw ce;
             log.warn("Expected encrypted persisted file, attempting to getPersisted without decryption");
             try (InputStream rawStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
                 return protobuf.PersistableEnvelope.parseDelimitedFrom(rawStream);
@@ -435,10 +476,8 @@ public class PersistenceManager<T extends PersistableEnvelope> {
              InputStream decryptStream = Encryption.decryptStream(parseStream, symmetricKey)) {
             Mac mac = Encryption.createHmac(symmetricKey);
             InputStream payloadStream = new MacUpdatingInputStream(ByteStreams.limit(decryptStream, payloadLength), mac);
-            // The previous read used parseFrom(byte[]), whose array decoder imposes no message size limit.
-            // The stream decoder defaults to a 64 MB limit, so we lift it explicitly; otherwise a large but
-            // valid store (the very case this streaming read exists for) would throw "Protocol message too
-            // large" and be wrongly moved to backup_of_corrupted_data.
+            // The stream decoder defaults to a 64 MB limit (the old array decoder had none); lift it
+            // so a large but valid store is not wrongly moved to backup_of_corrupted_data.
             CodedInputStream codedInput = CodedInputStream.newInstance(payloadStream);
             codedInput.setSizeLimit(Integer.MAX_VALUE);
             protobuf.PersistableEnvelope proto = protobuf.PersistableEnvelope.parseFrom(codedInput);
@@ -450,6 +489,26 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             if (!MessageDigest.isEqual(mac.doFinal(), expectedHmac)) {
                 throw new IOException("Storage file " + storageFile.getName() + " changed while it was being read");
             }
+            return proto;
+        }
+    }
+
+    // Two-pass v2 read: pass 1 verifies the tag over the raw stream, pass 2 parses plaintext from a
+    // stream that re-verifies the tag over the ciphertext it actually delivered before signaling EOF
+    // (so a file change between the two opens cannot go unnoticed).
+    private protobuf.PersistableEnvelope readEncryptedV2(File storageFile, SecretKey symmetricKey) throws Exception {
+        try (InputStream verifyStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE)) {
+            Encryption.verifyV2Stream(verifyStream, symmetricKey);
+        }
+        try (InputStream parseStream = new BufferedInputStream(new FileInputStream(storageFile), READ_BUFFER_SIZE);
+             InputStream payloadStream = Encryption.decryptV2Stream(parseStream, symmetricKey)) {
+            // The stream decoder defaults to a 64 MB limit; lift it so a large but valid store is not
+            // wrongly treated as corrupt.
+            CodedInputStream codedInput = CodedInputStream.newInstance(payloadStream);
+            codedInput.setSizeLimit(Integer.MAX_VALUE);
+            protobuf.PersistableEnvelope proto = protobuf.PersistableEnvelope.parseFrom(codedInput);
+            // Consume to EOF so the stream verifies the tag over this same read.
+            ByteStreams.exhaust(payloadStream);
             return proto;
         }
     }
@@ -569,8 +628,10 @@ public class PersistenceManager<T extends PersistableEnvelope> {
         FileOutputStream fileOutputStream = null;
 
         try {
-            // Before we write we backup existing file
-            FileUtil.rollingBackup(dir, fileName, source.getNumMaxBackupFiles());
+            // Before we write we backup existing file, unless it is still in a pre-v2 format:
+            // copying it would preserve a plaintext (or weakly encrypted) backup of the store
+            boolean migratingFormat = keyRing != null && !isCurrentFormatOnDisk(storageFile);
+            if (!migratingFormat) FileUtil.rollingBackup(dir, fileName, source.getNumMaxBackupFiles());
 
             if (!dir.exists() && !dir.mkdir())
                 log.warn("make dir failed {}", fileName);
@@ -584,12 +645,9 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             fileOutputStream = new FileOutputStream(tempFile);
 
             if (keyRing != null) {
-                // Stream the encryption directly to disk with constant memory: the proto is written
-                // through the hmac and the cipher in two passes, so neither a serialized byte[] nor
-                // an encrypted byte[] of the whole store is ever built. The array-building variants
-                // could throw OutOfMemoryError for large stores and silently leave the on-disk file
-                // frozen at the last successful write.
-                Encryption.encryptPayloadWithHmacToStream(serialized::writeTo, keyRing.getSymmetricKey(), fileOutputStream);
+                // Stream the encryption to disk with constant memory; building full byte[]s here
+                // previously threw OutOfMemoryError and froze the on-disk file for large stores.
+                Encryption.encryptV2ToStream(serialized::writeTo, keyRing.getSymmetricKey(), fileOutputStream);
             } else {
                 serialized.writeDelimitedTo(fileOutputStream);
             }
@@ -603,7 +661,14 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             // when rename temp file
             fileOutputStream.close();
 
-            FileUtil.renameFile(tempFile, storageFile);
+            // atomic where supported, so no crash window exists with neither file in place
+            FileUtil.atomicReplace(tempFile, storageFile);
+            if (migratingFormat) {
+                // purge pre-migration backups and take the first backup from the encrypted store
+                FileUtil.deleteRollingBackup(dir, fileName);
+                FileUtil.rollingBackup(dir, fileName, source.getNumMaxBackupFiles());
+            }
+            if (keyRing != null) PlaintextMigration.markMigrated(dir, fileName, keyRing.getSymmetricKey());
             usedTempFilePath = tempFile.toPath();
         } catch (Throwable t) {
             // If an error occurred, don't attempt to reuse this path again, in case temp file cleanup fails.
@@ -634,6 +699,16 @@ public class PersistenceManager<T extends PersistableEnvelope> {
             if (completeHandler != null) {
                 UserThread.execute(completeHandler);
             }
+        }
+    }
+
+    // Whether the file on disk is already in the current encrypted blob format (a missing file counts).
+    private static boolean isCurrentFormatOnDisk(File file) {
+        if (!file.exists()) return true;
+        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+            return Encryption.blobVersion(in) == Encryption.CURRENT_BLOB_VERSION;
+        } catch (IOException e) {
+            return true;
         }
     }
 

--- a/common/src/main/java/haveno/common/persistence/PlaintextMigration.java
+++ b/common/src/main/java/haveno/common/persistence/PlaintextMigration.java
@@ -17,6 +17,8 @@
 
 package haveno.common.persistence;
 
+import com.google.common.io.ByteStreams;
+import com.google.protobuf.CodedInputStream;
 import haveno.common.crypto.Encryption;
 import haveno.common.file.FileUtil;
 import java.io.BufferedInputStream;
@@ -25,123 +27,161 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.MessageDigest;
-import java.util.HexFormat;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Durable, authenticated inventory of the plaintext store files that existed before an account's
- * legacy key material was replaced by the v2 format. Plaintext is forgeable, so after that
- * replacement a plaintext store may only be read if it was recorded here (by name and content hash)
- * while the legacy key files - which cannot be planted without the password - still existed.
- * Entries are removed as stores are re-persisted encrypted. The inventory itself is a permanent
- * migration-state marker: it stays on disk (empty once migration completes) so plaintext is never
- * again authorized without a matching entry.
+ * One-time migration of plaintext store files to the v2 encrypted format. Plaintext is forgeable,
+ * so it is only ever parsed while the account still holds unmigrated legacy key material, which
+ * cannot be planted without the password. Before that material is replaced, every plaintext file
+ * in the persistence tree (live stores, crash-left temps, rolling backups and corruption backups)
+ * is encrypted in place, and a durable marker is then written so plaintext is never again
+ * accepted. The marker is written only after every file is encrypted, and the legacy key files
+ * are only replaced after migration completes, so an interruption at any point simply resumes at
+ * the next unlock.
  */
 @Slf4j
 public class PlaintextMigration {
 
     public static final String FILE_NAME = "plaintext_migration";
 
+    // Latched per storage dir once migration completes or its marker verifies, so deleting the
+    // on-disk marker cannot re-enable plaintext acceptance within this process.
+    private static final Set<String> MIGRATED_DIRS = ConcurrentHashMap.newKeySet();
+    // Existence-only marker observations, latched separately: they harden the plaintext gate but
+    // must never authorize skipping the migration itself (the marker could be planted or corrupt).
+    private static final Set<String> OBSERVED_MARKER_DIRS = ConcurrentHashMap.newKeySet();
+
     /**
-     * Scans the storage dir and durably records every file that is neither v2 nor valid
-     * legacy-encrypted, then encrypts residual plaintext in the backup and corruption-recovery
-     * trees in place. Must be called before the legacy key files are replaced; throwing here
-     * must abort that replacement so the record can be retried.
+     * Encrypts every plaintext file and upgrades every legacy encrypted file under the storage
+     * dir in place, then durably writes the migration marker. Must be called before the legacy
+     * key files are replaced; throwing here must abort that replacement so the migration can be
+     * retried.
      */
-    public static synchronized void record(File storageDir, SecretKey masterKey) throws IOException {
-        Map<String, String> entries = new TreeMap<>();
-        File[] files = storageDir.listFiles();
-        if (files == null) throw new IOException("Could not list storage directory " + storageDir.getAbsolutePath());
-        for (File file : files) {
-            if (!file.isFile() || file.length() == 0) continue;
-            String name = file.getName();
-            if (name.equals(FILE_NAME) || name.endsWith(".tmp") || name.startsWith("temp_")) continue;
-            if (isEncrypted(file, masterKey)) continue;
-            entries.put(name, HexFormat.of().formatHex(sha256(file)));
+    public static synchronized void migrate(File storageDir, SecretKey masterKey) throws IOException {
+        // never re-run after completion: replaying captured legacy key files over a migrated
+        // directory must not re-enable encrypting (and thereby authenticating) planted plaintext
+        if (hasVerifiedMarker(storageDir, masterKey)) return;
+        encryptResidualPlaintext(storageDir, masterKey, false);
+        for (File backupsDir : FileUtil.getRollingBackupDirs(storageDir)) encryptResidualPlaintext(backupsDir, masterKey, false);
+        // quarantined frame logs are never replayed again, so they are wrapped whole here rather
+        // than left to the log's own frame migration
+        encryptResidualPlaintext(new File(storageDir, FileUtil.CORRUPTED_BACKUP_FOLDER), masterKey, true);
+        writeMarker(storageDir, masterKey);
+        MIGRATED_DIRS.add(storageDir.getAbsolutePath());
+    }
+
+    /** Forgets latched migrations so an in-process restart re-reads the on-disk markers. */
+    public static void reset() {
+        MIGRATED_DIRS.clear();
+        OBSERVED_MARKER_DIRS.clear();
+    }
+
+    /** Whether migration has completed, after which plaintext stores are never accepted. */
+    public static boolean hasMarker(File storageDir) {
+        String key = storageDir.getAbsolutePath();
+        if (MIGRATED_DIRS.contains(key) || OBSERVED_MARKER_DIRS.contains(key)) return true;
+        if (!markerFile(storageDir).exists()) return false;
+        OBSERVED_MARKER_DIRS.add(key); // latch observed markers too
+        return true;
+    }
+
+    // The skip below authorizes replacing the legacy key files, so the marker must authenticate
+    // under the master key: a planted or corrupt marker re-runs the migration (idempotent) and is
+    // rewritten, instead of stranding unencrypted stores behind the plaintext rejection.
+    private static boolean hasVerifiedMarker(File storageDir, SecretKey masterKey) {
+        if (MIGRATED_DIRS.contains(storageDir.getAbsolutePath())) return true;
+        File marker = markerFile(storageDir);
+        if (!marker.exists()) return false;
+        try {
+            Encryption.decryptV2(Files.readAllBytes(marker.toPath()), masterKey);
+            MIGRATED_DIRS.add(storageDir.getAbsolutePath()); // a verified marker latches like a completed migration
+            return true;
+        } catch (Exception e) {
+            log.warn("Migration marker failed verification; re-running the migration", e);
+            return false;
         }
-        // written even when empty: the inventory is the durable marker that migration ran, so
-        // plaintext is never again authorized without a matching entry
-        if (!entries.isEmpty()) log.info("Recording {} unmigrated plaintext store(s) before key migration: {}", entries.size(), entries.keySet());
-        write(storageDir, entries, masterKey);
-
-        // historical plaintext copies must not outlive the migration either; encrypting them in
-        // place preserves their recovery value without leaving plaintext on disk
-        for (File backupsDir : FileUtil.getRollingBackupDirs(storageDir)) encryptResidualPlaintext(backupsDir, masterKey);
-        encryptResidualPlaintext(new File(storageDir, FileUtil.CORRUPTED_BACKUP_FOLDER), masterKey);
     }
 
-    public static boolean hasInventory(File storageDir) {
-        return inventoryFile(storageDir).exists();
-    }
-
-    private static void encryptResidualPlaintext(File dir, SecretKey masterKey) throws IOException {
+    private static void encryptResidualPlaintext(File dir, SecretKey masterKey, boolean wrapFrameLogs) throws IOException {
         if (!dir.exists()) return;
         File[] files = dir.listFiles();
         // fail closed: an uninspectable directory must abort the migration, not be skipped
         if (files == null) throw new IOException("Could not list directory " + dir.getAbsolutePath());
         for (File file : files) {
-            if (!file.isFile() || file.length() == 0 || file.getName().endsWith(".tmp")) continue;
-            if (isEncrypted(file, masterKey)) continue;
-            log.info("Encrypting residual plaintext file {}", file.getName());
-            try {
-                // streamed so a large backup cannot exhaust the heap
-                File tempFile = new File(dir, file.getName() + ".tmp");
-                try (FileOutputStream fos = new FileOutputStream(tempFile)) {
-                    Encryption.encryptV2ToStream(out -> {
-                        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
-                            in.transferTo(out);
-                        }
-                    }, masterKey, fos);
-                    fos.flush();
-                    fos.getFD().sync();
-                }
-                FileUtil.atomicReplace(tempFile, file);
-            } catch (IOException e) {
-                throw e;
-            } catch (Exception e) {
-                throw new IOException("Could not encrypt residual plaintext file " + file.getName(), e);
-            }
+            if (!file.isFile() || file.length() == 0 || file.getName().equals(FILE_NAME)) continue;
+            // JSON dumps (e.g. --dump-statistics) are exports for external readers, never stores
+            if (file.getName().endsWith(".json")) continue;
+            if (isCurrentFormat(file)) continue;
+            // append-logs are encrypted per record inside a length-prefixed framing, not as one
+            // blob; live ones migrate at replay
+            if (!wrapFrameLogs && EncryptedAppendLog.isEncryptedFrameLog(file, masterKey)) continue;
+            // legacy encrypted files are upgraded eagerly: files that are never persisted again
+            // (archives, stale backups, rarely written stores) would otherwise keep the
+            // deprecated format indefinitely
+            if (isLegacyEncrypted(file, masterKey)) reEncryptLegacyInPlace(file, masterKey);
+            else encryptInPlace(file, masterKey);
         }
     }
 
-    /**
-     * Returns the recorded pre-migration content hash for a store, or null if not recorded.
-     */
-    public static synchronized byte[] getRecordedHash(File storageDir, String fileName, SecretKey masterKey) {
-        Map<String, String> entries = read(storageDir, masterKey);
-        String hash = entries == null ? null : entries.get(fileName);
-        return hash == null ? null : HexFormat.of().parseHex(hash);
+    private static void encryptInPlace(File file, SecretKey masterKey) throws IOException {
+        log.info("Encrypting plaintext file {}", file.getName());
+        // plaintext stores were written length-delimited while encrypted stores hold the raw
+        // message, so a matching delimiter is stripped; other content is preserved byte for byte
+        long payloadOffset = delimitedPayloadOffset(file);
+        try {
+            // streamed so a large file cannot exhaust the heap
+            File tempFile = new File(file.getParentFile(), file.getName() + ".enc.tmp");
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                Encryption.encryptV2ToStream(out -> {
+                    try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+                        in.skipNBytes(payloadOffset);
+                        in.transferTo(out);
+                    }
+                }, masterKey, fos);
+                fos.flush();
+                fos.getFD().sync();
+            }
+            FileUtil.atomicReplace(tempFile, file);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Could not encrypt plaintext file " + file.getName(), e);
+        }
     }
 
-    /**
-     * Removes a store from the inventory after it was durably persisted in an encrypted format.
-     * The (possibly empty) inventory is rewritten, never deleted, and a failure propagates so the
-     * caller does not treat the write as complete while the old plaintext hash stays authorized.
-     */
-    public static synchronized void markMigrated(File storageDir, String fileName, SecretKey masterKey) throws IOException {
-        if (masterKey == null || !inventoryFile(storageDir).exists()) return;
-        Map<String, String> entries = read(storageDir, masterKey);
-        if (entries == null || entries.remove(fileName) == null) return;
-        write(storageDir, entries, masterKey);
+    // Returns the size of a leading varint whose value equals exactly the remaining file length
+    // (the layout writeDelimitedTo produces), or 0 for any other content.
+    private static long delimitedPayloadOffset(File file) {
+        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+            CodedInputStream codedInput = CodedInputStream.newInstance(in);
+            long payloadLength = codedInput.readRawVarint32() & 0xffffffffL;
+            int headerSize = codedInput.getTotalBytesRead();
+            return payloadLength == file.length() - headerSize ? headerSize : 0;
+        } catch (Exception e) {
+            return 0;
+        }
     }
 
-    private static File inventoryFile(File storageDir) {
+    private static File markerFile(File storageDir) {
         return new File(storageDir, FILE_NAME);
     }
 
     // A file is already protected if it is a v2 blob or verifies as a legacy encrypted stream.
-    private static boolean isEncrypted(File file, SecretKey masterKey) {
+    private static boolean isCurrentFormat(File file) {
         try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
-            if (Encryption.blobVersion(in) > 0) return true;
+            return Encryption.blobVersion(in) >= Encryption.CURRENT_BLOB_VERSION;
         } catch (IOException e) {
             return false;
         }
+    }
+
+    private static boolean isLegacyEncrypted(File file, SecretKey masterKey) {
         try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
             Encryption.verifyPayloadWithHmacStream(in, masterKey);
             return true;
@@ -150,56 +190,68 @@ public class PlaintextMigration {
         }
     }
 
-    private static byte[] sha256(File file) throws IOException {
+    // Legacy encrypted stores hold the raw message like v2 does, so the authenticated payload is
+    // carried over byte for byte under the new format.
+    private static void reEncryptLegacyInPlace(File file, SecretKey masterKey) throws IOException {
+        log.info("Re-encrypting legacy encrypted file {}", file.getName());
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            long payloadLength;
             try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
-                byte[] buf = new byte[64 * 1024];
-                int read;
-                while ((read = in.read(buf)) != -1) digest.update(buf, 0, read);
+                payloadLength = Encryption.verifyPayloadWithHmacStream(in, masterKey);
             }
-            return digest.digest();
+            File tempFile = new File(file.getParentFile(), file.getName() + ".enc.tmp");
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                Encryption.encryptV2ToStream(out -> {
+                    try (InputStream in = new BufferedInputStream(new FileInputStream(file));
+                         InputStream decrypted = Encryption.decryptStream(in, masterKey)) {
+                        // re-verify the hmac over the bytes actually copied, so a file swapped
+                        // between the two passes cannot be sealed unauthenticated
+                        Mac mac = Encryption.createHmac(masterKey);
+                        byte[] buffer = new byte[64 * 1024];
+                        long remaining = payloadLength;
+                        while (remaining > 0) {
+                            int read = decrypted.read(buffer, 0, (int) Math.min(buffer.length, remaining));
+                            if (read < 0) throw new IOException("Unexpected end of legacy payload in " + file.getName());
+                            mac.update(buffer, 0, read);
+                            out.write(buffer, 0, read);
+                            remaining -= read;
+                        }
+                        byte[] expectedHmac = new byte[32];
+                        ByteStreams.readFully(decrypted, expectedHmac);
+                        if (!MessageDigest.isEqual(mac.doFinal(), expectedHmac)) {
+                            throw new IOException("Legacy file " + file.getName() + " changed while being re-encrypted");
+                        }
+                    } catch (IOException e) {
+                        throw e;
+                    } catch (Exception e) {
+                        throw new IOException(e);
+                    }
+                }, masterKey, fos);
+                fos.flush();
+                fos.getFD().sync();
+            }
+            FileUtil.atomicReplace(tempFile, file);
+        } catch (IOException e) {
+            throw e;
         } catch (Exception e) {
-            throw new IOException("Could not hash " + file.getName(), e);
+            throw new IOException("Could not re-encrypt legacy encrypted file " + file.getName(), e);
         }
     }
 
-    private static Map<String, String> read(File storageDir, SecretKey masterKey) {
-        File file = inventoryFile(storageDir);
-        if (masterKey == null || !file.exists()) return null;
+    private static void writeMarker(File storageDir, SecretKey masterKey) throws IOException {
         try {
-            byte[] plain = Encryption.decryptV2(Files.readAllBytes(file.toPath()), masterKey);
-            Map<String, String> entries = new TreeMap<>();
-            for (String line : new String(plain, StandardCharsets.UTF_8).split("\n")) {
-                if (line.isEmpty()) continue;
-                int sep = line.indexOf(' ');
-                entries.put(line.substring(sep + 1), line.substring(0, sep));
-            }
-            return entries;
-        } catch (Exception e) {
-            log.error("Could not read plaintext migration inventory; treating as absent", e);
-            return null;
-        }
-    }
-
-    private static void write(File storageDir, Map<String, String> entries, SecretKey masterKey) throws IOException {
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> entry : entries.entrySet()) {
-            sb.append(entry.getValue()).append(' ').append(entry.getKey()).append('\n');
-        }
-        try {
-            byte[] blob = Encryption.encryptV2(sb.toString().getBytes(StandardCharsets.UTF_8), masterKey);
+            byte[] blob = Encryption.encryptV2(new byte[0], masterKey);
             File tempFile = new File(storageDir, FILE_NAME + ".tmp");
             try (FileOutputStream fos = new FileOutputStream(tempFile)) {
                 fos.write(blob);
                 fos.flush();
                 fos.getFD().sync();
             }
-            FileUtil.atomicReplace(tempFile, inventoryFile(storageDir));
+            FileUtil.atomicReplace(tempFile, markerFile(storageDir));
         } catch (IOException e) {
             throw e;
         } catch (Exception e) {
-            throw new IOException("Could not write plaintext migration inventory", e);
+            throw new IOException("Could not write plaintext migration marker", e);
         }
     }
 }

--- a/common/src/main/java/haveno/common/persistence/PlaintextMigration.java
+++ b/common/src/main/java/haveno/common/persistence/PlaintextMigration.java
@@ -1,0 +1,205 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.persistence;
+
+import haveno.common.crypto.Encryption;
+import haveno.common.file.FileUtil;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Durable, authenticated inventory of the plaintext store files that existed before an account's
+ * legacy key material was replaced by the v2 format. Plaintext is forgeable, so after that
+ * replacement a plaintext store may only be read if it was recorded here (by name and content hash)
+ * while the legacy key files - which cannot be planted without the password - still existed.
+ * Entries are removed as stores are re-persisted encrypted. The inventory itself is a permanent
+ * migration-state marker: it stays on disk (empty once migration completes) so plaintext is never
+ * again authorized without a matching entry.
+ */
+@Slf4j
+public class PlaintextMigration {
+
+    public static final String FILE_NAME = "plaintext_migration";
+
+    /**
+     * Scans the storage dir and durably records every file that is neither v2 nor valid
+     * legacy-encrypted, then encrypts residual plaintext in the backup and corruption-recovery
+     * trees in place. Must be called before the legacy key files are replaced; throwing here
+     * must abort that replacement so the record can be retried.
+     */
+    public static synchronized void record(File storageDir, SecretKey masterKey) throws IOException {
+        Map<String, String> entries = new TreeMap<>();
+        File[] files = storageDir.listFiles();
+        if (files == null) throw new IOException("Could not list storage directory " + storageDir.getAbsolutePath());
+        for (File file : files) {
+            if (!file.isFile() || file.length() == 0) continue;
+            String name = file.getName();
+            if (name.equals(FILE_NAME) || name.endsWith(".tmp") || name.startsWith("temp_")) continue;
+            if (isEncrypted(file, masterKey)) continue;
+            entries.put(name, HexFormat.of().formatHex(sha256(file)));
+        }
+        // written even when empty: the inventory is the durable marker that migration ran, so
+        // plaintext is never again authorized without a matching entry
+        if (!entries.isEmpty()) log.info("Recording {} unmigrated plaintext store(s) before key migration: {}", entries.size(), entries.keySet());
+        write(storageDir, entries, masterKey);
+
+        // historical plaintext copies must not outlive the migration either; encrypting them in
+        // place preserves their recovery value without leaving plaintext on disk
+        for (File backupsDir : FileUtil.getRollingBackupDirs(storageDir)) encryptResidualPlaintext(backupsDir, masterKey);
+        encryptResidualPlaintext(new File(storageDir, FileUtil.CORRUPTED_BACKUP_FOLDER), masterKey);
+    }
+
+    public static boolean hasInventory(File storageDir) {
+        return inventoryFile(storageDir).exists();
+    }
+
+    private static void encryptResidualPlaintext(File dir, SecretKey masterKey) throws IOException {
+        if (!dir.exists()) return;
+        File[] files = dir.listFiles();
+        // fail closed: an uninspectable directory must abort the migration, not be skipped
+        if (files == null) throw new IOException("Could not list directory " + dir.getAbsolutePath());
+        for (File file : files) {
+            if (!file.isFile() || file.length() == 0 || file.getName().endsWith(".tmp")) continue;
+            if (isEncrypted(file, masterKey)) continue;
+            log.info("Encrypting residual plaintext file {}", file.getName());
+            try {
+                // streamed so a large backup cannot exhaust the heap
+                File tempFile = new File(dir, file.getName() + ".tmp");
+                try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                    Encryption.encryptV2ToStream(out -> {
+                        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+                            in.transferTo(out);
+                        }
+                    }, masterKey, fos);
+                    fos.flush();
+                    fos.getFD().sync();
+                }
+                FileUtil.atomicReplace(tempFile, file);
+            } catch (IOException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new IOException("Could not encrypt residual plaintext file " + file.getName(), e);
+            }
+        }
+    }
+
+    /**
+     * Returns the recorded pre-migration content hash for a store, or null if not recorded.
+     */
+    public static synchronized byte[] getRecordedHash(File storageDir, String fileName, SecretKey masterKey) {
+        Map<String, String> entries = read(storageDir, masterKey);
+        String hash = entries == null ? null : entries.get(fileName);
+        return hash == null ? null : HexFormat.of().parseHex(hash);
+    }
+
+    /**
+     * Removes a store from the inventory after it was durably persisted in an encrypted format.
+     * The (possibly empty) inventory is rewritten, never deleted, and a failure propagates so the
+     * caller does not treat the write as complete while the old plaintext hash stays authorized.
+     */
+    public static synchronized void markMigrated(File storageDir, String fileName, SecretKey masterKey) throws IOException {
+        if (masterKey == null || !inventoryFile(storageDir).exists()) return;
+        Map<String, String> entries = read(storageDir, masterKey);
+        if (entries == null || entries.remove(fileName) == null) return;
+        write(storageDir, entries, masterKey);
+    }
+
+    private static File inventoryFile(File storageDir) {
+        return new File(storageDir, FILE_NAME);
+    }
+
+    // A file is already protected if it is a v2 blob or verifies as a legacy encrypted stream.
+    private static boolean isEncrypted(File file, SecretKey masterKey) {
+        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+            if (Encryption.blobVersion(in) > 0) return true;
+        } catch (IOException e) {
+            return false;
+        }
+        try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+            Encryption.verifyPayloadWithHmacStream(in, masterKey);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static byte[] sha256(File file) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
+                byte[] buf = new byte[64 * 1024];
+                int read;
+                while ((read = in.read(buf)) != -1) digest.update(buf, 0, read);
+            }
+            return digest.digest();
+        } catch (Exception e) {
+            throw new IOException("Could not hash " + file.getName(), e);
+        }
+    }
+
+    private static Map<String, String> read(File storageDir, SecretKey masterKey) {
+        File file = inventoryFile(storageDir);
+        if (masterKey == null || !file.exists()) return null;
+        try {
+            byte[] plain = Encryption.decryptV2(Files.readAllBytes(file.toPath()), masterKey);
+            Map<String, String> entries = new TreeMap<>();
+            for (String line : new String(plain, StandardCharsets.UTF_8).split("\n")) {
+                if (line.isEmpty()) continue;
+                int sep = line.indexOf(' ');
+                entries.put(line.substring(sep + 1), line.substring(0, sep));
+            }
+            return entries;
+        } catch (Exception e) {
+            log.error("Could not read plaintext migration inventory; treating as absent", e);
+            return null;
+        }
+    }
+
+    private static void write(File storageDir, Map<String, String> entries, SecretKey masterKey) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            sb.append(entry.getValue()).append(' ').append(entry.getKey()).append('\n');
+        }
+        try {
+            byte[] blob = Encryption.encryptV2(sb.toString().getBytes(StandardCharsets.UTF_8), masterKey);
+            File tempFile = new File(storageDir, FILE_NAME + ".tmp");
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                fos.write(blob);
+                fos.flush();
+                fos.getFD().sync();
+            }
+            FileUtil.atomicReplace(tempFile, inventoryFile(storageDir));
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Could not write plaintext migration inventory", e);
+        }
+    }
+}

--- a/common/src/test/java/haveno/common/crypto/EncryptionV2Test.java
+++ b/common/src/test/java/haveno/common/crypto/EncryptionV2Test.java
@@ -1,0 +1,199 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.crypto;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Random;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EncryptionV2Test {
+
+    // Sizes around AES block (16) and stream chunk (64 KiB) boundaries, plus an empty payload.
+    private static final int[] SIZES = {0, 1, 15, 16, 17, 1000, 65_535, 65_536, 65_537, 100_000, 5_000_000};
+
+    @Test
+    public void testRoundTrip() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        Random random = new Random(1234);
+        for (int size : SIZES) {
+            byte[] payload = new byte[size];
+            random.nextBytes(payload);
+            byte[] blob = Encryption.encryptV2(payload, key);
+            assertTrue(Encryption.isV2Format(blob));
+            assertArrayEquals(payload, Encryption.decryptV2(blob, key), "round-trip failed for size " + size);
+            assertArrayEquals(payload, Encryption.decryptAuto(blob, key));
+            assertArrayEquals(payload, Encryption.decryptPayloadWithHmacAuto(blob, key));
+        }
+    }
+
+    @Test
+    public void testBlobVersionDetection() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        byte[] v2 = Encryption.encryptV2("hello".getBytes(), key);
+        assertEquals(Encryption.CURRENT_BLOB_VERSION, Encryption.blobVersion(v2), "fresh blobs must detect as the current format");
+        assertEquals(0, Encryption.blobVersion(Encryption.encrypt(new byte[16], key)), "legacy blobs must detect as version 0");
+        assertEquals(0, Encryption.blobVersion(new byte[0]));
+        assertEquals(0, Encryption.blobVersion((byte[]) null));
+    }
+
+    @Test
+    public void testCiphertextIsNonDeterministic() throws CryptoException {
+        // Same payload and key must never produce the same blob (random IV), unlike legacy ECB.
+        SecretKey key = Encryption.generateSecretKey(256);
+        byte[] payload = new byte[1000];
+        assertFalse(Arrays.equals(Encryption.encryptV2(payload, key), Encryption.encryptV2(payload, key)));
+    }
+
+    @Test
+    public void testNoEcbBlockPatterns() throws CryptoException {
+        // A payload of identical 16-byte blocks must not produce identical ciphertext blocks.
+        SecretKey key = Encryption.generateSecretKey(256);
+        byte[] payload = new byte[64];
+        Arrays.fill(payload, (byte) 0x42);
+        byte[] blob = Encryption.encryptV2(payload, key);
+        byte[] block0 = Arrays.copyOfRange(blob, 20, 36);
+        byte[] block1 = Arrays.copyOfRange(blob, 36, 52);
+        assertFalse(Arrays.equals(block0, block1));
+    }
+
+    @Test
+    public void testTamperDetection() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        byte[] payload = new byte[1000];
+        new Random(42).nextBytes(payload);
+        byte[] blob = Encryption.encryptV2(payload, key);
+        // Flip one bit in the IV, ciphertext and tag regions.
+        for (int pos : new int[]{5, blob.length / 2, blob.length - 1}) {
+            byte[] tampered = blob.clone();
+            tampered[pos] ^= 0x01;
+            assertThrows(CryptoException.class, () -> Encryption.decryptV2(tampered, key), "tamper at " + pos + " not detected");
+        }
+        // Truncation.
+        byte[] truncated = Arrays.copyOf(blob, blob.length - 1);
+        assertThrows(CryptoException.class, () -> Encryption.decryptV2(truncated, key));
+    }
+
+    @Test
+    public void testWrongKeyFails() throws CryptoException {
+        byte[] blob = Encryption.encryptV2(new byte[100], Encryption.generateSecretKey(256));
+        assertThrows(CryptoException.class, () -> Encryption.decryptV2(blob, Encryption.generateSecretKey(256)));
+    }
+
+    @Test
+    public void testLegacyBlobsStillDecryptViaAutoDetect() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        byte[] payload = new byte[1000];
+        new Random(7).nextBytes(payload);
+
+        byte[] legacyRaw = Encryption.encrypt(payload, key);
+        assertFalse(Encryption.isV2Format(legacyRaw));
+        assertArrayEquals(payload, Encryption.decryptAuto(legacyRaw, key));
+
+        byte[] legacyWithHmac = Encryption.encryptPayloadWithHmac(payload, key);
+        assertFalse(Encryption.isV2Format(legacyWithHmac));
+        assertArrayEquals(payload, Encryption.decryptPayloadWithHmacAuto(legacyWithHmac, key));
+    }
+
+    @Test
+    public void testStreamWriteReadRoundTrip() throws CryptoException, IOException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        Random random = new Random(4321);
+        for (int size : SIZES) {
+            byte[] payload = new byte[size];
+            random.nextBytes(payload);
+
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            Encryption.encryptV2ToStream(out -> {
+                for (int off = 0; off < payload.length; off += 4096) {
+                    out.write(payload, off, Math.min(4096, payload.length - off));
+                }
+            }, key, bos);
+            byte[] blob = bos.toByteArray();
+
+            // Stream-written blobs are one-shot decryptable and vice versa.
+            assertArrayEquals(payload, Encryption.decryptV2(blob, key), "stream blob one-shot decrypt failed for size " + size);
+            long payloadLen = Encryption.verifyV2Stream(new ByteArrayInputStream(blob), key);
+            assertEquals(size, payloadLen);
+            try (InputStream in = Encryption.decryptV2Stream(new ByteArrayInputStream(blob), key)) {
+                assertArrayEquals(payload, in.readAllBytes(), "streamed decrypt failed for size " + size);
+            }
+
+            byte[] oneShot = Encryption.encryptV2(payload, key);
+            assertEquals(size, Encryption.verifyV2Stream(new ByteArrayInputStream(oneShot), key));
+            try (InputStream in = Encryption.decryptV2Stream(new ByteArrayInputStream(oneShot), key)) {
+                assertArrayEquals(payload, in.readAllBytes());
+            }
+        }
+    }
+
+    @Test
+    public void testStreamTamperDetection() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        byte[] payload = new byte[100_000];
+        new Random(9).nextBytes(payload);
+        byte[] blob = Encryption.encryptV2(payload, key);
+        byte[] tampered = blob.clone();
+        tampered[tampered.length / 2] ^= 0x01;
+
+        assertThrows(CryptoException.class, () -> Encryption.verifyV2Stream(new ByteArrayInputStream(tampered), key));
+        // Pass-2 stream must also fail on its own before signaling EOF.
+        assertThrows(IOException.class, () -> {
+            try (InputStream in = Encryption.decryptV2Stream(new ByteArrayInputStream(tampered), key)) {
+                in.readAllBytes();
+            }
+        });
+    }
+
+    @Test
+    public void testStreamCloseBeforeAuthenticationThrows() throws Exception {
+        SecretKey key = Encryption.generateSecretKey(256);
+        byte[] blob = Encryption.encryptV2(new byte[100_000], key);
+        InputStream in = Encryption.decryptV2Stream(new ByteArrayInputStream(blob), key);
+        assertEquals(1000, in.read(new byte[1000]));
+        // partially consumed plaintext is unauthenticated, so an early close must fail loudly
+        assertThrows(IOException.class, in::close);
+    }
+
+    @Test
+    public void testStreamDoesNotCloseOutputStream() throws CryptoException {
+        SecretKey key = Encryption.generateSecretKey(256);
+        TrackingOutputStream out = new TrackingOutputStream();
+        Encryption.encryptV2ToStream(o -> o.write(new byte[1000]), key, out);
+        assertFalse(out.closed, "stream must not be closed by the helper");
+    }
+
+    private static class TrackingOutputStream extends ByteArrayOutputStream {
+        boolean closed = false;
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/common/src/test/java/haveno/common/crypto/KeyStorageTest.java
+++ b/common/src/test/java/haveno/common/crypto/KeyStorageTest.java
@@ -17,6 +17,7 @@
 
 package haveno.common.crypto;
 
+import haveno.common.file.FileUtil;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
@@ -24,6 +25,7 @@ import java.nio.file.Files;
 import java.security.KeyStore;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Arrays;
+import java.util.List;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,6 +60,60 @@ public class KeyStorageTest {
     }
 
     @Test
+    public void testCorruptSymKeyRecoveredFromBackup(@TempDir File dir) throws Exception {
+        KeyRing keyRing = new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        byte[] symKeyBytes = keyRing.getSymmetricKey().getEncoded();
+        assertFalse(FileUtil.getBackupFiles(dir, "sym.key").isEmpty());
+
+        // flip a byte inside the wrapped blob; unlock must recover from the backup, not report
+        // an incorrect password
+        File symFile = new File(dir, "sym.key");
+        byte[] corrupt = Files.readAllBytes(symFile.toPath());
+        corrupt[corrupt.length - 1] ^= 0x01;
+        Files.write(symFile.toPath(), corrupt);
+
+        KeyRing recovered = new KeyRing(new KeyStorage(dir), PASSWORD, false);
+        assertTrue(recovered.isUnlocked());
+        assertArrayEquals(symKeyBytes, recovered.getSymmetricKey().getEncoded());
+        assertFalse(Arrays.equals(corrupt, Files.readAllBytes(symFile.toPath()))); // live file restored
+
+        // structural corruption (truncation) recovers too, not only authentication failures
+        byte[] good = Files.readAllBytes(symFile.toPath());
+        Files.write(symFile.toPath(), Arrays.copyOf(good, 74));
+        KeyRing recoveredAgain = new KeyRing(new KeyStorage(dir), PASSWORD, false);
+        assertArrayEquals(symKeyBytes, recoveredAgain.getSymmetricKey().getEncoded());
+
+        // a wrong password still fails with backups present
+        assertThrows(IncorrectPasswordException.class,
+                () -> new KeyStorage(dir).loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, "wrong password"));
+    }
+
+    @Test
+    public void testFreshAccountPreservesAnotherAccountsKeyMaterial(@TempDir File dir) throws Exception {
+        // an account whose sig.key was lost (e.g. crash, av quarantine) becomes unopenable and
+        // triggers a silent fresh account creation; the lost account's surviving live files and
+        // backups may be its only remaining key copies, so they move to a lost_account folder
+        // where the new account's saves, password changes and backup rotation can never purge them
+        KeyRing lostKeyRing = new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        byte[] lostSymKey = lostKeyRing.getSymmetricKey().getEncoded();
+        assertFalse(FileUtil.getBackupFiles(dir, "sym.key").isEmpty());
+        assertTrue(new File(dir, "sig.key").delete());
+        assertFalse(new KeyStorage(dir).allKeyFilesExist());
+
+        new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        File[] preserved = dir.listFiles((d, name) -> name.startsWith("lost_account_"));
+        assertNotNull(preserved);
+        assertEquals(1, preserved.length);
+        // the lost account's live wrapper still unlocks from the preserved folder
+        KeyStorage preservedStorage = new KeyStorage(preserved[0]);
+        assertArrayEquals(lostSymKey, preservedStorage.loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, PASSWORD).getEncoded());
+        assertTrue(new File(preserved[0], "backup").isDirectory());
+        // the fresh account works and has its own backups
+        assertTrue(new KeyRing(new KeyStorage(dir), PASSWORD, false).isUnlocked());
+        assertFalse(FileUtil.getBackupFiles(dir, "sym.key").isEmpty());
+    }
+
+    @Test
     public void testWrongPasswordThrows(@TempDir File dir) throws Exception {
         new KeyRing(new KeyStorage(dir), PASSWORD, true);
         KeyStorage keyStorage = new KeyStorage(dir);
@@ -78,6 +135,8 @@ public class KeyStorageTest {
     @Test
     public void testCorruptKeyFileIsNotReportedAsIncorrectPassword(@TempDir File dir) throws Exception {
         new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        // remove the backups so recovery cannot mask the classification
+        FileUtil.deleteRollingBackup(dir, "sym.key");
         File symFile = new File(dir, "sym.key");
         byte[] bytes = Files.readAllBytes(symFile.toPath());
         // keep the header but mangle the wrapped blob below its minimum valid length
@@ -119,6 +178,8 @@ public class KeyStorageTest {
     @Test
     public void testTamperedKdfHeaderIsRejectedBeforeDerivation(@TempDir File dir) throws Exception {
         new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        // remove the backups so recovery cannot mask the rejection
+        FileUtil.deleteRollingBackup(dir, "sym.key");
 
         // inflate the mem cost field (offset 6: magic 4 + version 1 + kdf 1) far beyond the bound
         File symFile = new File(dir, "sym.key");
@@ -135,6 +196,8 @@ public class KeyStorageTest {
     @Test
     public void testOversizedKeyFileIsRejectedBeforeReading(@TempDir File dir) throws Exception {
         new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        // remove the backups so recovery cannot mask the rejection
+        FileUtil.deleteRollingBackup(dir, "sym.key");
 
         File symFile = new File(dir, "sym.key");
         byte[] padded = Arrays.copyOf(Files.readAllBytes(symFile.toPath()), 64 * 1024);
@@ -173,6 +236,13 @@ public class KeyStorageTest {
         assertFalse(new File(dir, "sym.p12").exists());
         assertTrue(Encryption.isV2Format(Files.readAllBytes(new File(dir, "sig.key").toPath())));
         assertTrue(Encryption.isV2Format(Files.readAllBytes(new File(dir, "enc.key").toPath())));
+
+        // legacy-format backups of the key files are replaced by v2 backups
+        for (String name : new String[]{"sig.key", "enc.key"}) {
+            List<File> backups = FileUtil.getBackupFiles(dir, name);
+            assertFalse(backups.isEmpty());
+            for (File backup : backups) assertTrue(Encryption.isV2Format(Files.readAllBytes(backup.toPath())));
+        }
 
         // and the migrated keyring reopens with the same keys
         KeyRing reopened = new KeyRing(new KeyStorage(dir), PASSWORD, false);

--- a/common/src/test/java/haveno/common/crypto/KeyStorageTest.java
+++ b/common/src/test/java/haveno/common/crypto/KeyStorageTest.java
@@ -1,0 +1,190 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.crypto;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.security.KeyStore;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Arrays;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KeyStorageTest {
+
+    private static final String PASSWORD = "correct horse battery";
+
+    @Test
+    public void testGenerateAndReopenWithPassword(@TempDir File dir) throws Exception {
+        KeyStorage keyStorage = new KeyStorage(dir);
+        KeyRing keyRing = new KeyRing(keyStorage, PASSWORD, true);
+        assertTrue(keyRing.isUnlocked());
+
+        // new accounts are written in the v2 format only
+        assertTrue(new File(dir, "sym.key").exists());
+        assertFalse(new File(dir, "sym.p12").exists());
+        assertTrue(Encryption.isV2Format(Files.readAllBytes(new File(dir, "sig.key").toPath())));
+        assertTrue(Encryption.isV2Format(Files.readAllBytes(new File(dir, "enc.key").toPath())));
+
+        KeyRing reopened = new KeyRing(new KeyStorage(dir), PASSWORD, false);
+        assertTrue(reopened.isUnlocked());
+        assertEquals(keyRing.getPubKeyRing(), reopened.getPubKeyRing());
+        assertArrayEquals(keyRing.getSymmetricKey().getEncoded(), reopened.getSymmetricKey().getEncoded());
+    }
+
+    @Test
+    public void testWrongPasswordThrows(@TempDir File dir) throws Exception {
+        new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        KeyStorage keyStorage = new KeyStorage(dir);
+        assertThrows(IncorrectPasswordException.class,
+                () -> keyStorage.loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, "wrong password"));
+        assertThrows(IncorrectPasswordException.class,
+                () -> keyStorage.loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, null));
+    }
+
+    @Test
+    public void testNullPasswordAccount(@TempDir File dir) {
+        KeyRing keyRing = new KeyRing(new KeyStorage(dir), null, true);
+        assertTrue(keyRing.isUnlocked());
+        KeyRing reopened = new KeyRing(new KeyStorage(dir), null, false);
+        assertTrue(reopened.isUnlocked());
+        assertEquals(keyRing.getPubKeyRing(), reopened.getPubKeyRing());
+    }
+
+    @Test
+    public void testCorruptKeyFileIsNotReportedAsIncorrectPassword(@TempDir File dir) throws Exception {
+        new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        File symFile = new File(dir, "sym.key");
+        byte[] bytes = Files.readAllBytes(symFile.toPath());
+        // keep the header but mangle the wrapped blob below its minimum valid length
+        Files.write(symFile.toPath(), java.util.Arrays.copyOf(bytes, 74));
+        KeyStorage keyStorage = new KeyStorage(dir);
+        // must surface as corruption (RuntimeException), not IncorrectPasswordException (a checked exception)
+        assertThrows(RuntimeException.class,
+                () -> keyStorage.loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, PASSWORD));
+    }
+
+    @Test
+    public void testBackupsSurviveFailedUnlockAttempts(@TempDir File dir) throws Exception {
+        new KeyRing(new KeyStorage(dir), PASSWORD, true);
+        // saving keeps a fresh backup so the wrapped key never exists as a single copy
+        File backupDir = new File(dir, "backup/backups_sym_key");
+        assertEquals(1, backupDir.listFiles().length);
+
+        // failed unlock attempts must not rotate more copies into the backups (a corrupt key file
+        // could otherwise churn out every good backup over repeated password retries)
+        KeyStorage keyStorage = new KeyStorage(dir);
+        for (int i = 0; i < 3; i++) {
+            assertThrows(IncorrectPasswordException.class,
+                    () -> keyStorage.loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, "wrong password"));
+        }
+        assertEquals(1, backupDir.listFiles().length);
+    }
+
+    @Test
+    public void testUnicodePasswordIsNormalized(@TempDir File dir) throws Exception {
+        // NFD (e + combining acute) and NFC (precomposed) forms must derive the same key
+        String nfd = "cafe\u0301 password";
+        String nfc = "caf\u00e9 password";
+        new KeyRing(new KeyStorage(dir), nfd, true);
+
+        KeyRing reopened = new KeyRing(new KeyStorage(dir), nfc, false);
+        assertTrue(reopened.isUnlocked());
+    }
+
+    @Test
+    public void testTamperedKdfHeaderIsRejectedBeforeDerivation(@TempDir File dir) throws Exception {
+        new KeyRing(new KeyStorage(dir), PASSWORD, true);
+
+        // inflate the mem cost field (offset 6: magic 4 + version 1 + kdf 1) far beyond the bound
+        File symFile = new File(dir, "sym.key");
+        byte[] bytes = Files.readAllBytes(symFile.toPath());
+        ByteBuffer.wrap(bytes).putInt(6, Integer.MAX_VALUE);
+        Files.write(symFile.toPath(), bytes);
+
+        KeyStorage keyStorage = new KeyStorage(dir);
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> keyStorage.loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, PASSWORD));
+        assertTrue(e.getCause().getMessage().contains("KDF parameters out of bounds"));
+    }
+
+    @Test
+    public void testOversizedKeyFileIsRejectedBeforeReading(@TempDir File dir) throws Exception {
+        new KeyRing(new KeyStorage(dir), PASSWORD, true);
+
+        File symFile = new File(dir, "sym.key");
+        byte[] padded = Arrays.copyOf(Files.readAllBytes(symFile.toPath()), 64 * 1024);
+        Files.write(symFile.toPath(), padded);
+
+        KeyStorage keyStorage = new KeyStorage(dir);
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> keyStorage.loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, PASSWORD));
+        assertTrue(e.getCause().getMessage().contains("too large"));
+    }
+
+    @Test
+    public void testLegacyFormatMigratesOnUnlock(@TempDir File dir) throws Exception {
+        // write a keyring in the legacy format: PKCS#12 sym.p12 + AES-ECB-with-hmac key files
+        SecretKey symKey = Encryption.generateSecretKey(256);
+        var sigPair = Sig.generateKeyPair();
+        var encPair = Encryption.generateKeyPair();
+
+        char[] passwordChars = PASSWORD.toCharArray();
+        KeyStore p12 = KeyStore.getInstance("PKCS12");
+        p12.load(null, null);
+        p12.setKeyEntry("sym", symKey, passwordChars, null);
+        try (FileOutputStream fos = new FileOutputStream(new File(dir, "sym.p12"))) {
+            p12.store(fos, passwordChars);
+        }
+        writeLegacyKeyFile(dir, "sig.key", sigPair.getPrivate().getEncoded(), symKey);
+        writeLegacyKeyFile(dir, "enc.key", encPair.getPrivate().getEncoded(), symKey);
+
+        // unlocking migrates to v2 and removes the PKCS#12 file
+        KeyRing keyRing = new KeyRing(new KeyStorage(dir), PASSWORD, false);
+        assertTrue(keyRing.isUnlocked());
+        assertArrayEquals(symKey.getEncoded(), keyRing.getSymmetricKey().getEncoded());
+        assertEquals(sigPair.getPublic(), keyRing.getSignatureKeyPair().getPublic());
+        assertEquals(encPair.getPublic(), keyRing.getEncryptionKeyPair().getPublic());
+        assertTrue(new File(dir, "sym.key").exists());
+        assertFalse(new File(dir, "sym.p12").exists());
+        assertTrue(Encryption.isV2Format(Files.readAllBytes(new File(dir, "sig.key").toPath())));
+        assertTrue(Encryption.isV2Format(Files.readAllBytes(new File(dir, "enc.key").toPath())));
+
+        // and the migrated keyring reopens with the same keys
+        KeyRing reopened = new KeyRing(new KeyStorage(dir), PASSWORD, false);
+        assertTrue(reopened.isUnlocked());
+        assertEquals(keyRing.getPubKeyRing(), reopened.getPubKeyRing());
+        assertArrayEquals(symKey.getEncoded(), reopened.getSymmetricKey().getEncoded());
+    }
+
+    private static void writeLegacyKeyFile(File dir, String fileName, byte[] privateKeyEncoded, SecretKey symKey) throws Exception {
+        byte[] pkcs8 = new PKCS8EncodedKeySpec(privateKeyEncoded).getEncoded();
+        try (FileOutputStream fos = new FileOutputStream(new File(dir, fileName))) {
+            fos.write(Encryption.encryptPayloadWithHmac(pkcs8, symKey));
+        }
+    }
+}

--- a/common/src/test/java/haveno/common/file/FileUtilTest.java
+++ b/common/src/test/java/haveno/common/file/FileUtilTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.common.file;
+
+import haveno.common.util.Utilities;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Set;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FileUtilTest {
+
+    @Test
+    public void testUnlistableBackupDirsFailClosed(@TempDir File dir) throws Exception {
+        Assumptions.assumeFalse(Utilities.isWindows()); // POSIX permissions
+
+        File backupRoot = new File(dir, "backup");
+        File backupsDir = new File(backupRoot, "backups_test");
+        assertTrue(backupsDir.mkdirs());
+        Files.write(new File(backupsDir, "1_test").toPath(), new byte[]{1});
+        assertTrue(FileUtil.hasBackups(dir, "test"));
+
+        // an unlistable, still-populated directory must count as present, not empty
+        assertTrue(backupsDir.setReadable(false));
+        Assumptions.assumeTrue(backupsDir.listFiles() == null, "permissions not enforced (running as root?)");
+        try {
+            assertTrue(FileUtil.hasBackups(dir, "test"));
+        } finally {
+            assertTrue(backupsDir.setReadable(true));
+        }
+
+        // and an unlistable backup root must fail the sweep instead of reporting success
+        assertTrue(backupRoot.setReadable(false));
+        try {
+            assertThrows(IOException.class, () -> FileUtil.getRollingBackupDirsExcept(dir, Set.of()));
+        } finally {
+            assertTrue(backupRoot.setReadable(true));
+        }
+
+        FileUtil.deleteRollingBackup(dir, "test");
+        assertFalse(FileUtil.hasBackups(dir, "test"));
+    }
+}

--- a/common/src/test/java/haveno/common/persistence/EncryptedAppendLogTest.java
+++ b/common/src/test/java/haveno/common/persistence/EncryptedAppendLogTest.java
@@ -121,6 +121,44 @@ public class EncryptedAppendLogTest {
     }
 
     @Test
+    public void testOversizedFrameLengthIsCorruption() throws Exception {
+        EncryptedAppendLog log = newLog();
+        log.append(rec("alpha"));
+
+        // a length prefix beyond the frame bound is corruption (backup + truncate), never a huge allocation
+        File logFile = new File(dir, "Test.log");
+        long validLength = logFile.length();
+        try (RandomAccessFile raf = new RandomAccessFile(logFile, "rw")) {
+            raf.seek(raf.length());
+            raf.writeInt(Integer.MAX_VALUE);
+            raf.write(new byte[100]);
+        }
+
+        assertRecords(List.of("alpha"), newLog().readAllValidRecords());
+        assertEquals(validLength, logFile.length());
+        assertEquals(1, corruptedBackupCount());
+    }
+
+    @Test
+    public void testShortLegacyFrameIsCorruption() throws Exception {
+        EncryptedAppendLog log = newLog();
+        log.append(rec("alpha"));
+
+        // a legacy-encrypted frame whose plaintext is too short to hold an hmac must classify as
+        // corruption (backup + truncate), not abort replay with an unchecked range error
+        byte[] shortLegacy = Encryption.encrypt(rec("tiny"), key);
+        File logFile = new File(dir, "Test.log");
+        try (RandomAccessFile raf = new RandomAccessFile(logFile, "rw")) {
+            raf.seek(raf.length());
+            raf.writeInt(shortLegacy.length);
+            raf.write(shortLegacy);
+        }
+
+        assertRecords(List.of("alpha"), newLog().readAllValidRecords());
+        assertEquals(1, corruptedBackupCount());
+    }
+
+    @Test
     public void testTornTailIsTruncatedAndPrefixKept() throws Exception {
         EncryptedAppendLog log = newLog();
         List<String> full = List.of("one", "two", "three");
@@ -265,5 +303,42 @@ public class EncryptedAppendLogTest {
         List<byte[]> read = wrongKeyLog.readAllValidRecords();
         assertTrue(read.isEmpty(), "no records should be recovered with the wrong key");
         assertEquals(1, corruptedBackupCount(), "undecryptable log must be backed up");
+    }
+
+    @Test
+    public void testLegacyFramesAreReadAndRewrittenInCurrentFormat() throws Exception {
+        // Write a log with legacy (AES-ECB + HMAC) frames, followed by one v2 frame.
+        List<String> expected = List.of("legacy-a", "legacy-b", "v2-c");
+        File logFile = new File(dir, "Test.log");
+        try (var fos = new java.io.FileOutputStream(logFile);
+             var out = new java.io.DataOutputStream(fos)) {
+            for (String s : List.of("legacy-a", "legacy-b")) {
+                byte[] ciphertext = Encryption.encryptPayloadWithHmac(rec(s), key);
+                out.writeInt(ciphertext.length);
+                out.write(ciphertext);
+            }
+            byte[] ciphertext = Encryption.encryptV2(rec("v2-c"), key);
+            out.writeInt(ciphertext.length);
+            out.write(ciphertext);
+        }
+
+        // Replay returns all records and upgrades the file to the current format.
+        assertRecords(expected, newLog().readAllValidRecords());
+        byte[] bytes = Files.readAllBytes(logFile.toPath());
+        int offset = 0;
+        int frames = 0;
+        while (offset < bytes.length) {
+            int len = ((bytes[offset] & 0xff) << 24) | ((bytes[offset + 1] & 0xff) << 16)
+                    | ((bytes[offset + 2] & 0xff) << 8) | (bytes[offset + 3] & 0xff);
+            byte[] frame = new byte[len];
+            System.arraycopy(bytes, offset + 4, frame, 0, len);
+            assertTrue(Encryption.isV2Format(frame), "frame " + frames + " not upgraded to v2");
+            offset += 4 + len;
+            frames++;
+        }
+        assertEquals(3, frames);
+
+        // And the upgraded log still reads back the same records.
+        assertRecords(expected, newLog().readAllValidRecords());
     }
 }

--- a/common/src/test/java/haveno/common/persistence/EncryptedAppendLogTest.java
+++ b/common/src/test/java/haveno/common/persistence/EncryptedAppendLogTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EncryptedAppendLogTest {
@@ -248,7 +249,10 @@ public class EncryptedAppendLogTest {
         assertRecords(List.of("keep-1", "keep-2"), newLog().readAllValidRecords());
         assertEquals(1, corruptedBackupCount(), "dropped bytes must be preserved in a backup copy");
         File[] backups = new File(dir, "backup_of_corrupted_data").listFiles((d, name) -> name.endsWith("_Test.log"));
-        assertEquals(originalLength, backups[0].length(), "backup must contain the full pre-truncation file");
+        // the quarantined copy is wrapped in the current format; unwrapped it is the full original
+        byte[] unwrapped = Encryption.decryptV2(Files.readAllBytes(backups[0].toPath()), key);
+        assertEquals(originalLength, unwrapped.length, "backup must contain the full pre-truncation file");
+        assertArrayEquals(bytes, unwrapped);
     }
 
     @Test
@@ -340,5 +344,106 @@ public class EncryptedAppendLogTest {
 
         // And the upgraded log still reads back the same records.
         assertRecords(expected, newLog().readAllValidRecords());
+    }
+
+    @Test
+    public void testLegacyBackupsPurgedAfterFrameUpgrade() throws Exception {
+        // legacy-framed log plus planted rolling backups: one all-legacy, one mixed with a
+        // current-format first frame hiding a later legacy frame
+        byte[] legacyFrame = Encryption.encryptPayloadWithHmac(rec("legacy-a"), key);
+        java.io.ByteArrayOutputStream framed = new java.io.ByteArrayOutputStream();
+        try (var out = new java.io.DataOutputStream(framed)) {
+            out.writeInt(legacyFrame.length);
+            out.write(legacyFrame);
+        }
+        java.io.ByteArrayOutputStream mixed = new java.io.ByteArrayOutputStream();
+        try (var out = new java.io.DataOutputStream(mixed)) {
+            byte[] v2Frame = Encryption.encryptV2(rec("v2-a"), key);
+            out.writeInt(v2Frame.length);
+            out.write(v2Frame);
+            out.writeInt(legacyFrame.length);
+            out.write(legacyFrame);
+        }
+        Files.write(new File(dir, "Test.log").toPath(), framed.toByteArray());
+        File backupsDir = new File(dir, "backup/backups_Test_log");
+        assertTrue(backupsDir.mkdirs());
+        Files.write(new File(backupsDir, "111_Test.log").toPath(), framed.toByteArray());
+        Files.write(new File(backupsDir, "112_Test.log").toPath(), mixed.toByteArray());
+
+        assertRecords(List.of("legacy-a"), newLog().readAllValidRecords());
+
+        // the legacy-format backups are gone; what remains is the current-format backup
+        List<File> backups = FileUtil.getBackupFiles(dir, "Test.log");
+        assertFalse(backups.isEmpty());
+        for (File backup : backups) {
+            byte[] bytes = Files.readAllBytes(backup.toPath());
+            byte[] frame = new byte[frameOffset(bytes, 1) - 4];
+            System.arraycopy(bytes, 4, frame, 0, frame.length);
+            assertTrue(Encryption.isV2Format(frame), "backup holds a legacy frame: " + backup.getName());
+        }
+    }
+
+    @Test
+    public void testTornCurrentBackupDoesNotStandInAsSafetyCopy() throws Exception {
+        // a legacy backup plus a torn current-format backup (one valid frame, then a partial
+        // length prefix from an interrupted copy): the tear must classify as malformed, so the
+        // purge still takes a fresh complete backup before deleting the legacy generation
+        byte[] legacyFrame = Encryption.encryptPayloadWithHmac(rec("legacy-a"), key);
+        java.io.ByteArrayOutputStream framed = new java.io.ByteArrayOutputStream();
+        try (var out = new java.io.DataOutputStream(framed)) {
+            out.writeInt(legacyFrame.length);
+            out.write(legacyFrame);
+        }
+        Files.write(new File(dir, "Test.log").toPath(), framed.toByteArray());
+        java.io.ByteArrayOutputStream torn = new java.io.ByteArrayOutputStream();
+        try (var out = new java.io.DataOutputStream(torn)) {
+            byte[] v2Frame = Encryption.encryptV2(rec("v2-a"), key);
+            out.writeInt(v2Frame.length);
+            out.write(v2Frame);
+            out.write(new byte[]{0, 0}); // partial length prefix of a lost second frame
+        }
+        File backupsDir = new File(dir, "backup/backups_Test_log");
+        assertTrue(backupsDir.mkdirs());
+        Files.write(new File(backupsDir, "111_Test.log").toPath(), framed.toByteArray());
+        File tornBackup = new File(backupsDir, "112_Test.log");
+        Files.write(tornBackup.toPath(), torn.toByteArray());
+
+        assertRecords(List.of("legacy-a"), newLog().readAllValidRecords());
+
+        // the legacy backup is gone, the torn copy is untouched, and a complete current-format
+        // backup of the upgraded log exists alongside it
+        assertFalse(new File(backupsDir, "111_Test.log").exists());
+        assertArrayEquals(torn.toByteArray(), Files.readAllBytes(tornBackup.toPath()));
+        boolean hasCompleteBackup = false;
+        for (File backup : FileUtil.getBackupFiles(dir, "Test.log")) {
+            if (backup.equals(tornBackup)) continue;
+            byte[] bytes = Files.readAllBytes(backup.toPath());
+            byte[] frame = new byte[frameOffset(bytes, 1) - 4];
+            System.arraycopy(bytes, 4, frame, 0, frame.length);
+            assertTrue(Encryption.isV2Format(frame));
+            assertEquals(frameOffset(bytes, 1), bytes.length, "backup must end on a frame boundary");
+            hasCompleteBackup = true;
+        }
+        assertTrue(hasCompleteBackup, "a fresh complete backup must exist before the legacy one is purged");
+    }
+
+    @Test
+    public void testRewriteEnforcesFrameBoundLikeAppend() throws Exception {
+        // v2 framing adds 52 bytes (magic + iv + hmac); the largest accepted plaintext round-trips
+        EncryptedAppendLog log = newLog();
+        byte[] largest = new byte[EncryptedAppendLog.MAX_FRAME_SIZE - 52];
+        new Random(42).nextBytes(largest);
+        log.rewrite(List.of(largest));
+        List<byte[]> read = newLog().readAllValidRecords();
+        assertEquals(1, read.size());
+        assertArrayEquals(largest, read.get(0));
+
+        // one byte more must be rejected by rewrite (as by append), not written and later
+        // classified as corrupt by the reader
+        byte[] oversize = new byte[EncryptedAppendLog.MAX_FRAME_SIZE - 51];
+        assertThrows(IllegalArgumentException.class, () -> log.rewrite(List.of(oversize)));
+        read = newLog().readAllValidRecords();
+        assertEquals(1, read.size());
+        assertArrayEquals(largest, read.get(0)); // existing log untouched
     }
 }

--- a/common/src/test/java/haveno/common/persistence/PersistenceManagerTest.java
+++ b/common/src/test/java/haveno/common/persistence/PersistenceManagerTest.java
@@ -218,7 +218,7 @@ public class PersistenceManagerTest {
     }
 
     @Test
-    public void testRecordedPlaintextStoreSurvivesRestartAfterKeyMigration() throws Exception {
+    public void testPlaintextStoreEncryptedAtKeyMigration() throws Exception {
         File appDir = File.createTempFile("persistence_test_restart", "");
         assertTrue(appDir.delete());
         File keysDir = new File(appDir, "keys");
@@ -239,13 +239,18 @@ public class PersistenceManagerTest {
                 data.toProtoMessage().writeDelimitedTo(fos);
             }
 
-            // the unlock records the store in the migration inventory before upgrading the keys
+            // the unlock encrypts the store in place and writes the marker before upgrading the keys
             KeyRing legacyKeyRing = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
             assertTrue(legacyKeyRing.isUnlocked());
-            assertTrue(new File(dbDir, PlaintextMigration.FILE_NAME).exists());
+            assertTrue(PlaintextMigration.hasMarker(dbDir));
             assertFalse(new File(keysDir, "sym.p12").exists());
+            byte[] head = new byte[4];
+            try (var fis = new java.io.FileInputStream(storageFile)) {
+                assertEquals(4, fis.read(head));
+            }
+            assertArrayEquals(Encryption.V2_MAGIC, head);
 
-            // simulate a crash before the store was rewritten: a fresh process loads only v2 keys
+            // a fresh process loads only v2 keys and reads the encrypted store
             KeyRing restarted = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
             assertTrue(restarted.isUnlocked());
             assertFalse(restarted.getKeyStorage().hasLegacyFormatEverLoaded());
@@ -253,14 +258,7 @@ public class PersistenceManagerTest {
             manager.initialize(data, "RestartStore", PersistenceManager.Source.PRIVATE);
             assertEquals(data, manager.getPersisted("RestartStore"));
 
-            // re-persisting encrypted removes the store from the inventory, so a plaintext
-            // replacement (even byte-identical to the original) is rejected afterwards
-            CountDownLatch latch = new CountDownLatch(1);
-            manager.persistNow(latch::countDown);
-            assertTrue(latch.await(15, TimeUnit.SECONDS), "write did not complete");
-            // the emptied inventory remains as a durable marker that migration ran
-            assertTrue(new File(dbDir, PlaintextMigration.FILE_NAME).exists());
-            assertBackupsAreEncrypted(dbDir, "RestartStore");
+            // a plaintext replacement (even byte-identical to the original) is rejected
             try (FileOutputStream fos = new FileOutputStream(storageFile)) {
                 data.toProtoMessage().writeDelimitedTo(fos);
             }
@@ -272,38 +270,34 @@ public class PersistenceManagerTest {
     }
 
     @Test
-    public void testTamperedRecordedPlaintextStoreIsRejected() throws Exception {
-        File appDir = File.createTempFile("persistence_test_tamper", "");
+    public void testInterruptedMigrationResumesOnNextUnlock() throws Exception {
+        File appDir = File.createTempFile("persistence_test_resume", "");
         assertTrue(appDir.delete());
         File keysDir = new File(appDir, "keys");
         File dbDir = new File(appDir, "db");
         assertTrue(keysDir.mkdirs());
         assertTrue(dbDir.mkdirs());
-        PersistenceManager<NavigationPath> manager = null;
         try {
             String password = "test password 123";
             SecretKey symKey = Encryption.generateSecretKey(256);
             writeLegacySymFile(keysDir, symKey, password);
             writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
             writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
-            NavigationPath data = largeNavigationPath();
-            File storageFile = new File(dbDir, "TamperStore");
-            try (FileOutputStream fos = new FileOutputStream(storageFile)) {
-                data.toProtoMessage().writeDelimitedTo(fos);
-            }
-            new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
 
-            // replacing the recorded store's content after the crash fails the recorded hash
-            NavigationPath forged = new NavigationPath(List.of("forged/entry"));
-            try (FileOutputStream fos = new FileOutputStream(storageFile)) {
-                forged.toProtoMessage().writeDelimitedTo(fos);
-            }
-            KeyRing restarted = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
-            manager = new PersistenceManager<>(dbDir, RESOLVER, null, restarted);
-            manager.initialize(data, "TamperStore", PersistenceManager.Source.PRIVATE);
-            assertNull(manager.getPersisted("TamperStore"));
+            // a crash mid-migration leaves one store encrypted, one still plaintext and no marker;
+            // the legacy key files were not replaced, so the next unlock resumes the migration
+            byte[] doneBytes = "already encrypted store".getBytes();
+            byte[] pendingBytes = "still plaintext store".getBytes();
+            File doneFile = new File(dbDir, "DoneStore");
+            File pendingFile = new File(dbDir, "PendingStore");
+            java.nio.file.Files.write(doneFile.toPath(), Encryption.encryptV2(doneBytes, symKey));
+            java.nio.file.Files.write(pendingFile.toPath(), pendingBytes);
+
+            new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertTrue(PlaintextMigration.hasMarker(dbDir));
+            assertArrayEquals(doneBytes, Encryption.decryptV2(java.nio.file.Files.readAllBytes(doneFile.toPath()), symKey));
+            assertArrayEquals(pendingBytes, Encryption.decryptV2(java.nio.file.Files.readAllBytes(pendingFile.toPath()), symKey));
         } finally {
-            if (manager != null) manager.shutdown();
             FileUtil.deleteDirectory(appDir);
         }
     }
@@ -329,14 +323,14 @@ public class PersistenceManagerTest {
                 data.toProtoMessage().writeDelimitedTo(fos);
             }
 
-            // the unlock records the inventory; the same process may read the recorded content
+            // the unlock encrypts the store in place; the same process reads it as v2
             KeyRing legacyKeyRing = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
             assertTrue(legacyKeyRing.getKeyStorage().hasLegacyFormatEverLoaded());
             manager = new PersistenceManager<>(dbDir, RESOLVER, null, legacyKeyRing);
             manager.initialize(data, "SameProcStore", PersistenceManager.Source.PRIVATE);
             assertEquals(data, manager.getPersisted("SameProcStore"));
 
-            // but a replacement written after the inventory is rejected even in the same process
+            // a plaintext replacement written after migration is rejected even in the same process
             NavigationPath forged = new NavigationPath(List.of("forged/entry"));
             try (FileOutputStream fos = new FileOutputStream(storageFile)) {
                 forged.toProtoMessage().writeDelimitedTo(fos);
@@ -400,7 +394,7 @@ public class PersistenceManagerTest {
             writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
             KeyRing keyRing = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
             assertTrue(keyRing.getKeyStorage().hasLegacyFormatEverLoaded());
-            assertTrue(new File(dbDir, PlaintextMigration.FILE_NAME).exists()); // empty inventory recorded
+            assertTrue(PlaintextMigration.hasMarker(dbDir)); // marker written
 
             // a plaintext store planted after the (empty) migration must be rejected
             NavigationPath data = largeNavigationPath();
@@ -417,6 +411,180 @@ public class PersistenceManagerTest {
     }
 
     @Test
+    public void testEncryptedFrameLogSurvivesMigration() throws Exception {
+        File appDir = File.createTempFile("persistence_test_framelog", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+
+            // a framed append-log with current frames plus a manually appended legacy frame
+            EncryptedAppendLog appendLog = new EncryptedAppendLog(dbDir, "Store.log", symKey, 1);
+            appendLog.append("record one".getBytes());
+            appendLog.append("record two".getBytes());
+            byte[] legacyCiphertext = Encryption.encryptPayloadWithHmac("record three".getBytes(), symKey);
+            try (java.io.DataOutputStream out = new java.io.DataOutputStream(new FileOutputStream(new File(dbDir, "Store.log"), true))) {
+                out.writeInt(legacyCiphertext.length);
+                out.write(legacyCiphertext);
+            }
+            byte[] plaintextBytes = "plaintext store".getBytes();
+            java.nio.file.Files.write(new File(dbDir, "PlainStore").toPath(), plaintextBytes);
+
+            // migration encrypts the plaintext store but must leave the framed log intact
+            new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertTrue(PlaintextMigration.hasMarker(dbDir));
+            assertArrayEquals(plaintextBytes, Encryption.decryptV2(java.nio.file.Files.readAllBytes(new File(dbDir, "PlainStore").toPath()), symKey));
+            List<byte[]> records = new EncryptedAppendLog(dbDir, "Store.log", symKey, 1).readAllValidRecords();
+            assertEquals(3, records.size());
+            assertArrayEquals("record three".getBytes(), records.get(2));
+        } finally {
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testDeletedMarkerDoesNotReenablePlaintextInProcess() throws Exception {
+        File appDir = File.createTempFile("persistence_test_marker", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        PersistenceManager<NavigationPath> manager = null;
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+            KeyRing keyRing = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertTrue(PlaintextMigration.hasMarker(dbDir));
+
+            // deleting the on-disk marker must not re-enable plaintext within this process
+            assertTrue(new File(dbDir, PlaintextMigration.FILE_NAME).delete());
+            assertTrue(PlaintextMigration.hasMarker(dbDir));
+            NavigationPath data = largeNavigationPath();
+            try (FileOutputStream fos = new FileOutputStream(new File(dbDir, "PlantedStore"))) {
+                data.toProtoMessage().writeDelimitedTo(fos);
+            }
+            manager = new PersistenceManager<>(dbDir, RESOLVER, null, keyRing);
+            manager.initialize(data, "PlantedStore", PersistenceManager.Source.PRIVATE);
+            assertNull(manager.getPersisted("PlantedStore"));
+        } finally {
+            if (manager != null) manager.shutdown();
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testLegacyEncryptedFilesReEncryptedAtMigration() throws Exception {
+        File appDir = File.createTempFile("persistence_test_rewrap", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+
+            byte[] payload = ((protobuf.PersistableEnvelope) largeNavigationPath().toProtoMessage()).toByteArray();
+            writeLegacyEncryptedFile(payload, symKey, new File(dbDir, "LegacyStore"));
+            File backupsDir = new File(dbDir, "backup/backups_LegacyStore");
+            assertTrue(backupsDir.mkdirs());
+            writeLegacyEncryptedFile(payload, symKey, new File(backupsDir, "123_LegacyStore"));
+
+            // a quarantined legacy frame log is never replayed again, so migration wraps it whole
+            File corruptedDir = new File(dbDir, "backup_of_corrupted_data");
+            assertTrue(corruptedDir.mkdirs());
+            byte[] legacyFrame = Encryption.encryptPayloadWithHmac("frame record".getBytes(), symKey);
+            File quarantined = new File(corruptedDir, "123_Old.log");
+            try (java.io.DataOutputStream out = new java.io.DataOutputStream(new FileOutputStream(quarantined))) {
+                out.writeInt(legacyFrame.length);
+                out.write(legacyFrame);
+            }
+            byte[] quarantinedRaw = java.nio.file.Files.readAllBytes(quarantined.toPath());
+
+            // legacy encrypted files (never re-persisted: backups, archives) upgrade at migration
+            new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertTrue(PlaintextMigration.hasMarker(dbDir));
+            for (File file : new File[]{new File(dbDir, "LegacyStore"), new File(backupsDir, "123_LegacyStore")}) {
+                byte[] bytes = java.nio.file.Files.readAllBytes(file.toPath());
+                assertEquals(Encryption.CURRENT_BLOB_VERSION, Encryption.blobVersion(bytes), file.getName());
+                assertArrayEquals(payload, Encryption.decryptV2(bytes, symKey), file.getName());
+            }
+            byte[] wrapped = java.nio.file.Files.readAllBytes(quarantined.toPath());
+            assertEquals(Encryption.CURRENT_BLOB_VERSION, Encryption.blobVersion(wrapped));
+            assertArrayEquals(quarantinedRaw, Encryption.decryptV2(wrapped, symKey));
+        } finally {
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testBogusMarkerDoesNotSkipMigration() throws Exception {
+        File appDir = File.createTempFile("persistence_test_bogusmarker", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+            byte[] plaintextBytes = "still plaintext store".getBytes();
+            File storeFile = new File(dbDir, "PlainStore");
+            java.nio.file.Files.write(storeFile.toPath(), plaintextBytes);
+
+            // a planted or corrupt marker must not skip the migration, which would replace the
+            // legacy keys and strand the plaintext store behind the plaintext rejection
+            java.nio.file.Files.write(new File(dbDir, PlaintextMigration.FILE_NAME).toPath(), "bogus".getBytes());
+            // an existence-only observation (as the plaintext gate makes) must not poison the
+            // verified latch that authorizes skipping the migration
+            assertTrue(PlaintextMigration.hasMarker(dbDir));
+
+            new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertArrayEquals(plaintextBytes, Encryption.decryptV2(java.nio.file.Files.readAllBytes(storeFile.toPath()), symKey));
+            // the marker was rewritten as an authenticated blob
+            Encryption.decryptV2(java.nio.file.Files.readAllBytes(new File(dbDir, PlaintextMigration.FILE_NAME).toPath()), symKey);
+        } finally {
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testResetClearsMigrationLatch() throws Exception {
+        File dbDir = File.createTempFile("persistence_test_latch_reset", "");
+        assertTrue(dbDir.delete());
+        assertTrue(dbDir.mkdirs());
+        try {
+            PlaintextMigration.migrate(dbDir, Encryption.generateSecretKey(256));
+            assertTrue(PlaintextMigration.hasMarker(dbDir));
+            assertTrue(new File(dbDir, PlaintextMigration.FILE_NAME).delete());
+            assertTrue(PlaintextMigration.hasMarker(dbDir)); // latched in-process
+
+            // an in-process restart must re-read the on-disk markers, not inherit the latch
+            PersistenceManager.reset();
+            assertFalse(PlaintextMigration.hasMarker(dbDir));
+        } finally {
+            FileUtil.deleteDirectory(dbDir);
+        }
+    }
+
+    @Test
     public void testUnlistableBackupDirAbortsMigrationRecording() throws Exception {
         Assumptions.assumeFalse(Utilities.isWindows()); // POSIX permissions
         File dbDir = File.createTempFile("persistence_test_unlistable", "");
@@ -428,11 +596,65 @@ public class PersistenceManagerTest {
         Assumptions.assumeTrue(backupsDir.listFiles() == null, "permissions not enforced (running as root?)");
         try {
             // an uninspectable directory must abort the migration, not be skipped
-            assertThrows(IOException.class, () -> PlaintextMigration.record(dbDir, Encryption.generateSecretKey(256)));
+            assertThrows(IOException.class, () -> PlaintextMigration.migrate(dbDir, Encryption.generateSecretKey(256)));
         } finally {
             assertTrue(backupsDir.setReadable(true));
             FileUtil.deleteDirectory(dbDir);
         }
+    }
+
+    @Test
+    public void testCrashTempPlaintextEncryptedAtMigration() throws Exception {
+        File appDir = File.createTempFile("persistence_test_crashtmp", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+
+            // crash-left store temps from a legacy release hold full plaintext copies
+            byte[] crashTempBytes = "plaintext store copy from a torn write".getBytes();
+            byte[] strayTempBytes = "another stale plaintext temp".getBytes();
+            File crashTemp = new File(dbDir, "temp_CrashStore6493725370163495412.tmp");
+            File strayTemp = new File(dbDir, "Straggler.tmp");
+            java.nio.file.Files.write(crashTemp.toPath(), crashTempBytes);
+            java.nio.file.Files.write(strayTemp.toPath(), strayTempBytes);
+
+            // migration encrypts them in place, preserving their content
+            new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertArrayEquals(crashTempBytes, Encryption.decryptV2(java.nio.file.Files.readAllBytes(crashTemp.toPath()), symKey));
+            assertArrayEquals(strayTempBytes, Encryption.decryptV2(java.nio.file.Files.readAllBytes(strayTemp.toPath()), symKey));
+        } finally {
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testBackupFlushReportsWriteError() throws Exception {
+        // a store that cannot be serialized must fail the backup flush, not report success
+        NavigationPath bad = new NavigationPath(List.of("x")) {
+            @Override
+            public com.google.protobuf.Message toProtoMessage() {
+                throw new RuntimeException("injected serialization failure");
+            }
+        };
+        persistenceManager.initialize(bad, "FlushErrorStore", PersistenceManager.Source.PRIVATE);
+        assertNull(persistenceManager.getPersisted("FlushErrorStore")); // marks the store as read
+
+        CountDownLatch latch = new CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicReference<Throwable> flushError = new java.util.concurrent.atomic.AtomicReference<>();
+        PersistenceManager.flushAllDataToDiskAtBackup(error -> {
+            flushError.set(error);
+            latch.countDown();
+        });
+        assertTrue(latch.await(15, TimeUnit.SECONDS), "flush did not complete");
+        assertNotNull(flushError.get(), "flush must report the write error");
     }
 
     private static void writeLegacySymFile(File keysDir, SecretKey symKey, String password) throws Exception {

--- a/common/src/test/java/haveno/common/persistence/PersistenceManagerTest.java
+++ b/common/src/test/java/haveno/common/persistence/PersistenceManagerTest.java
@@ -21,7 +21,9 @@ import haveno.common.Payload;
 import haveno.common.crypto.Encryption;
 import haveno.common.crypto.KeyRing;
 import haveno.common.crypto.KeyStorage;
+import haveno.common.crypto.Sig;
 import haveno.common.file.FileUtil;
+import haveno.common.util.Utilities;
 import haveno.common.proto.persistable.NavigationPath;
 import haveno.common.proto.persistable.PersistableEnvelope;
 import haveno.common.proto.persistable.PersistablePayload;
@@ -29,18 +31,24 @@ import haveno.common.proto.persistable.PersistenceProtoResolver;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.security.KeyStore;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PersistenceManagerTest {
@@ -101,10 +109,8 @@ public class PersistenceManagerTest {
         assertTrue(latch.await(15, TimeUnit.SECONDS), "write did not complete");
     }
 
-    // Writes encrypt(payload || hmac(payload)) to a file with constant memory through the same
-    // production helper PersistenceManager uses, so the fixture format can never drift from the
-    // real writer. Avoids the array encrypt's peak-memory amplification for large fixtures.
-    private void writeEncryptedFile(byte[] payload, SecretKey key, File file) throws Exception {
+    // Writes a legacy (AES-ECB + HMAC) encrypted store file as a migration fixture.
+    private void writeLegacyEncryptedFile(byte[] payload, SecretKey key, File file) throws Exception {
         try (FileOutputStream fos = new FileOutputStream(file)) {
             Encryption.encryptPayloadWithHmacToStream(payload, key, fos);
         }
@@ -115,25 +121,334 @@ public class PersistenceManagerTest {
         NavigationPath data = largeNavigationPath();
         persistAndWait(data, "EncryptedStore");
 
-        // Sanity: the on-disk file is actually present.
+        // Sanity: the on-disk file is actually present and in the v2 format.
         assertTrue(new File(dir, "EncryptedStore").length() > 0);
+        byte[] head = new byte[4];
+        try (var fis = new java.io.FileInputStream(new File(dir, "EncryptedStore"))) {
+            assertEquals(4, fis.read(head));
+        }
+        assertArrayEquals(Encryption.V2_MAGIC, head);
 
         NavigationPath read = persistenceManager.getPersisted("EncryptedStore");
         assertEquals(data, read);
     }
 
     @Test
-    public void testLegacyUnencryptedFileIsStillReadable() throws Exception {
+    public void testLegacyEncryptedFileIsReadAndUpgradedOnPersist() throws Exception {
         NavigationPath data = largeNavigationPath();
-        // Write the store the old, unencrypted way (delimited protobuf) directly to the storage file.
-        File storageFile = new File(dir, "LegacyStore");
+        byte[] payload = ((protobuf.PersistableEnvelope) data.toProtoMessage()).toByteArray();
+        writeLegacyEncryptedFile(payload, keyRing.getSymmetricKey(), new File(dir, "LegacyEncryptedStore"));
+
+        persistenceManager.initialize(data, "LegacyEncryptedStore", PersistenceManager.Source.PRIVATE);
+        NavigationPath read = persistenceManager.getPersisted("LegacyEncryptedStore");
+        assertEquals(data, read);
+
+        // The next persist rewrites the store in the v2 format and it stays readable.
+        CountDownLatch latch = new CountDownLatch(1);
+        persistenceManager.persistNow(latch::countDown);
+        assertTrue(latch.await(15, TimeUnit.SECONDS), "write did not complete");
+        byte[] head = new byte[4];
+        try (var fis = new java.io.FileInputStream(new File(dir, "LegacyEncryptedStore"))) {
+            assertEquals(4, fis.read(head));
+        }
+        assertArrayEquals(Encryption.V2_MAGIC, head);
+        assertEquals(data, persistenceManager.getPersisted("LegacyEncryptedStore"));
+        assertBackupsAreEncrypted(dir, "LegacyEncryptedStore");
+    }
+
+    // The migration write must not copy the pre-v2 store into the rolling backups; the first
+    // backup is taken from the encrypted replacement.
+    private static void assertBackupsAreEncrypted(File dir, String fileName) throws Exception {
+        List<File> backups = FileUtil.getBackupFiles(dir, fileName);
+        assertFalse(backups.isEmpty());
+        for (File backup : backups) {
+            byte[] head = new byte[4];
+            try (var fis = new java.io.FileInputStream(backup)) {
+                assertEquals(4, fis.read(head));
+            }
+            assertArrayEquals(Encryption.V2_MAGIC, head, "backup is not encrypted: " + backup.getName());
+        }
+    }
+
+    @Test
+    public void testPlaintextFileIsRejectedWithoutLegacyKeyMaterial() throws Exception {
+        NavigationPath data = largeNavigationPath();
+        // A plaintext store is forgeable, so a v2-native keyring must reject it as corrupt.
+        File storageFile = new File(dir, "PlaintextStore");
         try (FileOutputStream fos = new FileOutputStream(storageFile)) {
             data.toProtoMessage().writeDelimitedTo(fos);
         }
-        persistenceManager.initialize(data, "LegacyStore", PersistenceManager.Source.PRIVATE);
+        persistenceManager.initialize(data, "PlaintextStore", PersistenceManager.Source.PRIVATE);
 
-        NavigationPath read = persistenceManager.getPersisted("LegacyStore");
-        assertEquals(data, read);
+        assertNull(persistenceManager.getPersisted("PlaintextStore"));
+        assertFalse(storageFile.exists());
+        File[] backups = new File(dir, FileUtil.CORRUPTED_BACKUP_FOLDER).listFiles();
+        assertNotNull(backups);
+        assertEquals(1, backups.length);
+    }
+
+    @Test
+    public void testPlaintextFileIsReadableDuringLegacyMigration() throws Exception {
+        // build an account still in the legacy key format: PKCS#12 sym.p12 + AES-ECB-with-hmac key files
+        File legacyDir = File.createTempFile("persistence_test_legacy", "");
+        assertTrue(legacyDir.delete());
+        assertTrue(legacyDir.mkdir());
+        PersistenceManager<NavigationPath> legacyManager = null;
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(legacyDir, symKey, password);
+            writeLegacyKeyFile(legacyDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(legacyDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+            KeyRing legacyKeyRing = new KeyRing(new KeyStorage(legacyDir), password, false);
+            assertTrue(legacyKeyRing.isUnlocked());
+
+            // a plaintext store from the pre-encryption era is still readable during this migration
+            NavigationPath data = largeNavigationPath();
+            try (FileOutputStream fos = new FileOutputStream(new File(legacyDir, "LegacyStore"))) {
+                data.toProtoMessage().writeDelimitedTo(fos);
+            }
+            legacyManager = new PersistenceManager<>(legacyDir, RESOLVER, null, legacyKeyRing);
+            legacyManager.initialize(data, "LegacyStore", PersistenceManager.Source.PRIVATE);
+            assertEquals(data, legacyManager.getPersisted("LegacyStore"));
+        } finally {
+            if (legacyManager != null) legacyManager.shutdown();
+            FileUtil.deleteDirectory(legacyDir);
+        }
+    }
+
+    @Test
+    public void testRecordedPlaintextStoreSurvivesRestartAfterKeyMigration() throws Exception {
+        File appDir = File.createTempFile("persistence_test_restart", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        PersistenceManager<NavigationPath> manager = null;
+        try {
+            // legacy account with a plaintext store already on disk before the first unlock
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+            NavigationPath data = largeNavigationPath();
+            File storageFile = new File(dbDir, "RestartStore");
+            try (FileOutputStream fos = new FileOutputStream(storageFile)) {
+                data.toProtoMessage().writeDelimitedTo(fos);
+            }
+
+            // the unlock records the store in the migration inventory before upgrading the keys
+            KeyRing legacyKeyRing = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertTrue(legacyKeyRing.isUnlocked());
+            assertTrue(new File(dbDir, PlaintextMigration.FILE_NAME).exists());
+            assertFalse(new File(keysDir, "sym.p12").exists());
+
+            // simulate a crash before the store was rewritten: a fresh process loads only v2 keys
+            KeyRing restarted = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertTrue(restarted.isUnlocked());
+            assertFalse(restarted.getKeyStorage().hasLegacyFormatEverLoaded());
+            manager = new PersistenceManager<>(dbDir, RESOLVER, null, restarted);
+            manager.initialize(data, "RestartStore", PersistenceManager.Source.PRIVATE);
+            assertEquals(data, manager.getPersisted("RestartStore"));
+
+            // re-persisting encrypted removes the store from the inventory, so a plaintext
+            // replacement (even byte-identical to the original) is rejected afterwards
+            CountDownLatch latch = new CountDownLatch(1);
+            manager.persistNow(latch::countDown);
+            assertTrue(latch.await(15, TimeUnit.SECONDS), "write did not complete");
+            // the emptied inventory remains as a durable marker that migration ran
+            assertTrue(new File(dbDir, PlaintextMigration.FILE_NAME).exists());
+            assertBackupsAreEncrypted(dbDir, "RestartStore");
+            try (FileOutputStream fos = new FileOutputStream(storageFile)) {
+                data.toProtoMessage().writeDelimitedTo(fos);
+            }
+            assertNull(manager.getPersisted("RestartStore"));
+        } finally {
+            if (manager != null) manager.shutdown();
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testTamperedRecordedPlaintextStoreIsRejected() throws Exception {
+        File appDir = File.createTempFile("persistence_test_tamper", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        PersistenceManager<NavigationPath> manager = null;
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+            NavigationPath data = largeNavigationPath();
+            File storageFile = new File(dbDir, "TamperStore");
+            try (FileOutputStream fos = new FileOutputStream(storageFile)) {
+                data.toProtoMessage().writeDelimitedTo(fos);
+            }
+            new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+
+            // replacing the recorded store's content after the crash fails the recorded hash
+            NavigationPath forged = new NavigationPath(List.of("forged/entry"));
+            try (FileOutputStream fos = new FileOutputStream(storageFile)) {
+                forged.toProtoMessage().writeDelimitedTo(fos);
+            }
+            KeyRing restarted = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            manager = new PersistenceManager<>(dbDir, RESOLVER, null, restarted);
+            manager.initialize(data, "TamperStore", PersistenceManager.Source.PRIVATE);
+            assertNull(manager.getPersisted("TamperStore"));
+        } finally {
+            if (manager != null) manager.shutdown();
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testTamperedPlaintextStoreRejectedInSameProcess() throws Exception {
+        File appDir = File.createTempFile("persistence_test_sameproc", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        PersistenceManager<NavigationPath> manager = null;
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+            NavigationPath data = largeNavigationPath();
+            File storageFile = new File(dbDir, "SameProcStore");
+            try (FileOutputStream fos = new FileOutputStream(storageFile)) {
+                data.toProtoMessage().writeDelimitedTo(fos);
+            }
+
+            // the unlock records the inventory; the same process may read the recorded content
+            KeyRing legacyKeyRing = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertTrue(legacyKeyRing.getKeyStorage().hasLegacyFormatEverLoaded());
+            manager = new PersistenceManager<>(dbDir, RESOLVER, null, legacyKeyRing);
+            manager.initialize(data, "SameProcStore", PersistenceManager.Source.PRIVATE);
+            assertEquals(data, manager.getPersisted("SameProcStore"));
+
+            // but a replacement written after the inventory is rejected even in the same process
+            NavigationPath forged = new NavigationPath(List.of("forged/entry"));
+            try (FileOutputStream fos = new FileOutputStream(storageFile)) {
+                forged.toProtoMessage().writeDelimitedTo(fos);
+            }
+            assertNull(manager.getPersisted("SameProcStore"));
+        } finally {
+            if (manager != null) manager.shutdown();
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testResidualPlaintextBackupsAreEncryptedAtMigration() throws Exception {
+        File appDir = File.createTempFile("persistence_test_residual", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        try {
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+
+            // historical plaintext copies in the backup and corruption-recovery trees
+            byte[] backupBytes = "old plaintext backup".getBytes();
+            byte[] corruptedBytes = "old corrupted store".getBytes();
+            File backupFile = new File(dbDir, "backup/backups_OldStore/123_OldStore");
+            File corruptedFile = new File(dbDir, FileUtil.CORRUPTED_BACKUP_FOLDER + "/456_OldStore");
+            assertTrue(backupFile.getParentFile().mkdirs());
+            assertTrue(corruptedFile.getParentFile().mkdirs());
+            java.nio.file.Files.write(backupFile.toPath(), backupBytes);
+            java.nio.file.Files.write(corruptedFile.toPath(), corruptedBytes);
+
+            // migration encrypts them in place, preserving their content
+            new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertArrayEquals(backupBytes, Encryption.decryptV2(java.nio.file.Files.readAllBytes(backupFile.toPath()), symKey));
+            assertArrayEquals(corruptedBytes, Encryption.decryptV2(java.nio.file.Files.readAllBytes(corruptedFile.toPath()), symKey));
+        } finally {
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testPlaintextPlantedAfterEmptyMigrationIsRejected() throws Exception {
+        File appDir = File.createTempFile("persistence_test_empty", "");
+        assertTrue(appDir.delete());
+        File keysDir = new File(appDir, "keys");
+        File dbDir = new File(appDir, "db");
+        assertTrue(keysDir.mkdirs());
+        assertTrue(dbDir.mkdirs());
+        PersistenceManager<NavigationPath> manager = null;
+        try {
+            // legacy account with no plaintext stores at all
+            String password = "test password 123";
+            SecretKey symKey = Encryption.generateSecretKey(256);
+            writeLegacySymFile(keysDir, symKey, password);
+            writeLegacyKeyFile(keysDir, "sig.key", Sig.generateKeyPair().getPrivate().getEncoded(), symKey);
+            writeLegacyKeyFile(keysDir, "enc.key", Encryption.generateKeyPair().getPrivate().getEncoded(), symKey);
+            KeyRing keyRing = new KeyRing(new KeyStorage(keysDir), dbDir, password, false);
+            assertTrue(keyRing.getKeyStorage().hasLegacyFormatEverLoaded());
+            assertTrue(new File(dbDir, PlaintextMigration.FILE_NAME).exists()); // empty inventory recorded
+
+            // a plaintext store planted after the (empty) migration must be rejected
+            NavigationPath data = largeNavigationPath();
+            try (FileOutputStream fos = new FileOutputStream(new File(dbDir, "PlantedStore"))) {
+                data.toProtoMessage().writeDelimitedTo(fos);
+            }
+            manager = new PersistenceManager<>(dbDir, RESOLVER, null, keyRing);
+            manager.initialize(data, "PlantedStore", PersistenceManager.Source.PRIVATE);
+            assertNull(manager.getPersisted("PlantedStore"));
+        } finally {
+            if (manager != null) manager.shutdown();
+            FileUtil.deleteDirectory(appDir);
+        }
+    }
+
+    @Test
+    public void testUnlistableBackupDirAbortsMigrationRecording() throws Exception {
+        Assumptions.assumeFalse(Utilities.isWindows()); // POSIX permissions
+        File dbDir = File.createTempFile("persistence_test_unlistable", "");
+        assertTrue(dbDir.delete());
+        File backupsDir = new File(dbDir, "backup/backups_OldStore");
+        assertTrue(backupsDir.mkdirs());
+        java.nio.file.Files.write(new File(backupsDir, "123_OldStore").toPath(), "plaintext".getBytes());
+        assertTrue(backupsDir.setReadable(false));
+        Assumptions.assumeTrue(backupsDir.listFiles() == null, "permissions not enforced (running as root?)");
+        try {
+            // an uninspectable directory must abort the migration, not be skipped
+            assertThrows(IOException.class, () -> PlaintextMigration.record(dbDir, Encryption.generateSecretKey(256)));
+        } finally {
+            assertTrue(backupsDir.setReadable(true));
+            FileUtil.deleteDirectory(dbDir);
+        }
+    }
+
+    private static void writeLegacySymFile(File keysDir, SecretKey symKey, String password) throws Exception {
+        KeyStore p12 = KeyStore.getInstance("PKCS12");
+        p12.load(null, null);
+        p12.setKeyEntry("sym", symKey, password.toCharArray(), null);
+        try (FileOutputStream fos = new FileOutputStream(new File(keysDir, "sym.p12"))) {
+            p12.store(fos, password.toCharArray());
+        }
+    }
+
+    private static void writeLegacyKeyFile(File dir, String fileName, byte[] privateKeyEncoded, SecretKey symKey) throws Exception {
+        byte[] pkcs8 = new PKCS8EncodedKeySpec(privateKeyEncoded).getEncoded();
+        try (FileOutputStream fos = new FileOutputStream(new File(dir, fileName))) {
+            fos.write(Encryption.encryptPayloadWithHmac(pkcs8, symKey));
+        }
     }
 
     @Test
@@ -145,11 +460,28 @@ public class PersistenceManagerTest {
         String big = "a".repeat(oversize); // Latin-1 -> compact (1 byte/char) on the heap
         NavigationPath data = new NavigationPath(List.of(big));
         byte[] payload = ((protobuf.PersistableEnvelope) data.toProtoMessage()).toByteArray();
-        writeEncryptedFile(payload, keyRing.getSymmetricKey(), new File(dir, "LargeStore"));
+        writeLegacyEncryptedFile(payload, keyRing.getSymmetricKey(), new File(dir, "LargeStore"));
         payload = null; // allow GC before the read rebuilds the payload
         persistenceManager.initialize(data, "LargeStore", PersistenceManager.Source.PRIVATE);
 
         NavigationPath read = persistenceManager.getPersisted("LargeStore");
+        assertEquals(1, read.getPath().size());
+        assertEquals(oversize, read.getPath().get(0).length());
+    }
+
+    @Test
+    public void testV2StoreOverProtobufDefaultSizeLimitRoundTrips() throws Exception {
+        // Same as above but through the v2 read path, which must also lift the 64 MB stream limit.
+        int oversize = 66 * 1024 * 1024;
+        String big = "a".repeat(oversize);
+        NavigationPath data = new NavigationPath(List.of(big));
+        byte[] payload = ((protobuf.PersistableEnvelope) data.toProtoMessage()).toByteArray();
+        try (FileOutputStream fos = new FileOutputStream(new File(dir, "LargeStoreV2"))) {
+            Encryption.encryptV2ToStream(out -> out.write(payload), keyRing.getSymmetricKey(), fos);
+        }
+        persistenceManager.initialize(data, "LargeStoreV2", PersistenceManager.Source.PRIVATE);
+
+        NavigationPath read = persistenceManager.getPersisted("LargeStoreV2");
         assertEquals(1, read.getPath().size());
         assertEquals(oversize, read.getPath().get(0).length());
     }
@@ -170,6 +502,24 @@ public class PersistenceManagerTest {
         assertNull(read, "corrupt file must not return data");
         assertFalse(storageFile.exists(), "corrupt file should be moved out of place");
         assertTrue(new File(dir, "backup_of_corrupted_data/CorruptStore").exists(),
+                "corrupt file should be preserved in backup_of_corrupted_data");
+    }
+
+    @Test
+    public void testCorruptV2FileWithIntactMagicIsMovedToBackup() throws Exception {
+        NavigationPath data = largeNavigationPath();
+        persistAndWait(data, "CorruptV2Store");
+
+        // Flip one ciphertext byte but keep the v2 magic, so the failure surfaces in the v2 read path.
+        File storageFile = new File(dir, "CorruptV2Store");
+        byte[] bytes = java.nio.file.Files.readAllBytes(storageFile.toPath());
+        bytes[bytes.length / 2] ^= 0x01;
+        java.nio.file.Files.write(storageFile.toPath(), bytes);
+
+        NavigationPath read = persistenceManager.getPersisted("CorruptV2Store");
+        assertNull(read, "corrupt file must not return data");
+        assertFalse(storageFile.exists(), "corrupt file should be moved out of place");
+        assertTrue(new File(dir, "backup_of_corrupted_data/CorruptV2Store").exists(),
                 "corrupt file should be preserved in backup_of_corrupted_data");
     }
 }

--- a/core/src/main/java/haveno/core/api/CoreAccountService.java
+++ b/core/src/main/java/haveno/core/api/CoreAccountService.java
@@ -142,14 +142,20 @@ public class CoreAccountService {
         if (!StringUtils.equals(this.password, oldPassword)) throw new IllegalStateException("Incorrect password");
         if (newPassword != null && newPassword.length() < 8) throw new IllegalStateException("Password must be at least 8 characters");
 
-        // change wallet passwords before committing new account password
-        // TODO: recover if wallet password change fails
-        synchronized (listeners) {
-            for (AccountServiceListener listener : new ArrayList<>(listeners)) listener.onPasswordChanged(oldPassword, newPassword);
-        }
+        // commit the new account password to key storage first: this step is revertible (the master
+        // key is unchanged), whereas half-changed wallet passwords are not
+        keyStorage.saveKeyRing(keyRing, newPassword);
 
-        // commit new account password
-        keyStorage.saveKeyRing(keyRing, oldPassword, newPassword);
+        // change wallet passwords
+        // TODO: recover if wallet password change fails partway through the listeners
+        try {
+            synchronized (listeners) {
+                for (AccountServiceListener listener : new ArrayList<>(listeners)) listener.onPasswordChanged(oldPassword, newPassword);
+            }
+        } catch (RuntimeException e) {
+            keyStorage.saveKeyRing(keyRing, oldPassword); // revert
+            throw e;
+        }
         this.password = newPassword;
     }
 

--- a/core/src/main/java/haveno/core/api/CoreAccountService.java
+++ b/core/src/main/java/haveno/core/api/CoreAccountService.java
@@ -20,6 +20,8 @@ package haveno.core.api;
 import static com.google.common.base.Preconditions.checkState;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import haveno.common.ThreadUtils;
+import haveno.common.UserThread;
 import haveno.common.app.Log;
 import haveno.common.config.Config;
 import haveno.common.crypto.IncorrectPasswordException;
@@ -34,9 +36,11 @@ import java.io.InputStream;
 import java.time.LocalDate;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import lombok.Getter;
@@ -61,8 +65,16 @@ public class CoreAccountService {
     private final KeyRing keyRing;
 
     @Getter
-    private String password;
+    private volatile String password;
     private List<AccountServiceListener> listeners = new ArrayList<AccountServiceListener>();
+    private final Object passwordChangeLock = new Object();
+    private volatile boolean backupInProgress;
+    // Gate between wallet creation and the password change transaction: each side fails fast
+    // while the other is active, so no wallet file can appear with a password the transaction's
+    // rotation scans will not see.
+    private final Object walletCreationLock = new Object();
+    private int walletCreationCount; // guarded by walletCreationLock
+    private boolean passwordChangeInProgress; // guarded by walletCreationLock
 
     // seed and restore height or date to import when the main wallet is first created, held in memory only
     @Getter
@@ -117,6 +129,8 @@ public class CoreAccountService {
 
     public void createAccount(String password) {
         if (accountExists()) throw new IllegalStateException("Cannot create account if account already exists");
+        password = normalizePassword(password);
+        validatePassword(password);
         keyRing.generateKeys(password);
         this.password = password;
         synchronized (listeners) {
@@ -126,41 +140,224 @@ public class CoreAccountService {
 
     public void openAccount(String password) throws IncorrectPasswordException {
         if (!accountExists()) throw new IllegalStateException("Cannot open account if account does not exist");
+        password = normalizePassword(password);
         if (keyRing.unlockKeys(password, false)) {
             this.password = password;
             synchronized (listeners) {
                 for (AccountServiceListener listener : new ArrayList<>(listeners)) listener.onAccountOpened();
             }
+            maybeRecoverPasswordChange();
         } else {
             throw new IllegalStateException("keyRing.unlockKeys() returned false, that should never happen");
         }
     }
 
     public void changePassword(String oldPassword, String newPassword) {
-        if (!isAccountOpen()) throw new IllegalStateException("Cannot change password on unopened account");
-        if ("".equals(oldPassword)) oldPassword = null; // normalize to null
-        if (!StringUtils.equals(this.password, oldPassword)) throw new IllegalStateException("Incorrect password");
-        if (newPassword != null && newPassword.length() < 8) throw new IllegalStateException("Password must be at least 8 characters");
+        synchronized (passwordChangeLock) {
+            if (!isAccountOpen()) throw new IllegalStateException("Cannot change password on unopened account");
+            // the transaction converges wallets and credentials through listeners, which only all
+            // exist once services are initialized; committing earlier would leave components on
+            // the old password with no journal left to heal them
+            if (!PersistenceManager.allServicesInitialized.get()) throw new IllegalStateException("Cannot change password until the application is fully initialized");
+            oldPassword = normalizePassword(oldPassword);
+            newPassword = normalizePassword(newPassword);
+            if ("".equals(oldPassword)) oldPassword = null; // normalize to null
+            if (!StringUtils.equals(this.password, oldPassword)) throw new IllegalStateException("Incorrect password");
+            if (newPassword != null && newPassword.length() < 8) throw new IllegalStateException("Password must be at least 8 characters");
+            validatePassword(newPassword); // validate before any durable mutation
+            if (StringUtils.equals(oldPassword, newPassword)) return;
+            if (keyStorage.hasPasswordChangeJournal()) throw new IllegalStateException("A previous password change is incomplete; reopen the account to recover it first");
+            if (backupInProgress) throw new IllegalStateException("Cannot change password while an account backup is in progress");
 
-        // commit the new account password to key storage first: this step is revertible (the master
-        // key is unchanged), whereas half-changed wallet passwords are not
-        keyStorage.saveKeyRing(keyRing, newPassword);
+            // refuse wallet creation for the whole transaction, so every wallet file is visible
+            // to the rotation scans and none is created with a password about to be retired
+            blockWalletCreation();
+            try {
+                // durably journal both passwords and add a second sym.key wrapper under the new
+                // password, so a crash at any point leaves the account unlockable with either
+                keyStorage.beginPasswordChange(keyRing, oldPassword, newPassword);
 
-        // change wallet passwords
-        // TODO: recover if wallet password change fails partway through the listeners
-        try {
-            synchronized (listeners) {
-                for (AccountServiceListener listener : new ArrayList<>(listeners)) listener.onPasswordChanged(oldPassword, newPassword);
+                // change wallet and credential passwords; handlers are idempotent so a partial
+                // failure can be converged back to the old password
+                try {
+                    notifyPasswordChanged(oldPassword, newPassword);
+                } catch (RuntimeException e) {
+                    try {
+                        notifyPasswordChanged(newPassword, oldPassword); // revert
+                        keyStorage.clearPasswordChange();
+                    } catch (RuntimeException e2) {
+                        log.error("Could not revert partial password change; it will be recovered when the account is reopened", e2);
+                        e.addSuppressed(e2);
+                    }
+                    throw e;
+                }
+
+                // all components confirmed on the new password: rewrap sym.key (the commit point).
+                // a failed commit leaves sym.key on the old password, so roll the components back
+                try {
+                    keyStorage.commitPasswordChange(keyRing, newPassword);
+                } catch (RuntimeException e) {
+                    try {
+                        notifyPasswordChanged(newPassword, oldPassword); // revert
+                        keyStorage.clearPasswordChange();
+                    } catch (RuntimeException e2) {
+                        log.error("Could not revert partial password change; it will be recovered when the account is reopened", e2);
+                        e.addSuppressed(e2);
+                    }
+                    throw e;
+                }
+                this.password = newPassword;
+            } finally {
+                unblockWalletCreation();
             }
-        } catch (RuntimeException e) {
-            keyStorage.saveKeyRing(keyRing, oldPassword); // revert
-            throw e;
+
+            // past the commit point a cleanup failure must not report a failed change; the
+            // journal stays pending and cleanup is retried in the background until it succeeds,
+            // since a surviving backup still unwraps the master key with the old password
+            try {
+                keyStorage.finishPasswordChange();
+            } catch (RuntimeException e) {
+                log.error("Password change committed but cleanup is incomplete; retrying in the background", e);
+                scheduleFinishPasswordChangeRetry(1);
+            }
         }
-        this.password = newPassword;
+    }
+
+    /**
+     * Registers a wallet creation, failing while a password change transaction is active. The
+     * caller must read the account password after this returns and call
+     * {@link #endWalletCreation()} once the wallet exists on disk.
+     */
+    public void beginWalletCreation() {
+        synchronized (walletCreationLock) {
+            if (passwordChangeInProgress) throw new IllegalStateException("Cannot create a wallet while a password change is in progress; please retry shortly");
+            walletCreationCount++;
+        }
+    }
+
+    public void endWalletCreation() {
+        synchronized (walletCreationLock) {
+            walletCreationCount--;
+        }
+    }
+
+    /** Whether a password change transaction is active, during which wallets may be rotated ahead of the account password. */
+    public boolean isPasswordChangeInProgress() {
+        synchronized (walletCreationLock) {
+            return passwordChangeInProgress;
+        }
+    }
+
+    // Raises the creation gate for the transaction, refusing if a creation is in flight; either
+    // side fails fast, so no waiting and no lock cycle is possible.
+    private void blockWalletCreation() {
+        synchronized (walletCreationLock) {
+            if (walletCreationCount > 0) throw new IllegalStateException("Cannot change password while a wallet is being created; please retry shortly");
+            passwordChangeInProgress = true;
+        }
+    }
+
+    private void unblockWalletCreation() {
+        synchronized (walletCreationLock) {
+            passwordChangeInProgress = false;
+        }
+    }
+
+    // Retries cleanup of a committed password change with capped backoff, so old-password key
+    // wrappers do not silently persist until the account happens to be reopened.
+    private void scheduleFinishPasswordChangeRetry(int attempt) {
+        UserThread.runAfter(() -> ThreadUtils.submitToPool(() -> {
+            synchronized (passwordChangeLock) {
+                if (!isAccountOpen() || !keyStorage.hasPasswordChangeJournal()) return;
+                if (backupInProgress) {
+                    scheduleFinishPasswordChangeRetry(attempt + 1);
+                    return;
+                }
+                try {
+                    keyStorage.finishPasswordChange();
+                    log.info("Completed deferred password change cleanup");
+                } catch (RuntimeException e) {
+                    log.error("Password change cleanup failed again; retrying", e);
+                    scheduleFinishPasswordChangeRetry(attempt + 1);
+                }
+            }
+        }), Math.min(10L * attempt, 300L));
+    }
+
+    /**
+     * The counterpart password of an interrupted password change (may be null for no password),
+     * wrapped in a single-element array, or null if no change is pending. Wallets may still be
+     * on the counterpart until recovery converges them.
+     */
+    public String[] getPendingPasswordChangeCounterpart() {
+        if (!keyStorage.hasPasswordChangeJournal() || !keyRing.isUnlocked()) return null;
+        String[] change = keyStorage.readPasswordChangeJournal(keyRing.getSymmetricKey());
+        if (change == null) return null;
+        return new String[]{StringUtils.equals(this.password, change[1]) ? change[0] : change[1]};
+    }
+
+    // Completes an interrupted password change by converging every component to the password the
+    // user just proved, then committing it. Deferred until all services are initialized, so the
+    // stores have been read and wallets are serviceable; until then wallets on the counterpart
+    // password are healed on open (see XmrWalletService).
+    private void maybeRecoverPasswordChange() {
+        if (!keyStorage.hasPasswordChangeJournal()) return;
+        runAfterAllServicesInitialized(() -> ThreadUtils.submitToPool(this::recoverPasswordChange));
+    }
+
+    private void runAfterAllServicesInitialized(Runnable runnable) {
+        if (PersistenceManager.allServicesInitialized.get()) runnable.run();
+        else UserThread.runAfter(() -> runAfterAllServicesInitialized(runnable), 1);
+    }
+
+    private void recoverPasswordChange() {
+        synchronized (passwordChangeLock) {
+            if (!isAccountOpen() || !keyStorage.hasPasswordChangeJournal()) return;
+            String[] change = keyStorage.readPasswordChangeJournal(keyRing.getSymmetricKey());
+            if (change == null) {
+                // never delete the wrappers here: the pending wrapper may be the only artifact
+                // matching the entered password, so require manual intervention instead
+                log.error("Password change journal is unreadable; keeping both key wrappers. " +
+                        "Wallets that fail to open may require the counterpart password.");
+                return;
+            }
+            String other = StringUtils.equals(this.password, change[1]) ? change[0] : change[1];
+            log.warn("Recovering interrupted password change by converging to the entered password");
+            try {
+                notifyPasswordChanged(other, this.password);
+                keyStorage.commitPasswordChange(keyRing, this.password);
+            } catch (RuntimeException e) {
+                log.error("Password change recovery failed; will retry when the account is reopened", e);
+                return;
+            }
+            try {
+                keyStorage.finishPasswordChange();
+                log.info("Recovered interrupted password change");
+            } catch (RuntimeException e) {
+                log.error("Recovered password change but cleanup is incomplete; retrying in the background", e);
+                scheduleFinishPasswordChangeRetry(1);
+            }
+        }
+    }
+
+    private static void validatePassword(String password) {
+        if (password != null && password.chars().anyMatch(Character::isISOControl)) throw new IllegalStateException("Password must not contain control characters");
+    }
+
+    // The canonical password form, applied before any comparison, derivation or durable mutation,
+    // so key wrapping, wallets, credentials and the journal all see the same code points.
+    private static String normalizePassword(String password) {
+        return password == null ? null : Normalizer.normalize(password, Normalizer.Form.NFC);
+    }
+
+    private void notifyPasswordChanged(String oldPassword, String newPassword) {
+        synchronized (listeners) {
+            for (AccountServiceListener listener : new ArrayList<>(listeners)) listener.onPasswordChanged(oldPassword, newPassword);
+        }
     }
 
     public void verifyPassword(String password) throws IncorrectPasswordException {
-        if (!StringUtils.equals(this.password, password)) {
+        if (!StringUtils.equals(this.password, normalizePassword(password))) {
             throw new IncorrectPasswordException("Incorrect password");
         }
     }
@@ -173,15 +370,43 @@ public class CoreAccountService {
         }
     }
 
+    /**
+     * Acquires the exclusive backup guard for any backup of the data directory (API stream or
+     * desktop copy), refusing while a password change is pending or another backup runs; a backup
+     * must not archive the password change journal, pending wrapper or old-password key backups.
+     * The owner must call {@link #endBackup()} when done.
+     */
+    public void beginBackup() {
+        synchronized (passwordChangeLock) {
+            // any surviving transaction artifact (journal, pending wrapper or their temps) can
+            // hold key material or both passwords and must never be archived
+            if (keyStorage.hasPasswordChangeArtifacts()) throw new IllegalStateException("Cannot backup account while a password change is pending or incomplete");
+            if (backupInProgress) throw new IllegalStateException("Another account backup is in progress");
+            backupInProgress = true;
+        }
+    }
+
+    public void endBackup() {
+        backupInProgress = false;
+    }
+
     // TODO: share common code with BackupView to backup
     public void backupAccount(int bufferSize, Consumer<InputStream> consume, Consumer<Exception> error) {
         if (!accountExists()) throw new IllegalStateException("Cannot backup non existing account");
+        beginBackup();
 
         var accountWasOpen = isAccountOpen();
+        var producerStarted = new AtomicBoolean();
 
         // flush all known persistence objects to disk before locking the keys: encrypted stores
         // skip writes while the key ring is locked, which would silently back up stale files
-        PersistenceManager.flushAllDataToDiskAtBackup(() -> {
+        PersistenceManager.flushAllDataToDiskAtBackup(flushError -> {
+            if (flushError != null) {
+                // stale or inconsistent stores must not be backed up
+                endBackup();
+                error.accept(flushError instanceof Exception ? (Exception) flushError : new RuntimeException(flushError));
+                return;
+            }
             try {
                 // Needed to unlock haveno_XMR.keys
                 if (accountWasOpen)
@@ -192,18 +417,21 @@ public class CoreAccountService {
                 PipedOutputStream out = new PipedOutputStream(in);
                 log.info("Zipping directory " + dataDir);
 
-                // exclude monero binaries from backup so they're reinstalled with permissions
-                List<File> excludedFiles = Arrays.asList(
+                // exclude monero binaries from backup so they're reinstalled with permissions,
+                // and the throwaway seed validation wallet, which must never be archived
+                List<File> excludedFiles = new ArrayList<>(Arrays.asList(
                         new File(XmrWalletService.getMoneroWalletRpcPath()),
                         new File(XmrLocalNode.getMonerodPath())
-                );
+                ));
+                excludedFiles.addAll(XmrWalletService.getSeedValidationWalletFiles(config.walletDir));
 
-                new Thread(() -> {
+                Thread producer = new Thread(() -> {
                     try {
                         ZipUtils.zipDirToStream(dataDir, out, bufferSize, excludedFiles);
                     } catch (Exception ex) {
                         error.accept(ex);
                     } finally {
+                        endBackup();
                         // reopen only once the zip has read its last file, not concurrently with it
                         if (accountWasOpen) {
                             try {
@@ -213,9 +441,13 @@ public class CoreAccountService {
                             }
                         }
                     }
-                }).start();
+                }, "backup-account-producer");
+                producer.start();
+                // once started (and only then), the producer thread owns clearing the guard
+                producerStarted.set(true);
                 consume.accept(in);
             } catch (Exception err) {
+                if (!producerStarted.get()) endBackup();
                 error.accept(err);
             }
         });

--- a/core/src/main/java/haveno/core/trade/ClosedTradesStore.java
+++ b/core/src/main/java/haveno/core/trade/ClosedTradesStore.java
@@ -23,6 +23,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import haveno.common.UserThread;
 import haveno.common.config.Config;
+import haveno.common.crypto.Encryption;
 import haveno.common.crypto.KeyRing;
 import haveno.common.file.CorruptedStorageFileHandler;
 import haveno.common.file.FileUtil;
@@ -31,12 +32,14 @@ import haveno.common.persistence.PersistenceManager;
 import haveno.core.proto.persistable.CorePersistenceProtoResolver;
 import haveno.core.xmr.wallet.XmrWalletService;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 
@@ -151,6 +154,18 @@ public class ClosedTradesStore {
                 batch.addAll(entries);
             }
             if (batch.isEmpty()) return;
+            // an oversized record can never be appended (a near-limit legacy frame's re-encryption
+            // can exceed the bound); quarantine it with an error rather than letting it poison the
+            // retry queue and block every later record behind a permanently failing batch. Covers
+            // new entries, queued retries and records recovered from the pending log alike.
+            if (batch.stream().anyMatch(EncryptedAppendLog::exceedsMaxFrameSize)) {
+                batch = batch.stream().filter(record -> {
+                    if (!EncryptedAppendLog.exceedsMaxFrameSize(record)) return true;
+                    log.error("Dropping a {} byte record for {}, which exceeds the maximum frame size", record.length, LOG_FILE_NAME);
+                    quarantineOversized(record);
+                    return false;
+                }).collect(Collectors.toList());
+            }
             try {
                 appendLog().appendAll(batch);
                 failedEntries.clear();
@@ -182,6 +197,45 @@ public class ClosedTradesStore {
      */
     public void flushFailedEntries() {
         appendEntries(List.of());
+    }
+
+    // Preserves a record that can never be appended as an encrypted file under the corrupted-data
+    // folder, so it is recoverable rather than destroyed. Best effort - quarantine failure must
+    // not fail the surviving batch.
+    private void quarantineOversized(byte[] record) {
+        File file = null;
+        try {
+            File quarantineDir = new File(dir, FileUtil.CORRUPTED_BACKUP_FOLDER);
+            if (!quarantineDir.exists() && !quarantineDir.mkdir()) throw new IOException("Could not create " + quarantineDir.getName());
+            file = new File(quarantineDir, LOG_FILE_NAME + ".oversized." + System.currentTimeMillis());
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                Encryption.encryptV2ToStream(out -> {
+                    int chunkSize = 64 * 1024;
+                    for (int off = 0; off < record.length; off += chunkSize) {
+                        out.write(record, off, Math.min(chunkSize, record.length - off));
+                    }
+                }, keyRing.getSymmetricKey(), fos);
+                fos.flush();
+                fos.getFD().sync();
+            }
+            log.error("Quarantined the oversized record to {}/{}", FileUtil.CORRUPTED_BACKUP_FOLDER, file.getName());
+        } catch (OutOfMemoryError e) {
+            deletePartialQuarantine(file);
+            throw e;
+        } catch (Throwable t) {
+            log.error("Could not quarantine the oversized record; it is lost", t);
+            deletePartialQuarantine(file);
+        }
+    }
+
+    // A partial quarantine file could hold the very disk space the surviving batch needs.
+    private static void deletePartialQuarantine(File file) {
+        if (file == null) return;
+        try {
+            FileUtil.deleteFileIfExists(file, false);
+        } catch (Exception e) {
+            log.error("Could not delete the partially written quarantine file", e);
+        }
     }
 
     // Best-effort durable copy of the failed-write queue, so a queued batch survives a process

--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -1896,7 +1896,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
             // decrypt payment account payload
             getTradePeer().setPaymentAccountKey(paymentAccountKey);
             SecretKey sk = Encryption.getSecretKeyFromBytes(getTradePeer().getPaymentAccountKey());
-            byte[] decryptedPaymentAccountPayload = Encryption.decrypt(getTradePeer().getEncryptedPaymentAccountPayload(), sk);
+            byte[] decryptedPaymentAccountPayload = Encryption.decryptAuto(getTradePeer().getEncryptedPaymentAccountPayload(), sk);
             CoreNetworkProtoResolver resolver = new CoreNetworkProtoResolver(Clock.systemDefaultZone()); // TODO: reuse resolver from elsewhere?
             PaymentAccountPayload paymentAccountPayload = resolver.fromProto(protobuf.PaymentAccountPayload.parseFrom(decryptedPaymentAccountPayload));
 

--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -1033,7 +1033,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
         return walletHeight.get();
     }
 
-    private String getWalletName() {
+    public String getWalletName() {
         return MONERO_TRADE_WALLET_PREFIX + getShortId() + "_" + getShortUid();
     }
 
@@ -1110,8 +1110,27 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
 
     public void changeWalletPassword(String oldPassword, String newPassword) {
         synchronized (walletLock) {
-            getWallet().changePassword(oldPassword, newPassword);
+            XmrWalletService.changeWalletPassword(getWallet(), oldPassword, newPassword);
             saveWallet();
+
+            // arbitrator keeps no backups of trade wallets; drop any stale ones rather than
+            // leaving copies under the retired password, strictly so failure aborts the change
+            if (isArbitrator()) {
+                xmrWalletService.deleteWalletBackupsStrict(getWalletName());
+                return;
+            }
+
+            // backups must not outlive the old password; Windows locks open wallet files, so
+            // close for the backup refresh and reopen with the change's target password (the
+            // account password has not committed yet and would heal the wallet back)
+            if (Utilities.isWindows() && isWalletOpen()) {
+                closeWallet();
+                xmrWalletService.refreshWalletBackups(getWalletName());
+                if (isShutDownStarted) throw new IllegalStateException("Cannot reopen wallet for " + getClass().getSimpleName() + " " + getId() + " after backup refresh because shut down is started");
+                wallet = xmrWalletService.openWallet(getWalletName(), null, newPassword, isProxyApplied(), TRUST_DAEMON);
+            } else {
+                xmrWalletService.refreshWalletBackups(getWalletName());
+            }
         }
     }
 

--- a/core/src/main/java/haveno/core/trade/protocol/tasks/ProcessSignContractRequest.java
+++ b/core/src/main/java/haveno/core/trade/protocol/tasks/ProcessSignContractRequest.java
@@ -23,7 +23,6 @@ import haveno.common.app.Version;
 import haveno.common.crypto.Encryption;
 import haveno.common.crypto.Hash;
 import haveno.common.crypto.PubKeyRing;
-import haveno.common.crypto.ScryptUtil;
 import haveno.common.taskrunner.TaskRunner;
 import haveno.core.trade.ArbitratorTrade;
 import haveno.core.trade.Contract;
@@ -103,13 +102,15 @@ public class ProcessSignContractRequest extends TradeTask {
           if (!trade.isArbitrator()) {
 
               // generate random key to encrypt payment account payload
-              byte[] decryptionKey = ScryptUtil.getKeyCrypterScrypt().deriveKey(UUID.randomUUID().toString()).getKey();
+              byte[] decryptionKey = Encryption.generateSecretKey(256).getEncoded();
               trade.getSelf().setPaymentAccountKey(decryptionKey);
 
-              // encrypt payment account payload
+              // encrypt payment account payload; v1 is sent until the network can receive v2
               byte[] unencrypted = trade.getSelf().getPaymentAccountPayload().toProtoMessage().toByteArray();
               SecretKey sk = Encryption.getSecretKeyFromBytes(trade.getSelf().getPaymentAccountKey());
-              encryptedPaymentAccountPayload = Encryption.encrypt(unencrypted, sk);
+              encryptedPaymentAccountPayload = Version.NETWORK_ENCRYPTION_VERSION >= 2
+                      ? Encryption.encryptV2(unencrypted, sk)
+                      : Encryption.encrypt(unencrypted, sk);
           }
 
           // create response with contract signature

--- a/core/src/main/java/haveno/core/xmr/model/EncryptedConnectionList.java
+++ b/core/src/main/java/haveno/core/xmr/model/EncryptedConnectionList.java
@@ -87,6 +87,7 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
     @Override
     public void readPersisted(Runnable completeHandler) {
         persistenceManager.readPersisted(persistedEncryptedConnectionList -> {
+            boolean migrated = false;
             writeLock.lock();
             try {
                 initializeEncryption(persistedEncryptedConnectionList.keyCrypterScrypt);
@@ -95,11 +96,13 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
                 currentConnectionUrl = persistedEncryptedConnectionList.currentConnectionUrl;
                 refreshPeriod = persistedEncryptedConnectionList.refreshPeriod;
                 autoSwitch = persistedEncryptedConnectionList.autoSwitch;
+                migrated = migrateLegacyEncryption();
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
                 writeLock.unlock();
             }
+            if (migrated) requestPersistence();
             completeHandler.run();
         }, () -> {
             writeLock.lock();
@@ -117,6 +120,20 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
     private void initializeEncryption(KeyCrypterScrypt keyCrypterScrypt) {
         this.keyCrypterScrypt = keyCrypterScrypt;
         encryptionKey = toSecretKey(accountService.getPassword());
+    }
+
+    // Re-encrypts entries persisted in an older format than the current one; must hold the write lock.
+    private boolean migrateLegacyEncryption() {
+        if (encryptionKey == null) return false;
+        boolean migrated = false;
+        for (Map.Entry<String, EncryptedConnection> entry : items.entrySet()) {
+            byte[] encrypted = entry.getValue().getEncryptedPassword();
+            if (encrypted != null && encrypted.length > 0 && Encryption.blobVersion(encrypted) < Encryption.CURRENT_BLOB_VERSION) {
+                entry.setValue(reEncrypt(entry.getValue(), encryptionKey, encryptionKey));
+                migrated = true;
+            }
+        }
+        return migrated;
     }
 
     public List<MoneroRpcConnection> getConnections() {
@@ -309,7 +326,7 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
     private static byte[] decrypt(byte[] encrypted, SecretKey secret) {
         if (secret == null) return encrypted; // no encryption
         try {
-            return Encryption.decrypt(encrypted, secret);
+            return Encryption.decryptAuto(encrypted, secret); // v2 or legacy AES-ECB
         } catch (CryptoException e) {
             throw new IllegalArgumentException("Incorrect password", e);
         }
@@ -318,7 +335,7 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
     private static byte[] encrypt(byte[] unencrypted, SecretKey secretKey) {
         if (secretKey == null) return unencrypted; // no encryption
         try {
-            return Encryption.encrypt(unencrypted, secretKey);
+            return Encryption.encryptV2(unencrypted, secretKey);
         } catch (CryptoException e) {
             throw new RuntimeException("Could not encrypt data with the provided secret", e);
         }
@@ -374,6 +391,11 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
             // salt is prefix, so no actual password set
             return null;
         } else {
+            // the salt must be the suffix, else the value failed authentication (e.g. the raw
+            // legacy fallback of decryptAuto on a tampered v2 blob)
+            if (decryptedSaltedPassword.length < salt.length || !arrayEndsWith(decryptedSaltedPassword, salt)) {
+                throw new IllegalArgumentException("Could not authenticate decrypted connection password");
+            }
             // remove salt suffix, the rest is the actual password
             byte[] decryptedPassword = new byte[decryptedSaltedPassword.length - salt.length];
             System.arraycopy(decryptedSaltedPassword, 0, decryptedPassword, 0, decryptedPassword.length);
@@ -396,6 +418,19 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
         }
         for (int i = 0; i < prefix.length; i++) {
             if (container[i] != prefix[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean arrayEndsWith(byte[] container, byte[] suffix) {
+        if (container.length < suffix.length) {
+            return false;
+        }
+        int offset = container.length - suffix.length;
+        for (int i = 0; i < suffix.length; i++) {
+            if (container[offset + i] != suffix[i]) {
                 return false;
             }
         }

--- a/core/src/main/java/haveno/core/xmr/model/EncryptedConnectionList.java
+++ b/core/src/main/java/haveno/core/xmr/model/EncryptedConnectionList.java
@@ -11,12 +11,12 @@ import haveno.common.proto.persistable.PersistableEnvelope;
 import haveno.common.proto.persistable.PersistedDataHost;
 import haveno.core.api.CoreAccountService;
 import haveno.core.api.model.EncryptedConnection;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import monero.common.MoneroRpcConnection;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 
@@ -42,6 +43,7 @@ import org.bitcoinj.crypto.KeyCrypterScrypt;
  * salt is a prefix of the decrypted value. If it is a prefix, the connection has no password.
  * Otherwise, it is removed (from the end) and the remaining value is the actual password.
  */
+@Slf4j
 public class EncryptedConnectionList implements PersistableEnvelope, PersistedDataHost {
 
     private static final int MIN_FAKE_PASSWORD_LENGTH = 5;
@@ -137,12 +139,32 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
     }
 
     public List<MoneroRpcConnection> getConnections() {
+        try {
+            return doGetConnections();
+        } catch (IllegalArgumentException e) {
+            // like wallets healed on open, credentials still on the counterpart password of an
+            // interrupted password change are converged here, so startup can proceed to the
+            // deferred recovery instead of deadlocking on the decryption failure
+            if (!healInterruptedPasswordChange()) throw e;
+            return doGetConnections();
+        }
+    }
+
+    private List<MoneroRpcConnection> doGetConnections() {
         readLock.lock();
         try {
             return items.values().stream().map(this::toMoneroRpcConnection).collect(Collectors.toList());
         } finally {
             readLock.unlock();
         }
+    }
+
+    private boolean healInterruptedPasswordChange() {
+        String[] counterpart = accountService.getPendingPasswordChangeCounterpart();
+        if (counterpart == null) return false;
+        log.warn("Connection credentials do not match the account password; converging from the interrupted password change's counterpart password");
+        changePassword(counterpart[0], accountService.getPassword());
+        return true;
     }
 
     public boolean hasConnection(String connection) {
@@ -293,14 +315,23 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
     public void changePassword(String oldPassword, String newPassword) {
         writeLock.lock();
         try {
-            SecretKey oldSecret = encryptionKey;
-            assert Objects.equals(oldSecret, toSecretKey(oldPassword)) : "Old secret does not match old password";
-            encryptionKey = toSecretKey(newPassword);
-            items.replaceAll((key, connection) -> reEncrypt(connection, oldSecret, encryptionKey));
+            SecretKey oldSecret = toSecretKey(oldPassword);
+            SecretKey newSecret = toSecretKey(newPassword);
+            encryptionKey = newSecret;
+            items.replaceAll((key, connection) -> reEncryptIdempotent(connection, oldSecret, newSecret));
         } finally {
             writeLock.unlock();
         }
-        requestPersistence();
+        // persist synchronously so the credentials are durable before the account password commits
+        if (persistenceManager.readCalled.get()) {
+            persistenceManager.persistNowSync();
+            // replace rolling backups, whose credentials are still under the previous password
+            try {
+                persistenceManager.refreshBackups();
+            } catch (IOException e) {
+                throw new RuntimeException("Could not refresh backups of the connection list", e);
+            }
+        }
     }
 
     private SecretKey toSecretKey(String password) {
@@ -311,16 +342,68 @@ public class EncryptedConnectionList implements PersistableEnvelope, PersistedDa
     private static EncryptedConnection reEncrypt(EncryptedConnection connection,
                                                     SecretKey oldSecret, SecretKey newSecret) {
         return connection.toBuilder()
-                .encryptedPassword(reEncrypt(connection.getEncryptedPassword(), oldSecret, newSecret))
+                .encryptedPassword(reEncrypt(connection.getEncryptedPassword(), connection.getEncryptionSalt(), oldSecret, newSecret))
                 .build();
     }
 
-    private static byte[] reEncrypt(byte[] value,
+    private static EncryptedConnection reEncryptIdempotent(EncryptedConnection connection,
+                                                    SecretKey oldSecret, SecretKey newSecret) {
+        return connection.toBuilder()
+                .encryptedPassword(reEncryptIdempotent(connection.getEncryptedPassword(), connection.getEncryptionSalt(), oldSecret, newSecret))
+                .build();
+    }
+
+    // Re-encrypts a value from the old to the new secret, tolerating values already converged by an
+    // interrupted password change.
+    private static byte[] reEncryptIdempotent(byte[] value, byte[] salt, SecretKey oldSecret, SecretKey newSecret) {
+        if (newSecret == null) {
+            if (oldSecret == null) return value;
+            try {
+                return decryptChecked(value, salt, oldSecret);
+            } catch (RuntimeException e) {
+                if (!Encryption.isV2Format(value)) return value; // already plaintext
+                throw e;
+            }
+        }
+        if (oldSecret == null) {
+            if (Encryption.isV2Format(value)) {
+                try {
+                    decryptChecked(value, salt, newSecret);
+                    return value; // already encrypted with the new secret
+                } catch (RuntimeException ignore) {
+                }
+            }
+            return encrypt(value, newSecret);
+        }
+        try {
+            return encrypt(decryptChecked(value, salt, oldSecret), newSecret);
+        } catch (RuntimeException e) {
+            try {
+                decryptChecked(value, salt, newSecret);
+                return value; // already encrypted with the new secret
+            } catch (RuntimeException ignore) {
+            }
+            throw e;
+        }
+    }
+
+    private static byte[] reEncrypt(byte[] value, byte[] salt,
                                     SecretKey oldSecret, SecretKey newSecret) {
         // was previously not encrypted if null
-        byte[] decrypted = oldSecret == null ? value : decrypt(value, oldSecret);
+        byte[] decrypted = oldSecret == null ? value : decryptChecked(value, salt, oldSecret);
         // should not be encrypted if null
         return newSecret == null ? decrypted : encrypt(decrypted, newSecret);
+    }
+
+    // Decrypts and verifies the plaintext against the connection salt, so a spurious wrong-key
+    // decrypt of a legacy blob (unauthenticated AES-ECB) is never re-sealed as authenticated data.
+    private static byte[] decryptChecked(byte[] value, byte[] salt, SecretKey secret) {
+        byte[] decrypted = decrypt(value, secret);
+        // a planted empty or truncated salt must not weaken the check
+        if (salt.length != SALT_LENGTH || (!arrayStartsWith(decrypted, salt) && !arrayEndsWith(decrypted, salt))) {
+            throw new IllegalArgumentException("Could not authenticate decrypted connection password");
+        }
+        return decrypted;
     }
 
     private static byte[] decrypt(byte[] encrypted, SecretKey secret) {

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
@@ -48,6 +48,7 @@ import haveno.core.xmr.setup.MoneroWalletRpcManager;
 import haveno.core.xmr.setup.WalletsSetup;
 import haveno.network.utils.EventThrottler;
 import java.io.File;
+import java.io.IOException;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -62,6 +63,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
@@ -122,6 +124,8 @@ public class XmrWalletService extends XmrWalletBase {
     private static final String MONERO_WALLET_RPC_USERNAME = "haveno_user";
     private static final String MONERO_WALLET_RPC_DEFAULT_PASSWORD = "password"; // only used if account password is null
     private static final String MONERO_WALLET_NAME = "haveno_XMR";
+    // throwaway wallet restored under the default password to validate a seed, never rotated
+    private static final String SEED_VALIDATION_WALLET_NAME = MONERO_WALLET_NAME + "_seed_validation";
     private static final String KEYS_FILE_POSTFIX = ".keys";
     private static final String ADDRESS_FILE_POSTFIX = ".address.txt";
     private static final int NUM_WALLET_BACKUPS = 3;
@@ -329,16 +333,28 @@ public class XmrWalletService extends XmrWalletBase {
     private MoneroWallet createWallet(String walletName, Integer walletRpcPort, boolean applyProxyUri, boolean trustDaemon) {
         log.info("{}.createWallet({})", getClass().getSimpleName(), walletName);
         if (isShutDownStarted) throw new IllegalStateException("Cannot create wallet because shutting down");
-        MoneroWalletConfig config = getWalletConfig(walletName);
-        return isNativeLibraryApplied() ? createWalletFull(config, applyProxyUri) : createWalletRpc(config, walletRpcPort, applyProxyUri, trustDaemon);
+        // registered so a password change transaction drains this creation before scanning
+        // wallets; the password must be read inside the registered window
+        accountService.beginWalletCreation();
+        try {
+            MoneroWalletConfig config = getWalletConfig(walletName);
+            return isNativeLibraryApplied() ? createWalletFull(config, applyProxyUri) : createWalletRpc(config, walletRpcPort, applyProxyUri, trustDaemon);
+        } finally {
+            accountService.endWalletCreation();
+        }
     }
 
     private MoneroWallet createWalletFromSeed(String walletName, Integer walletRpcPort, boolean applyProxyUri, boolean trustDaemon, String seed, long restoreHeight) {
         log.info("{}.createWalletFromSeed({}, {})", getClass().getSimpleName(), walletName, restoreHeight);
         if (isShutDownStarted) throw new IllegalStateException("Cannot create wallet because shutting down");
         if (!isSeedValid(seed)) throw new IllegalArgumentException("Invalid wallet seed");
-        MoneroWalletConfig config = getWalletConfig(walletName).setSeed(seed).setRestoreHeight(restoreHeight);
-        return isNativeLibraryApplied() ? createWalletFull(config, applyProxyUri) : createWalletRpc(config, walletRpcPort, applyProxyUri, trustDaemon);
+        accountService.beginWalletCreation();
+        try {
+            MoneroWalletConfig config = getWalletConfig(walletName).setSeed(seed).setRestoreHeight(restoreHeight);
+            return isNativeLibraryApplied() ? createWalletFull(config, applyProxyUri) : createWalletRpc(config, walletRpcPort, applyProxyUri, trustDaemon);
+        } finally {
+            accountService.endWalletCreation();
+        }
     }
 
     // mainnet genesis timestamp and v2 fork height, to translate between block heights and dates
@@ -410,21 +426,34 @@ public class XmrWalletService extends XmrWalletBase {
 
     // validate the seed by restoring a temporary wallet with an offline monero-wallet-rpc instance
     private boolean isSeedValidRpc(String seed) {
-        String walletName = MONERO_WALLET_NAME + "_seed_validation";
-        deleteWalletFiles(walletName); // remove stale files from any previous validation
-        MoneroWalletRpc walletRpc = startWalletRpcInstance(null, null);
+        String walletName = SEED_VALIDATION_WALLET_NAME;
+        // registered so its throwaway file cannot race a password change's scans
+        accountService.beginWalletCreation();
         try {
-            walletRpc.createWallet(new MoneroWalletConfig()
-                    .setPath(walletName)
-                    .setPassword(MONERO_WALLET_RPC_DEFAULT_PASSWORD)
-                    .setSeed(seed));
-            return true;
-        } catch (MoneroError e) {
-            log.info("Seed failed validation: {}", e.getMessage());
-            return false;
+            deleteWalletFiles(walletName); // remove stale files from any previous validation
+            MoneroWalletRpc walletRpc = startWalletRpcInstance(null, null);
+            try {
+                walletRpc.createWallet(new MoneroWalletConfig()
+                        .setPath(walletName)
+                        // one-time random password, so a crash-left file never holds the seed's keys under a known password
+                        .setPassword(UUID.randomUUID().toString())
+                        .setSeed(seed));
+                return true;
+            } catch (MoneroError e) {
+                log.info("Seed failed validation: {}", e.getMessage());
+                return false;
+            } finally {
+                // best effort: cleanup failures must not mask the validation result, and the
+                // file is inert without its password
+                try {
+                    forceCloseWallet(walletRpc, walletName);
+                } catch (Exception e) {
+                    log.warn("Error closing seed validation wallet: {}", e.getMessage());
+                }
+                deleteWalletFilesBestEffort(walletName);
+            }
         } finally {
-            forceCloseWallet(walletRpc, walletName);
-            deleteWalletFiles(walletName);
+            accountService.endWalletCreation();
         }
     }
 
@@ -432,11 +461,47 @@ public class XmrWalletService extends XmrWalletBase {
         return openWallet(walletName, null, applyProxyUri, trustDaemon);
     }
 
+    /**
+     * Opens a wallet with an explicit password and no interrupted-change healing, for reopening
+     * with an in-flight password change's target before the account password itself commits (the
+     * account password still reports the old password during change notifications, and healing
+     * would silently convert the wallet back to it).
+     */
+    public MoneroWallet openWallet(String walletName, Integer walletRpcPort, String password, boolean applyProxyUri, boolean trustDaemon) {
+        if (isShutDownStarted) throw new IllegalStateException("Cannot open wallet '" + walletName + "' because shutting down");
+        MoneroWalletConfig config = getWalletConfig(walletName).setPassword(password);
+        return isNativeLibraryApplied() ? openWalletFull(config, applyProxyUri) : openWalletRpc(config, walletRpcPort, applyProxyUri, trustDaemon);
+    }
+
     public MoneroWallet openWallet(String walletName, Integer walletRpcPort, boolean applyProxyUri, boolean trustDaemon) {
         log.debug("{}.openWallet({})", getClass().getSimpleName(), walletName);
         if (isShutDownStarted) throw new IllegalStateException("Cannot open wallet '" + walletName + "' because shutting down");
-        MoneroWalletConfig config = getWalletConfig(walletName);
-        return isNativeLibraryApplied() ? openWalletFull(config, applyProxyUri) : openWalletRpc(config, walletRpcPort, applyProxyUri, trustDaemon);
+        try {
+            MoneroWalletConfig config = getWalletConfig(walletName);
+            return isNativeLibraryApplied() ? openWalletFull(config, applyProxyUri) : openWalletRpc(config, walletRpcPort, applyProxyUri, trustDaemon);
+        } catch (Exception e) {
+
+            // an interrupted password change can leave the wallet on the counterpart password;
+            // open with it and converge the wallet back to the current password
+            String[] counterpart = accountService.getPendingPasswordChangeCounterpart();
+            if (counterpart == null) throw e;
+            String counterpartPassword = counterpart[0] == null || counterpart[0].isEmpty() ? MONERO_WALLET_RPC_DEFAULT_PASSWORD : counterpart[0];
+            log.warn("Could not open wallet {}; retrying with the interrupted password change's counterpart password", walletName, e);
+            MoneroWalletConfig config = getWalletConfig(walletName).setPassword(counterpartPassword);
+            MoneroWallet wallet = isNativeLibraryApplied() ? openWalletFull(config, applyProxyUri) : openWalletRpc(config, walletRpcPort, applyProxyUri, trustDaemon);
+            // while a password change transaction runs in this process, the account password still
+            // reports the retiring password; converging would silently undo the wallet's rotation
+            if (accountService.isPasswordChangeInProgress()) return wallet;
+            wallet.changePassword(counterpartPassword, getWalletPassword());
+            wallet.save();
+            try {
+                refreshWalletBackups(walletName);
+            } catch (Exception e2) {
+                // keep the healed wallet available; pending recovery refreshes the backups again
+                log.warn("Could not refresh backups of healed wallet {}: {}", walletName, e2.getMessage());
+            }
+            return wallet;
+        }
     }
 
     // Restore the main wallet from the given seed, scanning from restoreHeight or else restoreDate. The restored wallet
@@ -451,19 +516,25 @@ public class XmrWalletService extends XmrWalletBase {
             log.info("{}.restoreWalletFromSeed(restoreHeight={})", getClass().getSimpleName(), height);
 
             // create the restored wallet under a temporary name so the current wallet is preserved if the seed is invalid
-            String restoreName = MONERO_WALLET_NAME + "_restore";
-            deleteWalletFiles(restoreName);
-            MoneroWalletConfig config = getWalletConfig(restoreName).setSeed(seed).setRestoreHeight(height);
-            MoneroWallet restored = isNativeLibraryApplied() ? createWalletFull(config, isProxyApplied()) : createWalletRpc(config, null, isProxyApplied(), xmrConnectionService.isTrustedDaemon());
-            closeWallet(restored, true);
+            // registered so a concurrent password change cannot miss the wallet files while they exist under either name
+            accountService.beginWalletCreation();
+            try {
+                String restoreName = MONERO_WALLET_NAME + "_restore";
+                deleteWalletFiles(restoreName);
+                MoneroWalletConfig config = getWalletConfig(restoreName).setSeed(seed).setRestoreHeight(height);
+                MoneroWallet restored = isNativeLibraryApplied() ? createWalletFull(config, isProxyApplied()) : createWalletRpc(config, null, isProxyApplied(), xmrConnectionService.isTrustedDaemon());
+                closeWallet(restored, true);
 
-            // replace the current wallet with the restored wallet, keeping a backup
-            closeMainWallet(true);
-            if (walletExists(MONERO_WALLET_NAME)) {
-                backupWallet(MONERO_WALLET_NAME);
-                deleteWallet(MONERO_WALLET_NAME);
+                // replace the current wallet with the restored wallet, keeping a backup
+                closeMainWallet(true);
+                if (walletExists(MONERO_WALLET_NAME)) {
+                    backupWallet(MONERO_WALLET_NAME);
+                    deleteWallet(MONERO_WALLET_NAME);
+                }
+                moveWallet(restoreName, MONERO_WALLET_NAME);
+            } finally {
+                accountService.endWalletCreation();
             }
-            moveWallet(restoreName, MONERO_WALLET_NAME);
             user.setWalletCreationDate(estimateHeightTimestamp(height));
         }
     }
@@ -485,6 +556,26 @@ public class XmrWalletService extends XmrWalletBase {
             File file = new File(walletDir, walletName + postfix);
             if (file.exists() && !file.delete()) throw new RuntimeException("Failed to delete wallet file " + Utilities.redactSensitiveInfo(file.toString()));
         }
+    }
+
+    // Best-effort per file with the keys file first, so a locked sibling cannot leave it behind.
+    private void deleteWalletFilesBestEffort(String walletName) {
+        assertNotPath(walletName);
+        for (String postfix : new String[] {KEYS_FILE_POSTFIX, "", ADDRESS_FILE_POSTFIX}) {
+            File file = new File(walletDir, walletName + postfix);
+            try {
+                if (file.exists() && !file.delete()) log.warn("Failed to delete wallet file {}", Utilities.redactSensitiveInfo(file.toString()));
+            } catch (Exception e) {
+                log.warn("Error deleting wallet file {}: {}", Utilities.redactSensitiveInfo(file.toString()), e.getMessage());
+            }
+        }
+    }
+
+    /** Files of the throwaway seed validation wallet, which must never be archived in backups. */
+    public static List<File> getSeedValidationWalletFiles(File walletDir) {
+        List<File> files = new ArrayList<>();
+        for (String postfix : new String[] {"", KEYS_FILE_POSTFIX, ADDRESS_FILE_POSTFIX}) files.add(new File(walletDir, SEED_VALIDATION_WALLET_NAME + postfix));
+        return files;
     }
 
     private MoneroWalletConfig getWalletConfig(String walletName) {
@@ -592,6 +683,18 @@ public class XmrWalletService extends XmrWalletBase {
         FileUtil.deleteRollingBackup(walletDir, walletName);
         FileUtil.deleteRollingBackup(walletDir, walletName + KEYS_FILE_POSTFIX);
         FileUtil.deleteRollingBackup(walletDir, walletName + ADDRESS_FILE_POSTFIX);
+    }
+
+    /** Like {@link #deleteWalletBackups} but verifies the deletion and propagates failure. */
+    public void deleteWalletBackupsStrict(String walletName) {
+        assertNotPath(walletName);
+        try {
+            FileUtil.deleteRollingBackupStrict(walletDir, walletName);
+            FileUtil.deleteRollingBackupStrict(walletDir, walletName + KEYS_FILE_POSTFIX);
+            FileUtil.deleteRollingBackupStrict(walletDir, walletName + ADDRESS_FILE_POSTFIX);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not delete backups of wallet " + walletName, e);
+        }
     }
 
     private static void assertNotPath(String name) {
@@ -1549,6 +1652,11 @@ public class XmrWalletService extends XmrWalletBase {
 
     private void initialize() {
 
+        // remove any crash-left seed validation wallet, which older versions keyed under a fixed password
+        synchronized (seedValidationLock) {
+            deleteWalletFilesBestEffort(SEED_VALIDATION_WALLET_NAME);
+        }
+
         // try to load native monero library
         if (useNativeXmrWallet && !MoneroUtils.isNativeLibraryLoaded()) {
             try {
@@ -2089,13 +2197,32 @@ public class XmrWalletService extends XmrWalletBase {
 
         // create task to change main wallet password
         List<Runnable> tasks = new ArrayList<Runnable>();
+        List<Exception> failures = Collections.synchronizedList(new ArrayList<>());
         tasks.add(() -> {
             try {
-                getInitializedWallet().changePassword(oldPassword, newPassword);
+                // nothing to rotate before the main wallet is first created (creating it here
+                // would be rejected by the wallet creation gate the transaction itself holds)
+                if (wallet == null && !walletExists(MONERO_WALLET_NAME)) {
+                    log.info("Main wallet does not exist, skipping password change");
+                    return;
+                }
+                changeWalletPassword(getInitializedWallet(), oldPassword, newPassword);
                 saveWallet();
+                if (Utilities.isWindows()) {
+                    // Windows locks open wallet files, so close for the backup refresh and reopen
+                    // with the change's target password (the account password has not committed yet)
+                    synchronized (walletLock) {
+                        log.info("Closing main wallet to refresh backups on Windows");
+                        closeMainWallet();
+                        refreshWalletBackups(MONERO_WALLET_NAME);
+                        wallet = openWallet(MONERO_WALLET_NAME, rpcBindPort, newPassword, isProxyApplied(), xmrConnectionService.isTrustedDaemon());
+                    }
+                } else {
+                    refreshWalletBackups(MONERO_WALLET_NAME);
+                }
             } catch (Exception e) {
                 log.warn("Error changing main wallet password: " + e.getMessage() + "\n", e);
-                throw e;
+                failures.add(e);
             }
         });
 
@@ -2103,17 +2230,132 @@ public class XmrWalletService extends XmrWalletBase {
         List<Trade> trades = HavenoUtils.tradeManager.getAllTrades();
         for (Trade trade : trades) {
             tasks.add(() -> {
-                synchronized (trade.getWalletLock()) {
-                    if (trade.walletExists()) {
-                        trade.changeWalletPassword(oldPassword, newPassword); // TODO (woodser): this unnecessarily connects and syncs unopen wallets and leaves open
+                try {
+                    synchronized (trade.getWalletLock()) {
+                        if (trade.walletExists()) {
+                            trade.changeWalletPassword(oldPassword, newPassword); // TODO (woodser): this unnecessarily connects and syncs unopen wallets and leaves open
+                        }
                     }
+                } catch (Exception e) {
+                    log.warn("Error changing trade wallet password for {}: {}\n", trade.getId(), e.getMessage(), e);
+                    failures.add(e);
                 }
             });
         }
 
-        // execute tasks in parallel
-        ThreadUtils.awaitTasks(tasks, Math.min(10, 1 + trades.size()));
+        // create tasks to change orphan wallet passwords (wallet files not represented by trade
+        // state, e.g. from failed cleanup or an interrupted restore), so no wallet file on disk
+        // silently remains under an old password
+        Set<String> knownWalletNames = new HashSet<>();
+        knownWalletNames.add(MONERO_WALLET_NAME);
+        // a crash-left seed validation wallet is on the default password, not an account password
+        knownWalletNames.add(SEED_VALIDATION_WALLET_NAME);
+        for (Trade trade : trades) knownWalletNames.add(trade.getWalletName());
+        List<String> orphanWalletNames = new ArrayList<>();
+        File[] walletFiles = walletDir.listFiles();
+        if (walletFiles == null) throw new IllegalStateException("Could not list wallet directory " + walletDir.getAbsolutePath());
+        for (File file : walletFiles) {
+            if (!file.isFile() || !file.getName().endsWith(KEYS_FILE_POSTFIX)) continue;
+            String orphanName = file.getName().substring(0, file.getName().length() - KEYS_FILE_POSTFIX.length());
+            if (knownWalletNames.contains(orphanName)) continue;
+            orphanWalletNames.add(orphanName);
+            tasks.add(() -> {
+                try {
+                    changeOrphanWalletPassword(orphanName, oldPassword, newPassword);
+                } catch (Exception e) {
+                    log.warn("Error changing orphan wallet password for {}: {}\n", orphanName, e.getMessage(), e);
+                    failures.add(e);
+                }
+            });
+        }
+
+        // execute all tasks in parallel, so every wallet is attempted before failure is reported
+        ThreadUtils.awaitTasks(tasks, Math.min(10, tasks.size()));
+        if (!failures.isEmpty()) throw new RuntimeException("Failed to change the password of " + failures.size() + " wallet(s)", failures.get(0));
+
+        // backups of wallets that no longer exist could not be rotated and still open with a
+        // previous password, but may also be the only remaining key copy (e.g. after a failed
+        // cleanup or lost trade state), so they are never deleted; warn so the user can resolve
+        Set<String> keep = new HashSet<>();
+        List<String> walletNames = new ArrayList<>();
+        walletNames.add(MONERO_WALLET_NAME);
+        for (Trade trade : trades) walletNames.add(trade.getWalletName());
+        walletNames.addAll(orphanWalletNames);
+        for (String walletName : walletNames) {
+            for (String postfix : new String[]{"", KEYS_FILE_POSTFIX, ADDRESS_FILE_POSTFIX}) keep.add(walletName + postfix);
+            // a kept backup with no live wallet could not be rotated and still opens with the
+            // previous password; keep it (it may be the only remaining key copy) but say so
+            if (!new File(walletDir, walletName + KEYS_FILE_POSTFIX).exists() && FileUtil.hasBackups(walletDir, walletName + KEYS_FILE_POSTFIX)) {
+                log.warn("Backups of wallet {} are retained but still open with the previous password because the wallet file itself is missing", walletName);
+            }
+        }
+        try {
+            for (File staleBackupDir : FileUtil.getRollingBackupDirsExcept(walletDir, keep)) {
+                log.warn("Wallet backups in {} are retained but still open with a previous password because their wallet no longer exists; " +
+                        "move them out of the wallet directory if they are no longer needed", staleBackupDir.getName());
+            }
+        } catch (IOException e) {
+            log.error("Could not inspect the wallet backup directory for stale backups", e);
+        }
         log.info("Done changing all wallet passwords");
+    }
+
+    /**
+     * Rotates a wallet file not represented by trade state. The wallet must open with the old or
+     * new password (the latter from an interrupted change); otherwise the password change fails
+     * so no wallet silently stays under a stale password. Never deletes a wallet.
+     */
+    private void changeOrphanWalletPassword(String walletName, String oldPassword, String newPassword) {
+        log.warn("Changing password of orphan wallet {}", walletName);
+        MoneroWallet wallet;
+        try {
+            wallet = openWallet(walletName, null, oldPassword, isProxyApplied(), xmrConnectionService.isTrustedDaemon());
+        } catch (Exception e) {
+            try {
+                wallet = openWallet(walletName, null, newPassword, isProxyApplied(), xmrConnectionService.isTrustedDaemon());
+            } catch (Exception e2) {
+                throw new IllegalStateException("Orphan wallet " + walletName + " cannot be opened with the current or target password; " +
+                        "move it out of the wallet directory to change the password", e);
+            }
+        }
+        try {
+            changeWalletPassword(wallet, oldPassword, newPassword);
+        } finally {
+            closeWallet(wallet, true);
+        }
+        refreshWalletBackups(walletName);
+    }
+
+    /**
+     * Replaces a wallet's backups so none remains under a previous password. The fresh backup is
+     * created and verified first, so a failure can never leave the wallet without a usable backup;
+     * only then are the stale generations purged, with verification.
+     */
+    public void refreshWalletBackups(String walletName) {
+        assertNotPath(walletName);
+        try {
+            for (String postfix : new String[]{"", KEYS_FILE_POSTFIX, ADDRESS_FILE_POSTFIX}) {
+                FileUtil.replaceRollingBackups(walletDir, walletName + postfix);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not refresh backups of wallet " + walletName, e);
+        }
+    }
+
+    /**
+     * Changes a wallet's password, tolerating a wallet already on the new password from an
+     * interrupted change (proven by a no-op re-encryption with the new password).
+     */
+    public static void changeWalletPassword(MoneroWallet wallet, String oldPassword, String newPassword) {
+        try {
+            wallet.changePassword(oldPassword, newPassword);
+        } catch (Exception e) {
+            try {
+                wallet.changePassword(newPassword, newPassword);
+            } catch (Exception e2) {
+                throw e;
+            }
+        }
     }
 
     private MoneroWallet openOrCreateMainWallet() {

--- a/core/src/test/java/haveno/core/api/CoreAccountServicePasswordChangeTest.java
+++ b/core/src/test/java/haveno/core/api/CoreAccountServicePasswordChangeTest.java
@@ -1,0 +1,661 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.api;
+
+import com.google.protobuf.ByteString;
+import haveno.common.Payload;
+import haveno.common.crypto.Encryption;
+import haveno.common.crypto.IncorrectPasswordException;
+import haveno.common.crypto.KeyRing;
+import haveno.common.crypto.KeyStorage;
+import haveno.common.crypto.ScryptUtil;
+import haveno.common.file.FileUtil;
+import haveno.common.persistence.PersistenceManager;
+import haveno.common.proto.persistable.PersistableEnvelope;
+import haveno.common.proto.persistable.PersistablePayload;
+import haveno.common.proto.persistable.PersistenceProtoResolver;
+import haveno.common.util.Utilities;
+import haveno.core.xmr.model.EncryptedConnectionList;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.crypto.SecretKey;
+import monero.common.MoneroRpcConnection;
+import org.bitcoinj.crypto.KeyCrypterScrypt;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fault-injection and restart-recovery tests for the transactional password change. Components
+ * (wallets, credentials) are simulated by listeners with the same idempotent ensure-semantics as
+ * the production handlers: converging to a password the component already holds succeeds.
+ */
+public class CoreAccountServicePasswordChangeTest {
+
+    private static final String OLD_PASSWORD = "old password 123";
+    private static final String NEW_PASSWORD = "new password 456";
+    private static final String JOURNAL_FILE = "password_change";
+    private static final String PENDING_SYM_FILE = "sym.key.new";
+
+    private File dir;
+
+    private static class ComponentListener extends AccountServiceListener {
+        final List<String[]> calls = new ArrayList<>();
+        String componentPassword;
+        int failuresToInject;
+
+        ComponentListener(String initialPassword) {
+            this.componentPassword = initialPassword;
+        }
+
+        @Override
+        public void onPasswordChanged(String oldPassword, String newPassword) {
+            calls.add(new String[]{oldPassword, newPassword});
+            if (failuresToInject > 0) {
+                failuresToInject--;
+                throw new RuntimeException("injected component failure");
+            }
+            if (Objects.equals(componentPassword, newPassword)) return; // already converged
+            if (!Objects.equals(componentPassword, oldPassword)) throw new IllegalStateException("Component is on an unexpected password");
+            componentPassword = newPassword;
+        }
+    }
+
+    @BeforeEach
+    public void setup(@TempDir File dir) {
+        this.dir = dir;
+        PersistenceManager.allServicesInitialized.set(true); // let recovery run immediately
+    }
+
+    @AfterEach
+    public void tearDown() {
+        PersistenceManager.allServicesInitialized.set(false);
+    }
+
+    private CoreAccountService createAccount() throws Exception {
+        KeyStorage keyStorage = new KeyStorage(dir);
+        KeyRing keyRing = new KeyRing(keyStorage, dir, OLD_PASSWORD, true);
+        CoreAccountService service = new CoreAccountService(null, keyStorage, keyRing);
+        service.openAccount(OLD_PASSWORD);
+        return service;
+    }
+
+    // Simulates a process restart: fresh key storage, key ring and account service over the same dir.
+    private CoreAccountService restart() {
+        KeyStorage keyStorage = new KeyStorage(dir);
+        return new CoreAccountService(null, keyStorage, new KeyRing(keyStorage, dir, null, false));
+    }
+
+    // Recovery runs on a background thread; wait for it to commit (journal removal).
+    private void awaitRecoveryCommit() throws InterruptedException {
+        for (int i = 0; i < 100 && new File(dir, JOURNAL_FILE).exists(); i++) Thread.sleep(50);
+        assertFalse(new File(dir, JOURNAL_FILE).exists(), "recovery did not commit");
+    }
+
+    private void interruptChangeMidway(CoreAccountService service) {
+        interruptChangeMidway(service, OLD_PASSWORD, NEW_PASSWORD);
+    }
+
+    private void interruptChangeMidway(CoreAccountService service, String fromPassword, String toPassword) {
+        ComponentListener crashing = new ComponentListener(fromPassword);
+        crashing.failuresToInject = 2; // fail the forward pass and the in-process revert, like a crash
+        service.addListener(crashing);
+        assertThrows(RuntimeException.class, () -> service.changePassword(fromPassword, toPassword));
+        service.removeListener(crashing);
+        assertTrue(new File(dir, JOURNAL_FILE).exists());
+    }
+
+    @Test
+    public void testChangePasswordCommitsAndCleansUp() throws Exception {
+        CoreAccountService service = createAccount();
+        ComponentListener component = new ComponentListener(OLD_PASSWORD);
+        service.addListener(component);
+
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+
+        assertEquals(NEW_PASSWORD, service.getPassword());
+        assertEquals(NEW_PASSWORD, component.componentPassword);
+        assertFalse(new File(dir, PENDING_SYM_FILE).exists());
+        assertFalse(new File(dir, JOURNAL_FILE).exists());
+
+        // only the new password unlocks after commit
+        assertThrows(IncorrectPasswordException.class, () -> restart().openAccount(OLD_PASSWORD));
+        restart().openAccount(NEW_PASSWORD);
+    }
+
+    @Test
+    public void testComponentFailureRevertsAndCleansUp() throws Exception {
+        CoreAccountService service = createAccount();
+        ComponentListener healthy = new ComponentListener(OLD_PASSWORD);
+        ComponentListener failing = new ComponentListener(OLD_PASSWORD);
+        failing.failuresToInject = 1;
+        service.addListener(healthy);
+        service.addListener(failing);
+
+        assertThrows(RuntimeException.class, () -> service.changePassword(OLD_PASSWORD, NEW_PASSWORD));
+
+        // the healthy component was converged back to the old password and no journal remains
+        assertEquals(OLD_PASSWORD, service.getPassword());
+        assertEquals(2, healthy.calls.size());
+        assertEquals(OLD_PASSWORD, healthy.componentPassword);
+        assertFalse(new File(dir, PENDING_SYM_FILE).exists());
+        assertFalse(new File(dir, JOURNAL_FILE).exists());
+        restart().openAccount(OLD_PASSWORD);
+    }
+
+    @Test
+    public void testInterruptedChangeLeavesBothPasswordsUnlockable() throws Exception {
+        interruptChangeMidway(createAccount());
+
+        // both wrappers unlock while the journal is pending (checked without triggering recovery)
+        new KeyStorage(dir).loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, OLD_PASSWORD);
+        new KeyStorage(dir).loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, NEW_PASSWORD);
+    }
+
+    @Test
+    public void testRecoveryConvergesForwardToNewPassword() throws Exception {
+        interruptChangeMidway(createAccount());
+
+        // restart and open with the new password: recovery converges components forward and commits
+        CoreAccountService restarted = restart();
+        ComponentListener component = new ComponentListener(OLD_PASSWORD); // e.g. a wallet not yet changed
+        restarted.addListener(component);
+        restarted.openAccount(NEW_PASSWORD);
+        awaitRecoveryCommit();
+
+        assertEquals(1, component.calls.size());
+        assertEquals(OLD_PASSWORD, component.calls.get(0)[0]);
+        assertEquals(NEW_PASSWORD, component.calls.get(0)[1]);
+        assertEquals(NEW_PASSWORD, component.componentPassword);
+        assertFalse(new File(dir, PENDING_SYM_FILE).exists());
+
+        assertThrows(IncorrectPasswordException.class, () -> restart().openAccount(OLD_PASSWORD));
+        restart().openAccount(NEW_PASSWORD);
+    }
+
+    @Test
+    public void testRecoveryConvergesBackToOldPassword() throws Exception {
+        interruptChangeMidway(createAccount());
+
+        // restart and open with the old password: recovery converges components back and commits
+        CoreAccountService restarted = restart();
+        ComponentListener component = new ComponentListener(NEW_PASSWORD); // e.g. a wallet already changed
+        restarted.addListener(component);
+        restarted.openAccount(OLD_PASSWORD);
+        awaitRecoveryCommit();
+
+        assertEquals(1, component.calls.size());
+        assertEquals(NEW_PASSWORD, component.calls.get(0)[0]);
+        assertEquals(OLD_PASSWORD, component.calls.get(0)[1]);
+        assertEquals(OLD_PASSWORD, component.componentPassword);
+
+        assertThrows(IncorrectPasswordException.class, () -> restart().openAccount(NEW_PASSWORD));
+        restart().openAccount(OLD_PASSWORD);
+    }
+
+    @Test
+    public void testPendingCounterpartExposedForWalletHealing() throws Exception {
+        CoreAccountService service = createAccount();
+        interruptChangeMidway(service);
+
+        // wallets opened before recovery completes can query the counterpart password
+        String[] counterpart = service.getPendingPasswordChangeCounterpart();
+        assertEquals(NEW_PASSWORD, counterpart[0]);
+
+        CoreAccountService restarted = restart();
+        restarted.openAccount(NEW_PASSWORD);
+        awaitRecoveryCommit();
+        assertNull(restarted.getPendingPasswordChangeCounterpart());
+    }
+
+    @Test
+    public void testChangeRejectedWhileRecoveryPending() throws Exception {
+        CoreAccountService service = createAccount();
+        interruptChangeMidway(service);
+
+        // a new change is refused until the pending one is recovered
+        assertThrows(IllegalStateException.class, () -> service.changePassword(OLD_PASSWORD, "another password"));
+    }
+
+    @Test
+    public void testUnreadableJournalPreservesBothWrappers() throws Exception {
+        interruptChangeMidway(createAccount());
+
+        // corrupt the journal so it fails authentication
+        File journal = new File(dir, JOURNAL_FILE);
+        byte[] bytes = java.nio.file.Files.readAllBytes(journal.toPath());
+        bytes[bytes.length - 1] ^= 0x01;
+        java.nio.file.Files.write(journal.toPath(), bytes);
+
+        // opening with the new password relies on the pending wrapper; recovery must not delete it
+        CoreAccountService restarted = restart();
+        restarted.openAccount(NEW_PASSWORD);
+        Thread.sleep(1000); // give deferred recovery a chance to run
+        assertTrue(new File(dir, JOURNAL_FILE).exists());
+        assertTrue(new File(dir, PENDING_SYM_FILE).exists());
+
+        // both passwords still unlock
+        new KeyStorage(dir).loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, OLD_PASSWORD);
+        new KeyStorage(dir).loadSecretKey(KeyStorage.KeyEntry.SYM_ENCRYPTION, NEW_PASSWORD);
+    }
+
+    @Test
+    public void testNonAsciiPasswordChangeSucceeds() throws Exception {
+        CoreAccountService service = createAccount();
+        ComponentListener component = new ComponentListener(OLD_PASSWORD);
+        service.addListener(component);
+
+        String unicodePassword = "pässwörd éè 123";
+        service.changePassword(OLD_PASSWORD, unicodePassword);
+
+        assertEquals(unicodePassword, component.componentPassword);
+        assertFalse(new File(dir, JOURNAL_FILE).exists());
+        restart().openAccount(unicodePassword);
+        assertThrows(IncorrectPasswordException.class, () -> restart().openAccount(OLD_PASSWORD));
+    }
+
+    @Test
+    public void testPasswordCanonicalizedForAllComponents() throws Exception {
+        CoreAccountService service = createAccount();
+        ComponentListener component = new ComponentListener(OLD_PASSWORD);
+        service.addListener(component);
+
+        String nfd = "passwo\u0301rd 123"; // o + combining acute
+        String nfc = java.text.Normalizer.normalize(nfd, java.text.Normalizer.Form.NFC);
+        assertNotEquals(nfd, nfc);
+        service.changePassword(OLD_PASSWORD, nfd);
+
+        // components (wallets, credentials) and account state receive the canonical NFC form
+        assertEquals(nfc, component.componentPassword);
+        assertEquals(nfc, service.getPassword());
+
+        // either spelling opens the account, both normalizing to the same form
+        restart().openAccount(nfc);
+        restart().openAccount(nfd);
+    }
+
+    @Test
+    public void testControlCharacterPasswordRejectedWithoutArtifacts() throws Exception {
+        CoreAccountService service = createAccount();
+
+        assertThrows(IllegalStateException.class, () -> service.changePassword(OLD_PASSWORD, "password\nwith newline"));
+
+        // nothing durable was written and a valid change still works
+        assertFalse(new File(dir, JOURNAL_FILE).exists());
+        assertFalse(new File(dir, PENDING_SYM_FILE).exists());
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+    }
+
+    @Test
+    public void testCleanupFailureAfterCommitKeepsNewPassword() throws Exception {
+        Assumptions.assumeFalse(Utilities.isWindows()); // POSIX permissions
+        CoreAccountService service = createAccount();
+        File symBackups = new File(dir, "backup/backups_sym_key");
+        assertTrue(symBackups.exists());
+        assertTrue(symBackups.setReadable(false));
+        Assumptions.assumeTrue(symBackups.listFiles() == null, "permissions not enforced (running as root?)");
+        try {
+            // cleanup fails after the commit point, but the change must still report success
+            service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+        } finally {
+            assertTrue(symBackups.setReadable(true));
+        }
+        assertEquals(NEW_PASSWORD, service.getPassword());
+        assertTrue(new File(dir, JOURNAL_FILE).exists()); // cleanup pending until recovered
+
+        // only the new password matches durable state; reopening finishes the cleanup
+        assertThrows(IncorrectPasswordException.class, () -> restart().openAccount(OLD_PASSWORD));
+        restart().openAccount(NEW_PASSWORD);
+        awaitRecoveryCommit();
+        assertTrue(FileUtil.hasBackups(dir, "sym.key")); // cleanup ends with a verified fresh backup
+    }
+
+    @Test
+    public void testMissingFreshBackupKeepsChangePending() throws Exception {
+        CoreAccountService service = createAccount();
+        // a regular file in place of the backup tree makes the fresh wrapper backup impossible
+        File backupDir = new File(dir, "backup");
+        FileUtil.deleteDirectory(backupDir);
+        assertTrue(backupDir.createNewFile());
+
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+
+        // the change commits, but the transaction stays visibly pending: the pending wrapper and
+        // journal must not be cleared while the live sym.key is the only durable copy
+        assertEquals(NEW_PASSWORD, service.getPassword());
+        assertTrue(new File(dir, JOURNAL_FILE).exists());
+        assertTrue(new File(dir, PENDING_SYM_FILE).exists());
+        assertFalse(FileUtil.hasBackups(dir, "sym.key"));
+
+        // once backups are possible again, reopening completes cleanup with a verified backup
+        assertTrue(backupDir.delete());
+        restart().openAccount(NEW_PASSWORD);
+        awaitRecoveryCommit();
+        assertTrue(FileUtil.hasBackups(dir, "sym.key"));
+    }
+
+    @Test
+    public void testChangeRejectedBeforeServicesInitialized() throws Exception {
+        // wallets and credentials converge through listeners that only all exist once services
+        // are initialized; an earlier change would commit with components left on the old password
+        CoreAccountService service = createAccount();
+        PersistenceManager.allServicesInitialized.set(false);
+        try {
+            assertThrows(IllegalStateException.class, () -> service.changePassword(OLD_PASSWORD, NEW_PASSWORD));
+            assertFalse(new File(dir, JOURNAL_FILE).exists());
+            assertFalse(new File(dir, PENDING_SYM_FILE).exists());
+        } finally {
+            PersistenceManager.allServicesInitialized.set(true);
+        }
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+    }
+
+    @Test
+    public void testAccountPasswordStaysOldDuringChangeNotifications() throws Exception {
+        // components must key wallet reopens on the listener's target argument: the account
+        // password does not switch until the commit point, and deriving a reopen password from it
+        // mid-change would let counterpart healing silently reverse the change
+        CoreAccountService service = createAccount();
+        List<String> observed = new ArrayList<>();
+        service.addListener(new AccountServiceListener() {
+            @Override
+            public void onPasswordChanged(String oldPassword, String newPassword) {
+                observed.add(service.getPassword());
+            }
+        });
+
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+
+        assertEquals(List.of(OLD_PASSWORD), observed);
+        assertEquals(NEW_PASSWORD, service.getPassword());
+    }
+
+    @Test
+    public void testCommitFailureRevertsAndCleansUp() throws Exception {
+        CoreAccountService service = createAccount();
+        ComponentListener component = new ComponentListener(OLD_PASSWORD);
+        service.addListener(component);
+
+        // block the commit-point sym.key rewrite (non-empty dir survives the temp cleanup); the
+        // components already on the new password must be rolled back instead of leaving a split state
+        File blocker = new File(dir, "sym.key.tmp");
+        assertTrue(blocker.mkdir());
+        File inner = new File(blocker, "inner");
+        assertTrue(inner.createNewFile());
+        try {
+            assertThrows(RuntimeException.class, () -> service.changePassword(OLD_PASSWORD, NEW_PASSWORD));
+        } finally {
+            assertTrue(inner.delete());
+            assertTrue(blocker.delete());
+        }
+
+        assertEquals(OLD_PASSWORD, service.getPassword());
+        assertEquals(OLD_PASSWORD, component.componentPassword);
+        assertFalse(new File(dir, JOURNAL_FILE).exists());
+        assertFalse(new File(dir, PENDING_SYM_FILE).exists());
+        restart().openAccount(OLD_PASSWORD);
+
+        // once the fault clears the change works
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+        assertEquals(NEW_PASSWORD, component.componentPassword);
+    }
+
+    @Test
+    public void testBackupGuardExcludesPasswordChange() throws Exception {
+        CoreAccountService service = createAccount();
+
+        // any backup entry point (API stream or desktop copy) shares this guard
+        service.beginBackup();
+        assertThrows(IllegalStateException.class, service::beginBackup);
+        assertThrows(IllegalStateException.class, () -> service.changePassword(OLD_PASSWORD, NEW_PASSWORD));
+        service.endBackup();
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+
+        // and a pending password change blocks new backups until recovered
+        CoreAccountService interrupted = createInterrupted();
+        assertThrows(IllegalStateException.class, interrupted::beginBackup);
+    }
+
+    // An account with an interrupted password change (pending journal), reusing the same dir.
+    private CoreAccountService createInterrupted() throws Exception {
+        CoreAccountService service = restart();
+        service.openAccount(NEW_PASSWORD);
+        interruptChangeMidway(service, NEW_PASSWORD, "another password 789");
+        return service;
+    }
+
+    @Test
+    public void testConnectionCredentialsHealedFromCounterpartPassword() throws Exception {
+        CoreAccountService service = createAccount();
+
+        // connection list whose credentials the interrupted change already converged to the new password
+        PersistenceManager<EncryptedConnectionList> manager = new PersistenceManager<>(dir, CONNECTIONS_RESOLVER, null, null);
+        try {
+            EncryptedConnectionList connections = new EncryptedConnectionList(manager, service);
+            CountDownLatch latch = new CountDownLatch(1);
+            connections.readPersisted(latch::countDown);
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            connections.addConnection(new MoneroRpcConnection("http://node:18081", "user", "pass"));
+            connections.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+            interruptChangeMidway(service); // journal pending; the account stays on the old password
+            manager.shutdown(); // deregister so the restarted instance can register
+
+            // a restart reads the credentials with the account password; instead of failing (and
+            // deadlocking startup before recovery can run) they converge from the counterpart
+            PersistenceManager<EncryptedConnectionList> restartedManager = new PersistenceManager<>(dir, CONNECTIONS_RESOLVER, null, null);
+            manager = restartedManager;
+            EncryptedConnectionList restarted = new EncryptedConnectionList(restartedManager, service);
+            CountDownLatch restartedLatch = new CountDownLatch(1);
+            restarted.readPersisted(restartedLatch::countDown);
+            assertTrue(restartedLatch.await(10, TimeUnit.SECONDS));
+            assertEquals("pass", restarted.getConnections().get(0).getPassword());
+            assertEquals("pass", restarted.getConnections().get(0).getPassword()); // stays readable once converged
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testLegacyConnectionMigratesToV2() throws Exception {
+        CoreAccountService service = createAccount();
+        KeyCrypterScrypt kcs = ScryptUtil.getKeyCrypterScrypt();
+        SecretKey legacyKey = Encryption.getSecretKeyFromBytes(kcs.deriveKey(OLD_PASSWORD).getKey());
+        byte[] connSalt = new byte[16];
+        java.util.Arrays.fill(connSalt, (byte) 0x55);
+        byte[] password = "pass".getBytes(StandardCharsets.UTF_8);
+        byte[] salted = new byte[password.length + connSalt.length];
+        System.arraycopy(password, 0, salted, 0, password.length);
+        System.arraycopy(connSalt, 0, salted, password.length, connSalt.length);
+        writeConnectionList(kcs, Encryption.encrypt(salted, legacyKey), connSalt);
+
+        PersistenceManager<EncryptedConnectionList> manager = new PersistenceManager<>(dir, CONNECTIONS_RESOLVER, null, null);
+        try {
+            EncryptedConnectionList connections = new EncryptedConnectionList(manager, service);
+            CountDownLatch latch = new CountDownLatch(1);
+            connections.readPersisted(latch::countDown);
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+            assertEquals("pass", connections.getConnections().get(0).getPassword());
+            assertTrue(Encryption.isV2Format(storedEncryptedPassword(connections)));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    public void testLegacyConnectionMigrationRejectsUnsaltedPlaintext() throws Exception {
+        CoreAccountService service = createAccount();
+        KeyCrypterScrypt kcs = ScryptUtil.getKeyCrypterScrypt();
+        SecretKey legacyKey = Encryption.getSecretKeyFromBytes(kcs.deriveKey(OLD_PASSWORD).getKey());
+        byte[] connSalt = new byte[16];
+        java.util.Arrays.fill(connSalt, (byte) 0x55);
+        // simulates a wrong-key ECB decrypt that spuriously succeeds: valid padding, no salt
+        byte[] legacyBlob = Encryption.encrypt(new byte[24], legacyKey);
+        writeConnectionList(kcs, legacyBlob, connSalt);
+
+        PersistenceManager<EncryptedConnectionList> manager = new PersistenceManager<>(dir, CONNECTIONS_RESOLVER, null, null);
+        try {
+            EncryptedConnectionList connections = new EncryptedConnectionList(manager, service);
+            CountDownLatch latch = new CountDownLatch(1);
+            connections.readPersisted(latch::countDown);
+            assertTrue(latch.await(10, TimeUnit.SECONDS));
+
+            // the value must stay in the legacy format, not be re-sealed as authenticated v2
+            assertArrayEquals(legacyBlob, storedEncryptedPassword(connections));
+            assertThrows(IllegalArgumentException.class, connections::getConnections);
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private void writeConnectionList(KeyCrypterScrypt kcs, byte[] encryptedPassword, byte[] encryptionSalt) throws Exception {
+        protobuf.PersistableEnvelope envelope = protobuf.PersistableEnvelope.newBuilder()
+                .setEncryptedConnectionList(protobuf.EncryptedConnectionList.newBuilder()
+                        .setSalt(kcs.getScryptParameters().getSalt())
+                        .addItems(protobuf.EncryptedConnection.newBuilder()
+                                .setUrl("http://node:18081")
+                                .setUsername("user")
+                                .setEncryptedPassword(ByteString.copyFrom(encryptedPassword))
+                                .setEncryptionSalt(ByteString.copyFrom(encryptionSalt)))
+                        .setCurrentConnectionUrl("")
+                        .setAutoSwitch(true))
+                .build();
+        try (FileOutputStream fos = new FileOutputStream(new File(dir, "EncryptedConnectionList"))) {
+            envelope.writeDelimitedTo(fos);
+        }
+    }
+
+    private static byte[] storedEncryptedPassword(EncryptedConnectionList connections) {
+        protobuf.PersistableEnvelope proto = (protobuf.PersistableEnvelope) connections.toProtoMessage();
+        return proto.getEncryptedConnectionList().getItems(0).getEncryptedPassword().toByteArray();
+    }
+
+    private static final PersistenceProtoResolver CONNECTIONS_RESOLVER = new PersistenceProtoResolver() {
+        @Override
+        public PersistableEnvelope fromProto(protobuf.PersistableEnvelope proto) {
+            return EncryptedConnectionList.fromProto(proto.getEncryptedConnectionList());
+        }
+
+        @Override
+        public Payload fromProto(protobuf.PaymentAccountPayload proto) {
+            return null;
+        }
+
+        @Override
+        public PersistablePayload fromProto(protobuf.PersistableNetworkPayload proto) {
+            return null;
+        }
+    };
+
+    @Test
+    public void testMissingLiveWrapperRecoveredFromPendingWrapper() throws Exception {
+        interruptChangeMidway(createAccount());
+
+        // a crash during a non-atomic sym.key replacement can lose the live wrapper while the
+        // journaled pending wrapper remains; the account must still exist and unlock with the
+        // pending wrapper's password, and recovery must recommit the live wrapper
+        assertTrue(new File(dir, "sym.key").delete());
+        CoreAccountService restarted = restart();
+        assertTrue(restarted.accountExists());
+        restarted.openAccount(NEW_PASSWORD);
+        awaitRecoveryCommit();
+
+        assertTrue(new File(dir, "sym.key").exists());
+        assertFalse(new File(dir, PENDING_SYM_FILE).exists());
+        restart().openAccount(NEW_PASSWORD);
+    }
+
+    @Test
+    public void testOrphanPendingWrapperRemovedOnUnlock() throws Exception {
+        createAccount();
+        // simulate a failed transaction initialization that left a pending wrapper but no journal
+        java.nio.file.Files.copy(new File(dir, "sym.key").toPath(), new File(dir, PENDING_SYM_FILE).toPath());
+
+        restart().openAccount(OLD_PASSWORD);
+        assertFalse(new File(dir, PENDING_SYM_FILE).exists());
+    }
+
+    @Test
+    public void testPasswordRemovalAndAddition() throws Exception {
+        CoreAccountService service = createAccount();
+        ComponentListener component = new ComponentListener(OLD_PASSWORD);
+        service.addListener(component);
+
+        service.changePassword(OLD_PASSWORD, null); // remove
+        assertNull(service.getPassword());
+        assertNull(component.componentPassword);
+        restart().openAccount(null);
+
+        service.changePassword(null, NEW_PASSWORD); // add
+        assertEquals(NEW_PASSWORD, service.getPassword());
+        assertEquals(NEW_PASSWORD, component.componentPassword);
+        restart().openAccount(NEW_PASSWORD);
+        assertThrows(IncorrectPasswordException.class, () -> restart().openAccount(null));
+    }
+
+    @Test
+    public void testWalletCreationRejectedDuringPasswordChange() throws Exception {
+        CoreAccountService service = createAccount();
+        AtomicBoolean rejected = new AtomicBoolean();
+        service.addListener(new AccountServiceListener() {
+            @Override
+            public void onPasswordChanged(String oldPassword, String newPassword) {
+                try {
+                    service.beginWalletCreation();
+                    service.endWalletCreation();
+                } catch (IllegalStateException e) {
+                    rejected.set(true);
+                }
+            }
+        });
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+        assertTrue(rejected.get());
+
+        // creations are accepted again once the transaction resolves
+        service.beginWalletCreation();
+        service.endWalletCreation();
+    }
+
+    @Test
+    public void testPasswordChangeRejectedDuringWalletCreation() throws Exception {
+        CoreAccountService service = createAccount();
+        service.beginWalletCreation();
+        assertThrows(IllegalStateException.class, () -> service.changePassword(OLD_PASSWORD, NEW_PASSWORD));
+        assertFalse(new File(dir, JOURNAL_FILE).exists()); // refused before any durable mutation
+        service.endWalletCreation();
+
+        service.changePassword(OLD_PASSWORD, NEW_PASSWORD);
+        assertEquals(NEW_PASSWORD, service.getPassword());
+    }
+}

--- a/core/src/test/java/haveno/core/trade/ClosedTradesStoreTest.java
+++ b/core/src/test/java/haveno/core/trade/ClosedTradesStoreTest.java
@@ -41,8 +41,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClosedTradesStoreTest {
@@ -138,6 +140,23 @@ public class ClosedTradesStoreTest {
         store.appendDelete("a");
         store.appendUpsert(openOffer("a", 0));
         assertEquals(List.of("b", "a"), ids(newStore().load()));
+    }
+
+    @Test
+    public void testOversizedRecordIsQuarantinedAndBatchSurvives() throws Exception {
+        ClosedTradesStore store = newStore();
+        byte[] oversized = new byte[64 * 1024 * 1024]; // EncryptedAppendLog.MAX_FRAME_SIZE
+        oversized[0] = 42;
+        store.appendEntries(List.of(oversized, ClosedTradesStore.upsertBytes(openOffer("a", 0))));
+
+        // the surviving record is appended, and the oversized one is preserved encrypted
+        assertEquals(List.of("a"), ids(newStore().load()));
+        File quarantineDir = new File(dir, FileUtil.CORRUPTED_BACKUP_FOLDER);
+        File[] quarantined = quarantineDir.listFiles((d, name) -> name.startsWith(ClosedTradesStore.LOG_FILE_NAME + ".oversized."));
+        assertNotNull(quarantined);
+        assertEquals(1, quarantined.length);
+        byte[] recovered = Encryption.decryptV2(Files.readAllBytes(quarantined[0].toPath()), keyRing.getSymmetricKey());
+        assertArrayEquals(oversized, recovered);
     }
 
     // Writes a legacy monolithic ClosedTrades file in the exact on-disk format PersistenceManager uses.

--- a/daemon/src/main/java/haveno/daemon/grpc/GrpcAccountService.java
+++ b/daemon/src/main/java/haveno/daemon/grpc/GrpcAccountService.java
@@ -208,6 +208,11 @@ public class GrpcAccountService extends AccountImplBase {
                     stream.close();
                     responseObserver.onCompleted();
                 } catch (Exception ex) {
+                    // close the pipe so the producer unblocks, releases the guard and reopens the account
+                    try {
+                        stream.close();
+                    } catch (Exception ignored) {
+                    }
                     exceptionHandler.handleException(log, ex, responseObserver);
                 }
             }, (ex) -> exceptionHandler.handleException(log, ex, responseObserver));

--- a/desktop/src/main/java/haveno/desktop/main/account/content/backup/BackupView.java
+++ b/desktop/src/main/java/haveno/desktop/main/account/content/backup/BackupView.java
@@ -24,6 +24,7 @@ import haveno.common.file.FileUtil;
 import haveno.common.persistence.PersistenceManager;
 import haveno.common.util.Tuple2;
 import haveno.common.util.Utilities;
+import haveno.core.api.CoreAccountService;
 import haveno.core.api.XmrLocalNode;
 import haveno.core.locale.Res;
 import haveno.core.user.Preferences;
@@ -53,9 +54,10 @@ import javax.annotation.Nullable;
 
 @FxmlView
 public class BackupView extends ActivatableView<GridPane, Void> {
-    private final File dataDir, logFile;
+    private final File dataDir, logFile, walletDir;
     private int gridRow = 0;
     private final Preferences preferences;
+    private final CoreAccountService accountService;
     private Button selectBackupDir, backupNow;
     private TextField backUpLocationTextField;
     private Button openDataDirButton, openLogsButton;
@@ -67,9 +69,11 @@ public class BackupView extends ActivatableView<GridPane, Void> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    private BackupView(Preferences preferences, Config config) {
+    private BackupView(Preferences preferences, Config config, CoreAccountService accountService) {
         super();
         this.preferences = preferences;
+        this.accountService = accountService;
+        this.walletDir = config.walletDir;
         dataDir = new File(config.appDataDir.getPath());
         logFile = new File(Paths.get(dataDir.getPath(), "haveno.log").toString());
     }
@@ -156,8 +160,21 @@ public class BackupView extends ActivatableView<GridPane, Void> {
         log.info("Backing up data directory");
         String backupDirectory = preferences.getBackupDirectory();
         if (backupDirectory != null && backupDirectory.length() > 0) {  // We need to flush data to disk
-            PersistenceManager.flushAllDataToDiskAtBackup(() -> {
+            // share the account backup guard so the copy cannot race a password change or
+            // archive its recovery artifacts
+            try {
+                accountService.beginBackup();
+            } catch (IllegalStateException e) {
+                new Popup().warning(e.getMessage()).show();
+                return;
+            }
+            PersistenceManager.flushAllDataToDiskAtBackup(flushError -> {
                 try {
+                    if (flushError != null) {
+                        log.error("Flushing data to disk failed; not backing up", flushError);
+                        new Popup().error(flushError.toString()).show();
+                        return;
+                    }
 
                     // copy data directory to backup directory
                     String dateString = new SimpleDateFormat("yyyy-MM-dd-HHmmss").format(new Date());
@@ -170,11 +187,19 @@ public class BackupView extends ActivatableView<GridPane, Void> {
                     if (monerod.exists()) monerod.delete();
                     File moneroWalletRpc = new File(destinationFile, XmrWalletService.MONERO_WALLET_RPC_NAME);
                     if (moneroWalletRpc.exists()) moneroWalletRpc.delete();
+
+                    // delete the throwaway seed validation wallet from the backup, which must never be archived
+                    for (File file : XmrWalletService.getSeedValidationWalletFiles(walletDir)) {
+                        File copied = new File(destinationFile, dataDir.toPath().relativize(file.toPath()).toString());
+                        if (copied.exists()) copied.delete();
+                    }
                     new Popup().feedback(Res.get("account.backup.success", destination)).show();
                 } catch (IOException e) {
                     e.printStackTrace();
                     log.error(e.getMessage());
                     showWrongPathWarningAndReset(e);
+                } finally {
+                    accountService.endBackup();
                 }
             });
         }

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,287 @@
+# Application encryption
+
+This documents Haveno's application-layer encryption after the v2 upgrade
+(issues [#1161](https://github.com/haveno-dex/haveno/issues/1161),
+[#2344](https://github.com/haveno-dex/haveno/issues/2344)), the migration
+behavior, and the remaining work with step-by-step plans.
+
+## v2 format
+
+All symmetric encryption uses one authenticated format
+(`common/src/main/java/haveno/common/crypto/Encryption.java`):
+
+```
+"HVN2" (4) || random IV (16) || AES-256-CTR ciphertext || HMAC-SHA256 tag (32)
+```
+
+- Encrypt-then-MAC; the tag covers magic || IV || ciphertext.
+- Encryption and MAC keys are derived from the master key with HKDF-SHA256
+  (infos `haveno.crypto.v2.enc` / `haveno.crypto.v2.mac`), so the master key is
+  never used directly by either primitive.
+- CTR+HMAC instead of GCM so large stores stream with constant memory in two
+  passes (JCE GCM buffers the entire payload on decrypt).
+- Decryption auto-detects v2 vs legacy (AES-ECB) blobs by the magic prefix
+  (`decryptAuto`, `decryptPayloadWithHmacAuto`). A legacy ECB blob starting
+  with the magic has probability 2^-32 and would then fail the tag check.
+- The last magic byte is the format version (`Encryption.blobVersion`,
+  `CURRENT_BLOB_VERSION`); consumers key their automatic re-encryption to it
+  (see "Adding a future format" below).
+
+## Key storage (`sym.key`)
+
+`common/src/main/java/haveno/common/crypto/KeyStorage.java`:
+
+```
+"HVNK" (4) || version (1) || kdf id (1) || mem KiB (4) || iterations (4) || parallelism (4) || salt (16) || v2 blob of master key
+```
+
+- KEK = Argon2id(password, salt) with parameters stored in the header
+  (default 64 MiB / t=3 / p=1; minimal cost when no password is set, since
+  hardening adds nothing without a secret). See `PasswordKdf.java`.
+- Passwords are UTF-8, NFC-normalized before hashing; only control characters
+  are rejected (`CoreAccountService`). Normalization cannot change the
+  password of an existing account: legacy `sym.p12` files could only ever be
+  created with printable-ASCII passwords (the JDK's PKCS#12 PBE rejects
+  anything else at creation, and no alternative provider is registered), and
+  NFC normalization is the identity on ASCII.
+- A wrong password fails the v2 tag check → `IncorrectPasswordException`.
+- The header is unauthenticated, so loads enforce a small file-size cap and
+  conservative KDF bounds (256 MiB / 10 iterations / 4 lanes) before allocating.
+- `sig.key` / `enc.key` are PKCS#8 keys encrypted as v2 blobs with the master key.
+
+## Migration (all automatic)
+
+| Data | Legacy format | Upgrade trigger |
+|---|---|---|
+| `sym.p12` | PKCS#12 (fast KDF) | first unlock rewrites `sym.key`, deletes `sym.p12` + its backups |
+| `sig.key`/`enc.key` | AES-ECB + HMAC | rewritten on the same unlock |
+| Persisted stores | AES-ECB + HMAC stream, or plaintext | rewritten in place at the same unlock (`PlaintextMigration`, covers backups and archives that are never re-persisted); plaintext only accepted while legacy key material exists |
+| Append log (`ClosedTrades`) | AES-ECB + HMAC frames | one-time rewrite after first replay |
+| XMR connection passwords | AES-ECB | re-encrypted on first read |
+| Password change | — | transactional, see "Password changes" below |
+
+All key files are written to a temp file, verified by a read-back and atomically swapped in, so a
+failed write can never replace a good file; `sym.key` saves also keep a fresh rolling backup,
+written strictly (fsynced and verified byte for byte) so a backup failure surfaces instead of
+leaving the live wrapper as the only copy.
+Load-time backups are only taken after a successful load so retries against a corrupt file cannot
+rotate out good copies.
+If key files are lost and a replacement account is generated over the directory, the previous
+account's leftover key material (live files, legacy wrapper, transaction artifacts and all
+rolling backups) is first moved to a timestamped `keys/lost_account_*` folder, so the
+replacement's saves, password changes and backup rotation can never purge what may be the lost
+account's only key copies.
+
+Plaintext stores are forgeable (no key needed), so they are parsed only while the account still
+holds unmigrated legacy key material — an unforgeable signal, since planting legacy key files
+requires the password or master key. Before that material is replaced, every plaintext file in
+the persistence tree (live stores, crash-left store temps, and historical copies under
+`db/backup/` and `db/backup_of_corrupted_data/`) is encrypted in place (streamed
+and atomically swapped, preserving its content), and a durable marker (`db/plaintext_migration`,
+see `PlaintextMigration`) is then written, so plaintext is never again accepted. The marker is
+written only after every file is encrypted, and migration aborts before key replacement if any
+directory in scope cannot be inspected or any file cannot be encrypted; since the legacy key
+files are only replaced after migration completes, an interruption at any point simply resumes
+at the next unlock. After migration, any plaintext or unauthenticated store file is treated as
+corrupt and moved to `backup_of_corrupted_data`, so a forged replacement cannot be laundered
+into an authenticated store.
+
+A store's later format-upgrade write (from the legacy encrypted format) does not copy the pre-v2
+file into the rolling backups; existing backups of a migrating store are purged and the first
+backup is taken from the encrypted replacement.
+
+A failed append-log write (e.g. disk full) is retried from memory and mirrored to
+`ClosedTrades.log.pending` (best effort), which is merged and re-appended on the next load, so a
+queued batch survives a process kill.
+
+Downgrade to a pre-v2 release is not supported once files are rewritten.
+
+## Password changes
+
+Changing the account password must update the account key wrapper, every Monero wallet, and the
+XMR connection credentials together, so it runs as a crash-safe transaction
+(`CoreAccountService.changePassword`). Changes are refused until all services are initialized,
+so every password-dependent component is represented by a registered listener before the
+transaction can commit:
+
+1. An authenticated journal of both passwords (`keys/password_change`, v2-encrypted with the
+   master key) and a second wrapper `keys/sym.key.new` under the new password are written
+   durably. `sym.key` stays on the old password, so a crash at any point leaves the account
+   unlockable with either password (`KeyStorage.loadSecretKey` falls back to the pending wrapper
+   while the journal exists).
+2. Wallet and credential passwords are changed with idempotent handlers: a wallet already on the
+   target password (from an interrupted attempt) passes. Connection credentials persist
+   synchronously. All wallets are attempted before failure is reported. Each wallet's rolling
+   backups are replaced after its change: the fresh backup is created and verified first, then
+   the stale generations are purged with verification, so a failure can never leave the wallet
+   without a usable backup (on Windows the wallet is closed for the copy and reopened with the
+   change's explicit target password, since open wallet files are locked there and the account
+   password has not committed yet); wallet files not represented by trade state are rotated as
+   well, and one that opens with neither the old nor the new password fails the change (it must
+   be moved out of the wallet directory, never silently deleted). Backups whose wallet cannot be
+   rotated — a backup of a wallet that no longer exists, or of a main/trade wallet whose live
+   file is missing (e.g. a crashed restore) — still open with the previous password but may be
+   the only remaining key copy, so they are never deleted; a warning is logged so the user can
+   move them out.
+3. On success, `sym.key` is rewrapped under the new password (the single commit point), then
+   stale wrappers and backups are purged with verification, a fresh verified backup is taken and
+   the journal and pending wrapper are removed (in that order, so they are never cleared while
+   the live wrapper is the only copy). A cleanup failure after the commit point keeps the
+   journal pending and is retried in the background with capped backoff (and finished on the
+   next account open) rather than reporting a failed change whose password already switched.
+   On failure before or at the commit point (including a failed `sym.key` rewrite, which leaves
+   the old wrapper in place), the handlers converge everything back to the old password.
+4. If the process dies mid-change, the next account open recovers deterministically: every
+   component is converged to the password the user unlocked with (either one works), then the
+   change is committed to it. Recovery waits until services are initialized; a wallet opened
+   before then that is still on the counterpart password is healed on open
+   (`XmrWalletService.openWallet`), and connection credentials are likewise converged on read
+   (`EncryptedConnectionList.getConnections`), so startup can always reach the deferred recovery.
+5. Known trade-off: the journal necessarily holds both passwords encrypted under the master
+   key, so someone who knows the old password and captures the data directory while a change
+   is pending can recover the new password (they can already decrypt all persisted data). The
+   window lasts only while a change is in flight or awaiting recovery, and account backups
+   (both the API stream and the desktop directory copy share one exclusive guard) are refused
+   while one is pending. Avoiding it entirely would require prompting for the
+   counterpart password during recovery instead of journaling it. The sharpest case is
+   *removing* the password: the pending wrapper is then unlockable without any password, so a
+   capture during the window yields the master key and, via the journal, the old password
+   itself (which a user may reuse elsewhere). This is inherent to crash recovery having to
+   unlock with either password when one of them is empty; the end state of a password removal
+   exposes the master key to a capture anyway, the incremental exposure is the old password.
+
+## Accepted limitations (local attacker with write access)
+
+At-rest encryption protects a captured copy of the data directory. An attacker with *write*
+access to the live directory (plus, where noted, an old capture) is largely outside the threat
+model; these residuals are accepted rather than defended:
+
+- **Master key is not rotated by a password change** (only rewrapped), so an old captured
+  `sym.key` plus the retired password can be replayed over the live directory to unlock current
+  data. Rotating would require re-encrypting every store and key file at change time.
+- **The plaintext-migration gate depends on its marker file**: deleting `db/plaintext_migration`
+  *and* replaying captured legacy key files re-opens the one-time plaintext migration. This is
+  inherent to supporting restores of pre-v2 account backups, which look identical.
+- **v2 blobs are not bound to their file identity**, so two authenticated stores holding the same
+  envelope type (e.g. `PendingTrades`/`FailedTrades`) can be swapped undetected.
+- **Append-log frames are individually authenticated**; reordering, replaying or truncating whole
+  frames of `ClosedTrades.log` is not detected (closed-trade history only).
+- **Secrets are not zeroized in memory**: passwords are immutable `String`s and JCE key objects
+  copy their bytes, so a heap or core dump of a running (unlocked) process can recover passwords
+  and key material. Inherent to the JVM; an attacker who can dump process memory is outside the
+  at-rest threat model.
+
+## Adding a future format (v3)
+
+At-rest blobs are versioned by their magic (`"HVN"` + version). If v2 ever needs
+replacing:
+
+1. Add `encryptV3`/`decryptV3` (+ stream variants) under magic `HVN3`, teach
+   `Encryption.blobVersion` to detect it, and route version 3 in `decryptAuto`,
+   `decryptPayloadWithHmacAuto` and `PersistenceManager.readEncrypted`.
+2. Switch the writers (the `encryptV2*` call sites) to v3 and bump
+   `Encryption.CURRENT_BLOB_VERSION` to 3.
+3. Migration is then automatic: every consumer re-encrypts on
+   `blobVersion(blob) < CURRENT_BLOB_VERSION` (key files on unlock, stores on
+   first read, append-log frames after replay, XMR connection passwords on
+   first read), exactly like v1 -> v2. `sym.key` additionally carries its own
+   header version and KDF id, so KDF/KEK changes need no new blob format.
+4. Network payloads follow the separate two-phase rollout via
+   `Version.NETWORK_ENCRYPTION_VERSION` (see below).
+
+## Network rollout (two phases)
+
+Hybrid message seals (`p2p/.../EncryptionService.java`) and trade payment
+account payloads (`ProcessSignContractRequest.java`, `Trade.java`) **decrypt**
+both formats from this release on, but still **send** legacy, because old
+peers cannot read v2 and per-peer capability lookup is unreliable
+(`P2PService.findPeersCapabilities`).
+
+To complete the rollout in a later release:
+
+1. Ensure the network has updated to a version ≥ this release (enforce via the
+   filter's minimum-version mechanism).
+2. Bump `Version.NETWORK_ENCRYPTION_VERSION` to `2` (future formats bump it
+   further, following the same two-phase pattern: ship decryption support
+   first, raise the sent version once the network has updated). The switch is
+   global, not per peer: the filter only stops outdated clients from trading,
+   so bump only after in-flight trades with pre-v2 peers have drained (or the
+   arbitrator confirms none remain), else their messages become unreadable to
+   the outdated side and a funded trade can stall.
+3. One release later, legacy sending code can be removed; keep legacy
+   *decryption* for mailbox messages until their TTL has passed.
+
+## Remaining work (with plans)
+
+### 1. DSA-2048 message signatures → Ed25519
+
+`Sig.java` uses `SHA256withDSA` (TomP2P legacy). Sound but dated; Ed25519 is
+smaller, faster, misuse-resistant. This changes node identity
+(`PubKeyRing.signaturePubKeyBytes`), which account signing, dispute
+resolution, and mailbox addressing depend on, so it needs its own migration:
+
+1. Add Ed25519 keypair to `KeyRing`/`KeyStorage` (new `ed25519.key`, v2 blob),
+   generated on first unlock; add optional field to `PubKeyRing` proto.
+2. Sign with both, verify either, keyed by which pubkey the peer advertises.
+3. After a filter-enforced minimum version, stop producing DSA signatures.
+   Account-age witness data signed with old keys must remain verifiable —
+   keep DSA verification code indefinitely.
+
+### 2. RSA-2048 key wrap → X25519 hybrid
+
+`Encryption.encryptSecretKey` (RSA-OAEP-SHA256) is fine today; X25519+HKDF
+would be preferable long-term. Same rollout shape as #1 (parallel key in
+`PubKeyRing`, sender picks best mutual). Lower priority.
+
+### 3. MobileMessageEncryption (`core/.../notifications/`)
+
+Uses `AES/CBC/NoPadding` with no MAC and a key shared via QR code with the
+phone app. Not addressed here because the relay and mobile apps parse the
+format. Plan: version the notification envelope, move to the v2 format with
+HKDF from the shared key, coordinate a release with the mobile apps, keep
+sending v1 to unupgraded app tokens.
+
+### 4. Monero wallet KDF rounds
+
+Wallet files are encrypted by monero with the account password at the default
+1 kdf round. `--kdf-rounds N` must match for open and create, and existing
+wallet files cannot be reopened with a different value. Plan: pass
+`--kdf-rounds` (e.g. 4) in `XmrWalletService`/`XmrConnectionService` wallet-rpc
+launch args for *newly created* wallets only, record the value per wallet in
+persisted state, and migrate old wallets by `change_wallet_password`-style
+rewrite (monero does not support changing kdf rounds in place — requires
+re-creating the wallet from keys, so gate it behind an explicit maintenance
+step). The account password itself is already Argon2id-hardened for the keys
+that encrypt Haveno's stores.
+
+### 5. EncryptedConnectionList scrypt parameters
+
+Passwords there are additionally scrypt-derived (N=32768, r=8, p=6) with only
+the salt persisted (`pb.proto` `EncryptedConnectionList.salt`). The whole
+store is itself encrypted with the master key, so this is defense-in-depth.
+Plan: add optional `n/r/p` fields to the proto, honor them on read (defaults =
+current values), write current recommended params, or switch to Argon2id via
+a `kdf` field.
+
+### 6. Master key rotation
+
+Changing the account password re-wraps but does not rotate the master
+symmetric key, so a leaked master key outlives a password change. Plan: on
+password change, generate a new master key, decrypt+re-encrypt `sig.key`,
+`enc.key`, and force `persistNow` on all `PersistenceManager` instances and an
+append-log `rewrite()`; only then commit the new `sym.key`. Needs a
+crash-safe two-phase write (keep old `sym.key` as `sym.key.old` until all
+stores are confirmed rewritten).
+
+### 7. At-rest freshness and append-log frame binding
+
+At-rest blobs are authenticated but carry no freshness or identity: an
+attacker with filesystem write access can restore an older authenticated copy
+of any store, and individual append-log frames are not bound to their log
+file, position or predecessor, so captured frames can be reordered, spliced
+between `ClosedTrades.log` and its `.pending` queue, or truncated at a frame
+boundary without failing authentication. Full rollback cannot be detected
+without trusted external state; frame reordering and cross-log splicing could
+be, by chaining each frame's MAC over the log identity, a sequence number and
+the previous tag. Low priority: the same attacker can simply delete the files,
+and the impact is limited to local trade-history state.

--- a/p2p/src/main/java/haveno/network/crypto/EncryptionService.java
+++ b/p2p/src/main/java/haveno/network/crypto/EncryptionService.java
@@ -19,6 +19,7 @@ package haveno.network.crypto;
 
 import com.google.inject.Inject;
 import com.google.protobuf.InvalidProtocolBufferException;
+import haveno.common.app.Version;
 import haveno.common.crypto.CryptoException;
 import haveno.common.crypto.Encryption;
 import static haveno.common.crypto.Encryption.decryptSecretKey;
@@ -68,7 +69,7 @@ public class EncryptionService {
             throw new CryptoException("Signature verification failed.");
 
         try {
-            final byte[] bytes = Encryption.decryptPayloadWithHmac(sealedAndSigned.getEncryptedPayloadWithHmac(), secretKey);
+            final byte[] bytes = Encryption.decryptPayloadWithHmacAuto(sealedAndSigned.getEncryptedPayloadWithHmac(), secretKey);
             final protobuf.NetworkEnvelope envelope = protobuf.NetworkEnvelope.parseFrom(bytes);
             NetworkEnvelope decryptedPayload = networkProtoResolver.fromProto(envelope);
             return new DecryptedDataTuple(decryptedPayload, sealedAndSigned.getSigPublicKey());
@@ -86,7 +87,11 @@ public class EncryptionService {
     }
 
     private static byte[] encryptPayloadWithHmac(NetworkEnvelope networkEnvelope, SecretKey secretKey) throws CryptoException {
-        return Encryption.encryptPayloadWithHmac(networkEnvelope.toProtoNetworkEnvelope().toByteArray(), secretKey);
+        byte[] payload = networkEnvelope.toProtoNetworkEnvelope().toByteArray();
+        // v1 is sent until the network can receive v2 (see Version.NETWORK_ENCRYPTION_VERSION)
+        return Version.NETWORK_ENCRYPTION_VERSION >= 2
+                ? Encryption.encryptV2(payload, secretKey)
+                : Encryption.encryptPayloadWithHmac(payload, secretKey);
     }
 
     /**

--- a/p2p/src/test/java/haveno/network/crypto/EncryptionServiceTests.java
+++ b/p2p/src/test/java/haveno/network/crypto/EncryptionServiceTests.java
@@ -1,47 +1,54 @@
 /*
- * This file is part of Bisq.
+ * This file is part of Haveno.
  *
- * Bisq is free software: you can redistribute it and/or modify it
+ * Haveno is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or (at
  * your option) any later version.
  *
- * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package haveno.network.crypto;
 
+import haveno.common.Payload;
 import haveno.common.crypto.CryptoException;
+import haveno.common.crypto.Encryption;
+import haveno.common.crypto.Hash;
 import haveno.common.crypto.KeyRing;
 import haveno.common.crypto.KeyStorage;
+import haveno.common.crypto.SealedAndSigned;
+import haveno.common.crypto.Sig;
 import haveno.common.file.FileUtil;
 import haveno.common.proto.network.NetworkEnvelope;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import haveno.common.proto.network.NetworkPayload;
+import haveno.common.proto.network.NetworkProtoResolver;
+import haveno.common.proto.persistable.PersistablePayload;
+import haveno.network.p2p.DecryptedMessageWithPubKey;
 import java.io.File;
 import java.io.IOException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
+import java.time.Clock;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EncryptionServiceTests {
-    private static final Logger log = LoggerFactory.getLogger(EncryptionServiceTests.class);
 
     private KeyRing keyRing;
     private File dir;
 
     @BeforeEach
-    public void setup() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException, CryptoException {
-
+    public void setup() throws IOException {
         dir = File.createTempFile("temp_tests", "");
         //noinspection ResultOfMethodCallIgnored
         dir.delete();
@@ -56,54 +63,86 @@ public class EncryptionServiceTests {
         FileUtil.deleteDirectory(dir);
     }
 
-    //TODO Use NetworkProtoResolver, PersistenceProtoResolver or ProtoResolver which are all in io.haveno.common.
-/*
     @Test
-    public void testDecryptAndVerifyMessage() throws CryptoException {
-        EncryptionService encryptionService = new EncryptionService(keyRing, TestUtils.getProtobufferResolver());
-        final PrivateNotificationPayload privateNotification = new PrivateNotificationPayload("test");
-        privateNotification.setSigAndPubKey("", pubKeyRing.getSignaturePubKey());
-        final NodeAddress nodeAddress = new NodeAddress("localhost", 2222);
-        PrivateNotificationMessage data = new PrivateNotificationMessage(privateNotification,
-                nodeAddress,
-                UUID.randomUUID().toString());
-        PrefixedSealedAndSignedMessage encrypted = new PrefixedSealedAndSignedMessage(nodeAddress,
-                encryptionService.encryptAndSign(pubKeyRing, data),
-                Hash.getHash("localhost"),
-                UUID.randomUUID().toString());
-        DecryptedMsgWithPubKey decrypted = encryptionService.decryptAndVerify(encrypted.sealedAndSigned);
-        assertEquals(data.privateNotificationPayload.message,
-                ((PrivateNotificationMessage) decrypted.message).privateNotificationPayload.message);
+    public void testSealRoundTrip() throws Exception {
+        EncryptionService service = new EncryptionService(keyRing, resolver());
+        SealedAndSigned sealed = service.encryptAndSign(keyRing.getPubKeyRing(), new MockMessage(12345));
+        DecryptedMessageWithPubKey decrypted = service.decryptAndVerify(sealed);
+        assertEquals(12345, ((MockMessage) decrypted.getNetworkEnvelope()).nonce);
     }
 
+    @Test
+    public void testV2SealIsAccepted() throws Exception {
+        // a received seal may carry a v2-encrypted payload regardless of what this node sends
+        SealedAndSigned sealed = sealWithPayloadCiphertext(Encryption::encryptV2, 54321);
+        EncryptionService service = new EncryptionService(keyRing, resolver());
+        DecryptedMessageWithPubKey decrypted = service.decryptAndVerify(sealed);
+        assertEquals(54321, ((MockMessage) decrypted.getNetworkEnvelope()).nonce);
+    }
 
     @Test
-    public void testDecryptHybridWithSignature() {
-        long ts = System.currentTimeMillis();
-        log.trace("start ");
-        for (int i = 0; i < 100; i++) {
-            Ping payload = new Ping(new Random().nextInt(), 10);
-            SealedAndSigned sealedAndSigned = null;
-            try {
-                sealedAndSigned = Encryption.encryptHybridWithSignature(payload,
-                        keyRing.getSignatureKeyPair(), keyRing.getPubKeyRing().getEncryptionPubKey());
-            } catch (CryptoException e) {
-                log.error("encryptHybridWithSignature failed");
-                e.printStackTrace();
-                assertTrue(false);
+    public void testTamperedPayloadIsRejected() throws Exception {
+        SecretKey secretKey = Encryption.generateSecretKey(256);
+        byte[] encryptedSecretKey = Encryption.encryptSecretKey(secretKey, keyRing.getPubKeyRing().getEncryptionPubKey());
+        byte[] payload = new MockMessage(999).toProtoNetworkEnvelope().toByteArray();
+        byte[] tampered = Encryption.encryptV2(payload, secretKey);
+        tampered[tampered.length / 2] ^= 0x01;
+        // re-sign the tampered ciphertext so the failure is attributable to the payload authentication
+        byte[] signature = Sig.sign(keyRing.getSignatureKeyPair().getPrivate(), Hash.getSha256Hash(tampered));
+        SealedAndSigned sealed = new SealedAndSigned(encryptedSecretKey, tampered, signature, keyRing.getSignatureKeyPair().getPublic());
+
+        EncryptionService service = new EncryptionService(keyRing, resolver());
+        assertThrows(CryptoException.class, () -> service.decryptAndVerify(sealed));
+    }
+
+    // Builds a seal like EncryptionService.encryptHybridWithSignature but with a caller-chosen
+    // payload encryption, to simulate senders using other supported formats.
+    private interface PayloadEncryptor {
+        byte[] encrypt(byte[] payload, SecretKey secretKey) throws CryptoException;
+    }
+
+    private SealedAndSigned sealWithPayloadCiphertext(PayloadEncryptor encryptor, int nonce) throws CryptoException {
+        SecretKey sessionKey = Encryption.generateSecretKey(256);
+        byte[] encryptedSecretKey = Encryption.encryptSecretKey(sessionKey, keyRing.getPubKeyRing().getEncryptionPubKey());
+        byte[] payload = new MockMessage(nonce).toProtoNetworkEnvelope().toByteArray();
+        byte[] encryptedPayload = encryptor.encrypt(payload, sessionKey);
+        byte[] signature = Sig.sign(keyRing.getSignatureKeyPair().getPrivate(), Hash.getSha256Hash(encryptedPayload));
+        return new SealedAndSigned(encryptedSecretKey, encryptedPayload, signature, keyRing.getSignatureKeyPair().getPublic());
+    }
+
+    private static NetworkProtoResolver resolver() {
+        return new NetworkProtoResolver() {
+            @Override
+            public NetworkEnvelope fromProto(protobuf.NetworkEnvelope envelope) {
+                return new MockMessage(envelope.getPing().getNonce());
             }
-            try {
-                EncryptionService encryptionService = new EncryptionService(null, TestUtils.getProtobufferResolver());
-                DecryptedDataTuple tuple = encryptionService.decryptHybridWithSignature(sealedAndSigned, keyRing.getEncryptionKeyPair().getPrivate());
-                assertEquals(((Ping) tuple.payload).nonce, payload.nonce);
-            } catch (CryptoException e) {
-                log.error("decryptHybridWithSignature failed");
-                e.printStackTrace();
-                assertTrue(false);
+
+            @Override
+            public NetworkPayload fromProto(protobuf.StoragePayload proto) {
+                return null;
             }
-        }
-        log.trace("took " + (System.currentTimeMillis() - ts) + " ms.");
-    }*/
+
+            @Override
+            public NetworkPayload fromProto(protobuf.StorageEntryWrapper proto) {
+                return null;
+            }
+
+            @Override
+            public Payload fromProto(protobuf.PaymentAccountPayload proto) {
+                return null;
+            }
+
+            @Override
+            public PersistablePayload fromProto(protobuf.PersistableNetworkPayload persistable) {
+                return null;
+            }
+
+            @Override
+            public Clock getClock() {
+                return null;
+            }
+        };
+    }
 
     private static class MockMessage extends NetworkEnvelope {
         public final int nonce;
@@ -124,22 +163,3 @@ public class EncryptionServiceTests {
         }
     }
 }
-/*@Value
-final class TestMessage implements MailboxMessage {
-    public String data = "test";
-    private final String messageVersion = Version.getP2PMessageVersion();
-    private final String uid;
-    private final String senderNodeAddress;
-
-    public TestMessage(String data) {
-        this.data = data;
-        uid = UUID.randomUUID().toString();
-        senderNodeAddress = null;
-    }
-
-
-    @Override
-    public PB.NetworkEnvelope toProtoNetworkEnvelope() {
-        throw new NotImplementedException();
-    }
-}*/


### PR DESCRIPTION
Fixes #1161, #2344

This PR must ship with NETWORK_ENCRYPTION_VERSION = 1 (send v1, decrypt both v1 and v2). Best released as a mandatory update.

Safe release sequence

1. Now: merge and release with NETWORK_ENCRYPTION_VERSION = 1. Optionally publish a disableTradeBelowVersion filter to pull everyone onto it.
2. Wait until the enforced minimum version is at/above this release and in‑flight trades and mailbox TTLs from before it have cleared.
3. Then: follow‑up release bumps to 2 (send v2, keep reading v1).
4. Later: remove legacy send code; keep legacy decrypt until no v1 mailbox messages remain.

Bumping to 2 in this release is unsafe: the mandatory gate only blocks new trades, so it can't stop v2 seals from reaching not‑yet‑updated clients over in‑flight trades, disputes, notifications, and mailbox delivery during the coexistence window.