### PR TITLE
ui: refresh open offers view on the user thread

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/portfolio/openoffer/OpenOffersView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/openoffer/OpenOffersView.java
@@ -20,6 +20,7 @@ package haveno.desktop.main.portfolio.openoffer;
 import com.google.inject.Inject;
 import java.util.function.Function;
 import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
+import haveno.common.UserThread;
 import haveno.core.locale.Res;
 import haveno.core.offer.Offer;
 import haveno.core.offer.OpenOffer;
@@ -864,7 +865,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
                                         openOffer.stateProperty().removeListener(offerStateChangeListeners.get(openOffer.getId()));
                                         offerStateChangeListeners.remove(openOffer.getId());
                                     }
-                                    ChangeListener<OpenOffer.State> listener = (observable, oldValue, newValue) -> { if (oldValue != newValue) refresh(); };
+                                    ChangeListener<OpenOffer.State> listener = (observable, oldValue, newValue) -> { if (oldValue != newValue) UserThread.execute(() -> refresh()); };
                                     offerStateChangeListeners.put(openOffer.getId(), listener);
                                     openOffer.stateProperty().addListener(listener);
 


### PR DESCRIPTION
Editing an open offer sometimes fails with the generic error popup
showing

    java.lang.NullPointerException: Cannot read field "e" because "this.sorted[<parameter1>]" is null

OpenOffersView adds a ChangeListener to each offer row's state
property that calls refresh() directly. editOpenOfferPublish runs on
the OpenOfferManager thread (ThreadUtils.execute) and sets the offer
state there, so the listener fires on that thread and refresh()
iterates the view's SortedList while the FX thread may be applying
changes to it. SortedList is not thread safe, so the read can hit a
null slot in its internal array. Being a race it only shows up now
and then, and is easiest to hit when several offers are edited in a
row, for example over the api. refresh() also calls
tableView.refresh(), which must only run on the FX thread anyway.

The fix posts the refresh to the user thread, the same way
OpenOffersDataModel already wraps its listeners in UserThread.execute.

Possibly related to #1121 (same exception out of SortedList, seen
from a different entry point).