### PR TITLE
core: fix posting same/specific bank offers with own account

### DIFF
--- a/core/src/main/java/haveno/core/api/CoreOffersService.java
+++ b/core/src/main/java/haveno/core/api/CoreOffersService.java
@@ -61,7 +61,7 @@ import haveno.core.proto.persistable.CorePersistenceProtoResolver;
 import haveno.core.provider.price.PriceFeedService;
 import haveno.core.trade.HavenoUtils;
 
-import static haveno.core.payment.PaymentAccountUtil.isPaymentAccountValidForOffer;
+import static haveno.core.payment.PaymentAccountUtil.isPaymentAccountValidForNewOffer;
 import haveno.core.user.User;
 import haveno.core.util.PriceUtil;
 import static java.lang.String.format;
@@ -475,7 +475,7 @@ public class CoreOffersService {
     // -------------------------- PRIVATE HELPERS -----------------------------
 
     private void verifyPaymentAccountIsValidForNewOffer(Offer offer, PaymentAccount paymentAccount) {
-        if (!isPaymentAccountValidForOffer(offer, paymentAccount)) {
+        if (!isPaymentAccountValidForNewOffer(offer, paymentAccount)) {
             String error = format("cannot create %s offer with payment account %s",
                     offer.getOfferPayload().getCounterCurrencyCode(),
                     paymentAccount.getId());

--- a/core/src/main/java/haveno/core/payment/PaymentAccountUtil.java
+++ b/core/src/main/java/haveno/core/payment/PaymentAccountUtil.java
@@ -145,6 +145,10 @@ public class PaymentAccountUtil {
         return new ReceiptValidator(offer, paymentAccount).isValid();
     }
 
+    public static boolean isPaymentAccountValidForNewOffer(Offer offer, PaymentAccount paymentAccount) {
+        return new ReceiptValidator(offer, paymentAccount).isValidForNewOffer();
+    }
+
     public static Optional<PaymentAccount> getMostMaturePaymentAccountForOffer(Offer offer,
                                                                                Set<PaymentAccount> paymentAccounts,
                                                                                AccountAgeWitnessService service) {

--- a/core/src/main/java/haveno/core/payment/ReceiptValidator.java
+++ b/core/src/main/java/haveno/core/payment/ReceiptValidator.java
@@ -37,6 +37,15 @@ class ReceiptValidator {
     }
 
     boolean isValid() {
+        return isValid(false);
+    }
+
+    // a new offer derives its bank fields from the maker's account, so bank matching only applies to takers
+    boolean isValidForNewOffer() {
+        return isValid(true);
+    }
+
+    private boolean isValid(boolean isNewOffer) {
         // We only support trades with the same currencies
         if (!predicates.isMatchingCurrency(offer, account)) {
             return false;
@@ -70,7 +79,7 @@ class ReceiptValidator {
             return false;
         }
 
-        if (predicates.isOfferRequireSameOrSpecificBank(offer, account)) {
+        if (!isNewOffer && predicates.isOfferRequireSameOrSpecificBank(offer, account)) {
             return predicates.isMatchingBankId(offer, account);
         }
 

--- a/core/src/test/java/haveno/core/payment/ReceiptValidatorTest.java
+++ b/core/src/test/java/haveno/core/payment/ReceiptValidatorTest.java
@@ -115,6 +115,21 @@ public class ReceiptValidatorTest {
     }
 
     @Test
+    public void testIsValidForNewOfferSkipsBankIdMatching() {
+        account = mock(SpecificBanksAccount.class);
+
+        when(predicates.isMatchingCurrency(offer, account)).thenReturn(true);
+        when(predicates.isEqualPaymentMethods(offer, account)).thenReturn(true);
+        when(predicates.isMatchingCountryCodes(offer, account)).thenReturn(true);
+        when(predicates.isMatchingSepaOffer(offer, account)).thenReturn(false);
+        when(predicates.isMatchingSepaInstant(offer, account)).thenReturn(false);
+        when(predicates.isOfferRequireSameOrSpecificBank(offer, account)).thenReturn(true);
+        when(predicates.isMatchingBankId(offer, account)).thenReturn(false);
+
+        assertTrue(new ReceiptValidator(offer, account, predicates).isValidForNewOffer());
+    }
+
+    @Test
     public void testIsValidWhenSameBankAccountAndOfferRequireSpecificBank() {
         account = mock(SameBankAccount.class);
 


### PR DESCRIPTION
Maker-side offer validation reused the taker's ReceiptValidator, which requires the account's own bank id among its accepted banks. Skip bank id matching for new offers since their bank fields derive from the account.