### PR TITLE
desktop: show offer count per payment method in filter dropdown

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/CryptoOfferBookViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/CryptoOfferBookViewModel.java
@@ -130,14 +130,15 @@ public class CryptoOfferBookViewModel extends OfferBookViewModel {
 
     @Override
     Predicate<OfferBookListItem> getCurrencyAndMethodPredicate(OfferDirection direction,
-                                                               TradeCurrency selectedTradeCurrency) {
+                                                               TradeCurrency selectedTradeCurrency,
+                                                               boolean applyPaymentMethodFilter) {
         return offerBookListItem -> {
             Offer offer = offerBookListItem.getOffer();
             boolean directionResult = offer.getDirection() != direction; // offer to buy xmr appears as offer to sell in peer's offer book and vice versa
-            boolean currencyResult = CurrencyUtil.isCryptoCurrency(offer.getCounterCurrencyCode()) && 
+            boolean currencyResult = CurrencyUtil.isCryptoCurrency(offer.getCounterCurrencyCode()) &&
                     (showAllTradeCurrenciesProperty.get() ||
                     offer.getCounterCurrencyCode().equals(selectedTradeCurrency.getCode()));
-            boolean paymentMethodResult = showAllPaymentMethods ||
+            boolean paymentMethodResult = !applyPaymentMethodFilter || showAllPaymentMethods ||
                     offer.getPaymentMethod().equals(selectedPaymentMethod);
             boolean notMyOfferOrShowMyOffersActivated = !isMyOffer(offerBookListItem.getOffer()) || preferences.isShowOwnOffersInOfferBook();
             return directionResult && currencyResult && paymentMethodResult && notMyOfferOrShowMyOffersActivated;

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/FiatOfferBookViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/FiatOfferBookViewModel.java
@@ -139,13 +139,14 @@ public class FiatOfferBookViewModel extends OfferBookViewModel {
 
     @Override
     Predicate<OfferBookListItem> getCurrencyAndMethodPredicate(OfferDirection direction,
-                                                               TradeCurrency selectedTradeCurrency) {
+                                                               TradeCurrency selectedTradeCurrency,
+                                                               boolean applyPaymentMethodFilter) {
         return offerBookListItem -> {
             Offer offer = offerBookListItem.getOffer();
             boolean directionResult = offer.getDirection() != direction;
             boolean currencyResult = (showAllTradeCurrenciesProperty.get() && offer.isFiatOffer()) ||
                     offer.getCounterCurrencyCode().equals(selectedTradeCurrency.getCode());
-            boolean paymentMethodResult = showAllPaymentMethods ||
+            boolean paymentMethodResult = !applyPaymentMethodFilter || showAllPaymentMethods ||
                     offer.getPaymentMethod().equals(selectedPaymentMethod);
             boolean notMyOfferOrShowMyOffersActivated = !isMyOffer(offerBookListItem.getOffer()) || preferences.isShowOwnOffersInOfferBook();
             return directionResult && currencyResult && paymentMethodResult && notMyOfferOrShowMyOffersActivated;

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookView.java
@@ -184,7 +184,6 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         Tuple3<VBox, Label, AutocompleteComboBox<PaymentMethod>> paymentBoxTuple = FormBuilder.addTopLabelAutocompleteComboBox(
                 Res.get("offerbook.filterByPaymentMethod"));
         paymentMethodComboBox = paymentBoxTuple.third;
-        paymentMethodComboBox.setCellFactory(GUIUtil.getPaymentMethodCellFactory());
         paymentMethodComboBox.setPrefWidth(250);
         paymentMethodComboBox.getStyleClass().add("input-with-border");
 
@@ -360,6 +359,7 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
                 return;
             model.onSetTradeCurrency(currencyComboBox.getSelectionModel().getSelectedItem());
             paymentMethodComboBox.setAutocompleteItems(model.getPaymentMethods());
+            updatePaymentMethodCellFactory();
             model.updateSelectedPaymentMethod();
             updatePaymentMethodComboBoxEditor();
             model.onSetPaymentMethod(paymentMethodComboBox.getSelectionModel().getSelectedItem());
@@ -378,6 +378,9 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         noDepositOffersToggleButton.setOnAction(e -> {
             boolean selected = noDepositOffersToggleButton.isSelected();
             model.onShowNoDepositOffers(selected);
+            paymentMethodComboBox.setAutocompleteItems(model.getPaymentMethods());
+            updatePaymentMethodCellFactory();
+            updatePaymentMethodComboBoxEditor();
             if (selected && privateOffersToggleButton.isSelected()) {
                 privateOffersToggleButton.setSelected(false);
                 model.onShowPrivateOffers(false);
@@ -388,6 +391,9 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         privateOffersToggleButton.setOnAction(e -> {
             boolean selected = privateOffersToggleButton.isSelected();
             model.onShowPrivateOffers(selected);
+            paymentMethodComboBox.setAutocompleteItems(model.getPaymentMethods());
+            updatePaymentMethodCellFactory();
+            updatePaymentMethodComboBoxEditor();
             if (selected && noDepositOffersToggleButton.isSelected()) {
                 noDepositOffersToggleButton.setSelected(false);
                 model.onShowNoDepositOffers(false);
@@ -415,6 +421,7 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         paymentMethodComboBox.getEditor().getStyleClass().add("combo-box-editor-bold");
 
         paymentMethodComboBox.setAutocompleteItems(model.getPaymentMethods());
+        updatePaymentMethodCellFactory();
         paymentMethodComboBox.setVisibleRowCount(Math.min(paymentMethodComboBox.getItems().size(), 10));
 
         paymentMethodComboBox.setOnChangeConfirmed(e -> {
@@ -463,6 +470,12 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         filterInputField.setOnKeyTyped(event -> {
             model.onFilterKeyTyped(filterInputField.getText());
         });
+    }
+
+    private void updatePaymentMethodCellFactory() {
+        paymentMethodComboBox.setCellFactory(GUIUtil.getPaymentMethodCellFactory(Res.get("shared.oneOffer"),
+                Res.get("shared.multipleOffers"),
+                model.getPaymentMethodOfferCounts()));
     }
 
     private void updatePaymentMethodComboBoxEditor() {

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OfferBookViewModel.java
@@ -80,7 +80,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigInteger;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -147,6 +149,7 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
     boolean showPrivateOffers;   // show all private (passphrase-protected) offers
 
     protected static final boolean SORT_CURRENCIES_BY_OFFER_COUNT = true; // TODO: make configurable via preferences?
+    protected static final boolean SORT_PAYMENT_METHODS_BY_OFFER_COUNT = true;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -424,6 +427,24 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
         return OfferViewUtil.isShownAsBuyOffer(getDirection(), getSelectedTradeCurrency()) ? getSellOfferCounts() : getBuyOfferCounts();
     }
 
+    // Number of offers per payment method matching currency, direction, passphrase, and no-deposit filters.
+    Map<String, Integer> getPaymentMethodOfferCounts() {
+        Map<String, Integer> counts = new HashMap<>();
+        Predicate<OfferBookListItem> predicate = getCurrencyAndMethodPredicate(direction, selectedTradeCurrency, false);
+        // Apply lock/passphrase and no-deposit filters (matching filterOffers logic)
+        predicate = predicate.and(offerBookListItem -> {
+            if (direction == OfferDirection.BUY && showNoDepositOffers) return offerBookListItem.getOffer().hasBuyerAsTakerWithoutDeposit();
+            if (showPrivateOffers) return offerBookListItem.getOffer().isPrivateOffer();
+            return !offerBookListItem.getOffer().isPrivateOffer();
+        });
+        for (OfferBookListItem item : new ArrayList<>(offerBook.getOfferBookListItems())) {
+            if (predicate.test(item)) {
+                counts.merge(item.getOffer().getPaymentMethod().getId(), 1, Integer::sum);
+            }
+        }
+        return counts;
+    }
+
     ObservableList<PaymentMethod> getPaymentMethods() {
         ObservableList<PaymentMethod> list = FXCollections.observableArrayList(PaymentMethod.paymentMethods);
         if (preferences.isHideNonAccountPaymentMethods() && user.getPaymentAccounts() != null) {
@@ -436,7 +457,14 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
 
         list = filterPaymentMethods(list, selectedTradeCurrency);
 
-        list.sort(Comparator.naturalOrder());
+        if (SORT_PAYMENT_METHODS_BY_OFFER_COUNT) {
+            Map<String, Integer> offerCounts = getPaymentMethodOfferCounts();
+            list.sort(Comparator.comparingInt((PaymentMethod pm) -> offerCounts.getOrDefault(pm.getId(), 0))
+                    .reversed()
+                    .thenComparing(Comparator.naturalOrder()));
+        } else {
+            list.sort(Comparator.naturalOrder());
+        }
         list.add(0, getShowAllEntryForPaymentMethod());
         return list;
     }
@@ -658,8 +686,8 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
 
     private void filterOffers() {
         Predicate<OfferBookListItem> predicate = useOffersMatchingMyAccountsFilter ?
-                getCurrencyAndMethodPredicate(direction, selectedTradeCurrency).and(getOffersMatchingMyAccountsPredicate()) :
-                getCurrencyAndMethodPredicate(direction, selectedTradeCurrency);
+                getCurrencyAndMethodPredicate(direction, selectedTradeCurrency, true).and(getOffersMatchingMyAccountsPredicate()) :
+                getCurrencyAndMethodPredicate(direction, selectedTradeCurrency, true);
 
         // no deposit filter shows only no-deposit offers, lock filter shows only private offers, otherwise only public offers
         predicate = predicate.and(offerBookListItem -> {
@@ -708,7 +736,8 @@ abstract class OfferBookViewModel extends ActivatableViewModel {
     }
 
     abstract Predicate<OfferBookListItem> getCurrencyAndMethodPredicate(OfferDirection direction,
-                                                                        TradeCurrency selectedTradeCurrency);
+                                                                        TradeCurrency selectedTradeCurrency,
+                                                                        boolean applyPaymentMethodFilter);
 
     private Predicate<OfferBookListItem> getOffersMatchingMyAccountsPredicate() {
         // This code duplicates code in the view at the button column. We need there the different results for

--- a/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OtherOfferBookViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/offerbook/OtherOfferBookViewModel.java
@@ -123,13 +123,14 @@ public class OtherOfferBookViewModel extends OfferBookViewModel {
 
     @Override
     Predicate<OfferBookListItem> getCurrencyAndMethodPredicate(OfferDirection direction,
-                                                               TradeCurrency selectedTradeCurrency) {
+                                                               TradeCurrency selectedTradeCurrency,
+                                                               boolean applyPaymentMethodFilter) {
         return offerBookListItem -> {
             Offer offer = offerBookListItem.getOffer();
             boolean directionResult = offer.getDirection() != direction;
             boolean currencyResult = CurrencyUtil.isTraditionalCurrency(offer.getCounterCurrencyCode()) && !CurrencyUtil.isFiatCurrency(offer.getCounterCurrencyCode()) &&
                     (showAllTradeCurrenciesProperty.get() || offer.getCounterCurrencyCode().equals(selectedTradeCurrency.getCode()));
-            boolean paymentMethodResult = showAllPaymentMethods ||
+            boolean paymentMethodResult = !applyPaymentMethodFilter || showAllPaymentMethods ||
                     offer.getPaymentMethod().equals(selectedPaymentMethod);
             boolean notMyOfferOrShowMyOffersActivated = !isMyOffer(offerBookListItem.getOffer()) || preferences.isShowOwnOffersInOfferBook();
             return directionResult && currencyResult && paymentMethodResult && notMyOfferOrShowMyOffersActivated;

--- a/desktop/src/main/java/haveno/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/haveno/desktop/util/GUIUtil.java
@@ -573,6 +573,12 @@ public class GUIUtil {
     }
 
     public static Callback<ListView<PaymentMethod>, ListCell<PaymentMethod>> getPaymentMethodCellFactory() {
+        return getPaymentMethodCellFactory("", "", Map.of());
+    }
+
+    public static Callback<ListView<PaymentMethod>, ListCell<PaymentMethod>> getPaymentMethodCellFactory(String postFixSingle,
+                                                                                                         String postFixMulti,
+                                                                                                         Map<String, Integer> offerCounts) {
         return p -> new ListCell<>() {
             @Override
             protected void updateItem(PaymentMethod method, boolean empty) {
@@ -583,15 +589,23 @@ public class GUIUtil {
 
                     HBox box = new HBox();
                     box.setSpacing(20);
+                    box.setAlignment(Pos.CENTER_LEFT);
                     Label paymentType = new AutoTooltipLabel(getCurrencyType(method));
                     paymentType.getStyleClass().add("currency-label-small");
                     Label paymentMethod = new AutoTooltipLabel(Res.get(id));
                     paymentMethod.getStyleClass().add("currency-label");
-                    box.getChildren().addAll(paymentType, paymentMethod);
+                    Label offerCount = new AutoTooltipLabel();
+                    box.getChildren().addAll(paymentType, paymentMethod, offerCount);
 
                     if (id.equals(GUIUtil.SHOW_ALL_FLAG)) {
                         paymentType.setText(Res.get("shared.all"));
                         paymentMethod.setText(Res.get("list.currency.showAll"));
+                    } else {
+                        Optional.ofNullable(offerCounts.get(id)).ifPresent(numOffers -> {
+                            HBox.setMargin(offerCount, new Insets(0, 0, 0, NUM_OFFERS_TRANSLATE_X));
+                            offerCount.getStyleClass().add("offer-label");
+                            offerCount.setText(numOffers + " " + (numOffers == 1 ? postFixSingle : postFixMulti));
+                        });
                     }
 
                     setGraphic(box);


### PR DESCRIPTION
Annotate each Buy/Sell offer book payment method with its number of matching offers and sort the dropdown by that count, mirroring the currency filter.