### PR TITLE
desktop: redesign support tab info popup

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -919,6 +919,17 @@ tradeFeedbackWindow.support.body=Get in touch with other users and contributors 
 tradeFeedbackWindow.support.link=Chat with us on Matrix
 tradeFeedbackWindow.done=Done
 
+supportInfoWindow.title=How support works
+supportInfoWindow.subtitle=Haveno is not a company, so it handles disputes differently.
+supportInfoWindow.chat.title=Resolve it together
+supportInfoWindow.chat.body=Trade partners can message each other with secure chat on the open trade screen to work things out directly.
+supportInfoWindow.arbitration.title=Arbitration when needed
+supportInfoWindow.arbitration.body=If chat isn't enough, a neutral arbitrator reviews the trade and decides a fair payout of the funds.
+supportInfoWindow.community.title=Need a hand?
+supportInfoWindow.community.body=Connect with other users and contributors in the Haveno community.
+supportInfoWindow.community.link=Chat with us on Matrix
+supportInfoWindow.gotIt=Got it
+
 portfolio.pending.role=My role
 portfolio.pending.tradeInformation=Trade information
 portfolio.pending.remainingTime=Remaining time
@@ -1277,10 +1288,6 @@ support.signature=Signature
 support.maker.penalty.fee=Maker Penalty Fee
 support.tx.miner.fee=Miner Fee
 
-support.backgroundInfo=Haveno is not a company, so it handles disputes differently.\n\n\
-Traders can communicate within the application via secure chat on the open trades screen to try solving disputes on their own. \
-  If that is not sufficient, an arbitrator will evaluate the situation and decide a \
-  payout of trade funds.
 support.initialInfo=Please enter a description of your problem in the text field below. \
   Add as much information as possible to speed up dispute resolution time.\n\n\
   Here is a check list for information you should provide:\n\

--- a/desktop/src/main/java/haveno/desktop/haveno.css
+++ b/desktop/src/main/java/haveno/desktop/haveno.css
@@ -2782,45 +2782,76 @@ textfield */
 
 /********************************************************************************************************************
  *                                                                                                                  *
- * Welcome window                                                                                                   *
+ * Hero info windows (welcome, trade feedback, support info)                                                        *
  *                                                                                                                  *
  ********************************************************************************************************************/
-.welcome-header-icon-box {
-    -fx-background-color: linear-gradient(to bottom right, rgba(28, 96, 220, 0.18), rgba(28, 96, 220, 0.06));
+.hero-accent-primary {
+    -hero-accent: -bs-hero-primary;
+    -hero-accent-strong: rgba(28, 96, 220, 0.18);
+    -hero-accent-faint: rgba(28, 96, 220, 0.06);
+}
+
+.hero-accent-green {
+    -hero-accent: rgb(62, 163, 74);
+    -hero-accent-strong: rgba(62, 163, 74, 0.18);
+    -hero-accent-faint: rgba(62, 163, 74, 0.06);
+}
+
+.hero-accent-orange {
+    -hero-accent: rgb(242, 104, 34);
+    -hero-accent-strong: rgba(242, 104, 34, 0.18);
+    -hero-accent-faint: rgba(242, 104, 34, 0.06);
+}
+
+.hero-accent-purple {
+    -hero-accent: -bs-hero-purple;
+    -hero-accent-strong: rgba(126, 87, 194, 0.18);
+    -hero-accent-faint: rgba(126, 87, 194, 0.06);
+}
+
+.hero-accent-amber {
+    -hero-accent: rgb(248, 178, 73);
+    -hero-accent-strong: rgba(248, 178, 73, 0.18);
+    -hero-accent-faint: rgba(248, 178, 73, 0.06);
+}
+
+.hero-header-icon-box {
+    -fx-background-color: linear-gradient(to bottom right, -hero-accent-strong, -hero-accent-faint);
     -fx-background-radius: 25;
     -fx-min-height: 50;
     -fx-pref-height: 50;
     -fx-max-height: 50;
 }
 
-.welcome-header-icon {
-    -fx-fill: -bs-color-primary;
+.hero-header-icon {
+    -fx-fill: -hero-accent;
 }
 
-.welcome-header-title {
+.hero-header-title {
     -fx-font-size: 1.4em;
     -fx-font-family: "IBM Plex Sans Medium";
-    -fx-text-fill: -bs-color-primary;
+    -fx-text-fill: -hero-accent;
 }
 
-.welcome-header-subtitle {
+.hero-header-subtitle {
     -fx-font-size: 0.92em;
     -fx-text-fill: -bs-rd-font-dark;
 }
 
-.welcome-header-divider {
-    -fx-background-color: -bs-color-primary;
+.hero-header-divider {
+    -fx-background-color: -hero-accent;
+    -fx-opacity: 0.55;
     -fx-min-height: 1;
     -fx-pref-height: 1;
     -fx-max-height: 1;
 }
 
-.welcome-feature-row {
+.hero-feature-row {
     -fx-padding: 8 24 8 24;
 }
 
-.welcome-feature-icon-box {
-    -fx-background-color: rgba(28, 96, 220, 0.08);
+.hero-feature-icon-box {
+    -fx-background-color: linear-gradient(to bottom right, -hero-accent-strong, -hero-accent-faint);
     -fx-background-radius: 22;
     -fx-min-width: 44;
     -fx-pref-width: 44;
@@ -2830,46 +2861,22 @@ textfield */
     -fx-max-height: 44;
 }
 
-.welcome-feature-icon {
-    -fx-fill: -bs-color-primary;
+.hero-feature-icon {
+    -fx-fill: -hero-accent;
 }
 
-.welcome-feature-icon-box.welcome-accent-trade {
-    -fx-background-color: linear-gradient(to bottom right, rgba(242, 104, 34, 0.18), rgba(242, 104, 34, 0.06));
-}
-
-.welcome-feature-icon.welcome-accent-trade {
-    -fx-fill: rgb(242, 104, 34);
-}
-
-.welcome-feature-icon-box.welcome-accent-start {
-    -fx-background-color: linear-gradient(to bottom right, rgba(62, 163, 74, 0.18), rgba(62, 163, 74, 0.06));
-}
-
-.welcome-feature-icon.welcome-accent-start {
-    -fx-fill: rgb(62, 163, 74);
-}
-
-.welcome-feature-icon-box.welcome-accent-support {
-    -fx-background-color: linear-gradient(to bottom right, rgba(126, 87, 194, 0.18), rgba(126, 87, 194, 0.06));
-}
-
-.welcome-feature-icon.welcome-accent-support {
-    -fx-fill: rgb(126, 87, 194);
-}
-
-.welcome-feature-title {
+.hero-feature-title {
     -fx-font-size: 0.98em;
     -fx-font-family: "IBM Plex Sans Medium";
     -fx-text-fill: -bs-rd-font-dark;
 }
 
-.welcome-feature-body {
+.hero-feature-body {
     -fx-font-size: 0.94em;
     -fx-text-fill: -bs-rd-font-dark;
 }
 
-.welcome-separator {
+.hero-separator {
     -fx-background-color: -bs-rd-separator;
     -fx-min-height: 1;
     -fx-pref-height: 1;
@@ -2893,93 +2900,6 @@ textfield */
     -fx-font-size: 0.92em;
     -fx-font-family: "IBM Plex Sans Medium";
     -fx-text-fill: -bs-rd-font-dark;
-}
-
-/********************************************************************************************************************
- *                                                                                                                  *
- * Trade feedback window                                                                                            *
- *                                                                                                                  *
- ********************************************************************************************************************/
-.trade-feedback-header-icon-box {
-    -fx-background-color: linear-gradient(to bottom right, rgba(62, 163, 74, 0.20), rgba(62, 163, 74, 0.06));
-    -fx-background-radius: 25;
-    -fx-min-height: 50;
-    -fx-pref-height: 50;
-    -fx-max-height: 50;
-}
-
-.trade-feedback-header-icon {
-    -fx-fill: rgb(62, 163, 74);
-}
-
-.trade-feedback-header-title {
-    -fx-font-size: 1.4em;
-    -fx-font-family: "IBM Plex Sans Medium";
-    -fx-text-fill: rgb(62, 163, 74);
-}
-
-.trade-feedback-header-subtitle {
-    -fx-font-size: 0.92em;
-    -fx-text-fill: -bs-rd-font-dark;
-}
-
-.trade-feedback-header-divider {
-    -fx-background-color: rgba(62, 163, 74, 0.55);
-    -fx-min-height: 1;
-    -fx-pref-height: 1;
-    -fx-max-height: 1;
-}
-
-.trade-feedback-feature-row {
-    -fx-padding: 8 24 8 24;
-}
-
-.trade-feedback-feature-icon-box {
-    -fx-background-radius: 22;
-    -fx-min-width: 44;
-    -fx-pref-width: 44;
-    -fx-max-width: 44;
-    -fx-min-height: 44;
-    -fx-pref-height: 44;
-    -fx-max-height: 44;
-}
-
-.trade-feedback-feature-icon {
-    -fx-fill: -bs-rd-font-dark;
-}
-
-.trade-feedback-feature-icon-box.trade-feedback-accent-feedback {
-    -fx-background-color: linear-gradient(to bottom right, rgba(248, 178, 73, 0.20), rgba(248, 178, 73, 0.06));
-}
-
-.trade-feedback-feature-icon.trade-feedback-accent-feedback {
-    -fx-fill: rgb(248, 178, 73);
-}
-
-.trade-feedback-feature-icon-box.trade-feedback-accent-support {
-    -fx-background-color: linear-gradient(to bottom right, rgba(126, 87, 194, 0.18), rgba(126, 87, 194, 0.06));
-}
-
-.trade-feedback-feature-icon.trade-feedback-accent-support {
-    -fx-fill: rgb(126, 87, 194);
-}
-
-.trade-feedback-feature-title {
-    -fx-font-size: 0.98em;
-    -fx-font-family: "IBM Plex Sans Medium";
-    -fx-text-fill: -bs-rd-font-dark;
-}
-
-.trade-feedback-feature-body {
-    -fx-font-size: 0.94em;
-    -fx-text-fill: -bs-rd-font-dark;
-}
-
-.trade-feedback-separator {
-    -fx-background-color: -bs-rd-separator;
-    -fx-min-height: 1;
-    -fx-pref-height: 1;
-    -fx-max-height: 1;
 }
 
 .account-status-title {

--- a/desktop/src/main/java/haveno/desktop/main/overlays/windows/HeroInfoWindow.java
+++ b/desktop/src/main/java/haveno/desktop/main/overlays/windows/HeroInfoWindow.java
@@ -1,0 +1,178 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.desktop.main.overlays.windows;
+
+import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
+import haveno.desktop.components.ExternalHyperlink;
+import haveno.desktop.components.HyperlinkWithIcon;
+import haveno.desktop.main.overlays.Overlay;
+import haveno.desktop.util.FormBuilder;
+import haveno.desktop.util.GUIUtil;
+import javafx.geometry.HPos;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import javax.annotation.Nullable;
+
+/**
+ * Base for hero-style info overlays: an accent-colored header with icon and
+ * divider, then icon-chip feature rows separated by thin lines.
+ */
+public abstract class HeroInfoWindow<T extends HeroInfoWindow<T>> extends Overlay<T> {
+
+    protected static final String MATRIX_URL = "https://matrix.to/#/#haveno:monero.social";
+
+    // accent style classes; the window accent is set via addContent, per-row accents via createFeatureRow
+    protected static final String ACCENT_PRIMARY = "hero-accent-primary";
+    protected static final String ACCENT_GREEN = "hero-accent-green";
+    protected static final String ACCENT_ORANGE = "hero-accent-orange";
+    protected static final String ACCENT_PURPLE = "hero-accent-purple";
+    protected static final String ACCENT_AMBER = "hero-accent-amber";
+
+    // wrap width of row texts: window width minus window padding, row padding, icon box and gap
+    private static final double WINDOW_HORIZONTAL_PADDING = 128;
+    private static final double FEATURE_HORIZONTAL_PADDING = 48;
+    private static final double FEATURE_ICON_BOX_WIDTH = 44;
+    private static final double FEATURE_TEXT_GAP = 18;
+
+    protected HeroInfoWindow() {
+        type = Type.Attention;
+    }
+
+    @Override
+    protected void onShow() {
+        display();
+    }
+
+    // the lone close button is the primary action; windows using an action button hide it
+    @Override
+    protected void addButtons() {
+        super.addButtons();
+        if (closeButton != null) {
+            closeButton.getStyleClass().remove("compact-button");
+            closeButton.getStyleClass().add("action-button");
+        }
+    }
+
+    protected void addContent(String accentClass, Node... children) {
+        VBox content = new VBox(10, children);
+        content.getStyleClass().add(accentClass);
+        GridPane.setHalignment(content, HPos.LEFT);
+        GridPane.setHgrow(content, Priority.ALWAYS);
+        GridPane.setMargin(content, new Insets(10, 0, 0, 0));
+        GridPane.setRowIndex(content, ++rowIndex);
+        GridPane.setColumnSpan(content, 2);
+        gridPane.getChildren().add(content);
+    }
+
+    protected VBox createHeader(MaterialDesignIcon icon, String titleText, String subtitleText) {
+        StackPane iconBox = new StackPane(createIcon(icon, "1.9em", "hero-header-icon"));
+        iconBox.getStyleClass().add("hero-header-icon-box");
+        iconBox.setMinWidth(50);
+        iconBox.setMaxWidth(50);
+
+        Label title = new Label(titleText);
+        title.getStyleClass().add("hero-header-title");
+        title.setWrapText(true);
+
+        Label subtitle = new Label(subtitleText);
+        subtitle.getStyleClass().add("hero-header-subtitle");
+        subtitle.setWrapText(true);
+
+        VBox titleBox = new VBox(3, title, subtitle);
+        titleBox.setAlignment(Pos.CENTER_LEFT);
+        HBox.setHgrow(titleBox, Priority.ALWAYS);
+
+        HBox headerRow = new HBox(14, iconBox, titleBox);
+        headerRow.setAlignment(Pos.CENTER_LEFT);
+        headerRow.setFillHeight(false);
+
+        Region divider = new Region();
+        divider.getStyleClass().add("hero-header-divider");
+
+        // the accent divider reads heavier than the gray row separators, so give it extra air
+        VBox header = new VBox(10, headerRow, divider);
+        VBox.setMargin(header, new Insets(0, 0, 6, 0));
+        return header;
+    }
+
+    protected HBox createFeatureRow(MaterialDesignIcon icon, String accentClass, String titleText, String bodyText) {
+        return createFeatureRow(icon, accentClass, titleText, bodyText, null, null);
+    }
+
+    protected HBox createFeatureRow(MaterialDesignIcon icon,
+                                    String accentClass,
+                                    String titleText,
+                                    String bodyText,
+                                    @Nullable String linkText,
+                                    @Nullable String linkUrl) {
+        double textWidth = width - WINDOW_HORIZONTAL_PADDING - FEATURE_HORIZONTAL_PADDING
+                - FEATURE_ICON_BOX_WIDTH - FEATURE_TEXT_GAP;
+
+        StackPane iconBox = new StackPane(createIcon(icon, "1.65em", "hero-feature-icon"));
+        iconBox.getStyleClass().addAll("hero-feature-icon-box", accentClass);
+
+        Label title = new Label(titleText);
+        title.getStyleClass().add("hero-feature-title");
+        title.setWrapText(true);
+        title.setPrefWidth(textWidth);
+
+        Label body = new Label(bodyText);
+        body.getStyleClass().add("hero-feature-body");
+        body.setWrapText(true);
+        body.setPrefWidth(textWidth);
+
+        VBox textBox = new VBox(3, title, body);
+        textBox.setMinHeight(Region.USE_PREF_SIZE);
+        HBox.setHgrow(textBox, Priority.ALWAYS);
+
+        if (linkText != null) {
+            HyperlinkWithIcon link = new ExternalHyperlink(linkText);
+            link.setOnAction(e -> GUIUtil.openWebPage(linkUrl));
+            textBox.getChildren().add(link);
+        }
+
+        HBox row = new HBox(FEATURE_TEXT_GAP, iconBox, textBox);
+        row.getStyleClass().add("hero-feature-row");
+        row.setAlignment(Pos.TOP_LEFT);
+        row.setFillHeight(false);
+        row.setMinHeight(Region.USE_PREF_SIZE);
+        return row;
+    }
+
+    protected Region createSeparator() {
+        Region separator = new Region();
+        separator.getStyleClass().add("hero-separator");
+        return separator;
+    }
+
+    protected static Text createIcon(MaterialDesignIcon icon, String size, String styleClass) {
+        Text textIcon = FormBuilder.getIcon(icon, size);
+        textIcon.getStyleClass().add(styleClass);
+        textIcon.setMouseTransparent(true);
+        return textIcon;
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/main/overlays/windows/SupportInfoWindow.java
+++ b/desktop/src/main/java/haveno/desktop/main/overlays/windows/SupportInfoWindow.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.desktop.main.overlays.windows;
+
+import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
+import haveno.core.locale.Res;
+
+/**
+ * First-visit support window: a header with icon, then rows explaining how
+ * disputes are resolved and where to find community help.
+ */
+public class SupportInfoWindow extends HeroInfoWindow<SupportInfoWindow> {
+
+    @Override
+    public void show() {
+        if (closeButtonText == null) closeButtonText = Res.get("supportInfoWindow.gotIt");
+        super.show();
+    }
+
+    @Override
+    protected void addMessage() {
+        addContent(ACCENT_PRIMARY,
+                createHeader(MaterialDesignIcon.SHIELD_HALF_FULL,
+                        Res.get("supportInfoWindow.title"),
+                        Res.get("supportInfoWindow.subtitle")),
+                createFeatureRow(MaterialDesignIcon.FORUM,
+                        ACCENT_PURPLE,
+                        Res.get("supportInfoWindow.chat.title"),
+                        Res.get("supportInfoWindow.chat.body")),
+                createSeparator(),
+                createFeatureRow(MaterialDesignIcon.SCALE_BALANCE,
+                        ACCENT_GREEN,
+                        Res.get("supportInfoWindow.arbitration.title"),
+                        Res.get("supportInfoWindow.arbitration.body")),
+                createSeparator(),
+                createFeatureRow(MaterialDesignIcon.ACCOUNT_MULTIPLE,
+                        ACCENT_ORANGE,
+                        Res.get("supportInfoWindow.community.title"),
+                        Res.get("supportInfoWindow.community.body"),
+                        Res.get("supportInfoWindow.community.link"), MATRIX_URL));
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/main/overlays/windows/TradeFeedbackWindow.java
+++ b/desktop/src/main/java/haveno/desktop/main/overlays/windows/TradeFeedbackWindow.java
@@ -19,41 +19,12 @@ package haveno.desktop.main.overlays.windows;
 
 import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
 import haveno.core.locale.Res;
-import haveno.desktop.components.ExternalHyperlink;
-import haveno.desktop.components.HyperlinkWithIcon;
-import haveno.desktop.main.overlays.Overlay;
-import haveno.desktop.util.FormBuilder;
-import haveno.desktop.util.GUIUtil;
-import javafx.geometry.HPos;
-import javafx.geometry.Insets;
-import javafx.geometry.Pos;
-import javafx.scene.control.Label;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.StackPane;
-import javafx.scene.layout.VBox;
-import javafx.scene.text.Text;
-import javax.annotation.Nullable;
 
 /**
  * Shown after a first successful trade: a success header with icon, then rows
  * inviting feedback and pointing to community support.
  */
-public class TradeFeedbackWindow extends Overlay<TradeFeedbackWindow> {
-
-    private static final String MATRIX_URL = "https://matrix.to/#/#haveno:monero.social";
-
-    // wrap width of row texts: window width minus window padding, row padding, icon box and gap
-    private static final double WINDOW_HORIZONTAL_PADDING = 128;
-    private static final double FEATURE_HORIZONTAL_PADDING = 48;
-    private static final double FEATURE_ICON_BOX_WIDTH = 44;
-    private static final double FEATURE_TEXT_GAP = 18;
-
-    public TradeFeedbackWindow() {
-        type = Type.Attention;
-    }
+public class TradeFeedbackWindow extends HeroInfoWindow<TradeFeedbackWindow> {
 
     @Override
     public void show() {
@@ -63,118 +34,20 @@ public class TradeFeedbackWindow extends Overlay<TradeFeedbackWindow> {
     }
 
     @Override
-    protected void onShow() {
-        display();
-    }
-
-    @Override
     protected void addMessage() {
-        VBox header = createHeader(Res.get("tradeFeedbackWindow.title"), Res.get("tradeFeedbackWindow.subtitle"));
-        VBox.setMargin(header, new Insets(0, 0, 6, 0));
-
-        VBox content = new VBox(10);
-        content.getChildren().addAll(
-                header,
+        addContent(ACCENT_GREEN,
+                createHeader(MaterialDesignIcon.CHECK_CIRCLE,
+                        Res.get("tradeFeedbackWindow.title"),
+                        Res.get("tradeFeedbackWindow.subtitle")),
                 createFeatureRow(MaterialDesignIcon.STAR,
-                        "trade-feedback-accent-feedback",
+                        ACCENT_AMBER,
                         Res.get("tradeFeedbackWindow.feedback.title"),
-                        Res.get("tradeFeedbackWindow.feedback.body"),
-                        null, null),
+                        Res.get("tradeFeedbackWindow.feedback.body")),
                 createSeparator(),
                 createFeatureRow(MaterialDesignIcon.FORUM,
-                        "trade-feedback-accent-support",
+                        ACCENT_PURPLE,
                         Res.get("tradeFeedbackWindow.support.title"),
                         Res.get("tradeFeedbackWindow.support.body"),
                         Res.get("tradeFeedbackWindow.support.link"), MATRIX_URL));
-
-        GridPane.setHalignment(content, HPos.LEFT);
-        GridPane.setHgrow(content, Priority.ALWAYS);
-        GridPane.setMargin(content, new Insets(10, 0, 0, 0));
-        GridPane.setRowIndex(content, ++rowIndex);
-        GridPane.setColumnSpan(content, 2);
-        gridPane.getChildren().add(content);
-    }
-
-    private VBox createHeader(String titleText, String subtitleText) {
-        StackPane iconBox = new StackPane(createIcon(MaterialDesignIcon.CHECK_CIRCLE, "1.9em", "trade-feedback-header-icon"));
-        iconBox.getStyleClass().add("trade-feedback-header-icon-box");
-        iconBox.setMinWidth(50);
-        iconBox.setMaxWidth(50);
-
-        Label title = new Label(titleText);
-        title.getStyleClass().add("trade-feedback-header-title");
-        title.setWrapText(true);
-
-        Label subtitle = new Label(subtitleText);
-        subtitle.getStyleClass().add("trade-feedback-header-subtitle");
-        subtitle.setWrapText(true);
-
-        VBox titleBox = new VBox(3, title, subtitle);
-        titleBox.setAlignment(Pos.CENTER_LEFT);
-        HBox.setHgrow(titleBox, Priority.ALWAYS);
-
-        HBox header = new HBox(14, iconBox, titleBox);
-        header.setAlignment(Pos.CENTER_LEFT);
-        header.setFillHeight(false);
-
-        Region divider = new Region();
-        divider.getStyleClass().add("trade-feedback-header-divider");
-
-        return new VBox(10, header, divider);
-    }
-
-    private HBox createFeatureRow(MaterialDesignIcon icon,
-                                  String accentClass,
-                                  String titleText,
-                                  String bodyText,
-                                  @Nullable String linkText,
-                                  @Nullable String linkUrl) {
-        double textWidth = width - WINDOW_HORIZONTAL_PADDING - FEATURE_HORIZONTAL_PADDING
-                - FEATURE_ICON_BOX_WIDTH - FEATURE_TEXT_GAP;
-
-        Text iconText = createIcon(icon, "1.65em", "trade-feedback-feature-icon");
-        iconText.getStyleClass().add(accentClass);
-        StackPane iconBox = new StackPane(iconText);
-        iconBox.getStyleClass().addAll("trade-feedback-feature-icon-box", accentClass);
-
-        Label title = new Label(titleText);
-        title.getStyleClass().add("trade-feedback-feature-title");
-        title.setWrapText(true);
-        title.setPrefWidth(textWidth);
-
-        Label body = new Label(bodyText);
-        body.getStyleClass().add("trade-feedback-feature-body");
-        body.setWrapText(true);
-        body.setPrefWidth(textWidth);
-
-        VBox textBox = new VBox(3, title, body);
-        textBox.setMinHeight(Region.USE_PREF_SIZE);
-        HBox.setHgrow(textBox, Priority.ALWAYS);
-
-        if (linkText != null) {
-            HyperlinkWithIcon link = new ExternalHyperlink(linkText);
-            link.setOnAction(e -> GUIUtil.openWebPage(linkUrl));
-            textBox.getChildren().add(link);
-        }
-
-        HBox row = new HBox(FEATURE_TEXT_GAP, iconBox, textBox);
-        row.getStyleClass().add("trade-feedback-feature-row");
-        row.setAlignment(Pos.TOP_LEFT);
-        row.setFillHeight(false);
-        row.setMinHeight(Region.USE_PREF_SIZE);
-        return row;
-    }
-
-    private Region createSeparator() {
-        Region separator = new Region();
-        separator.getStyleClass().add("trade-feedback-separator");
-        return separator;
-    }
-
-    private static Text createIcon(MaterialDesignIcon icon, String size, String styleClass) {
-        Text textIcon = FormBuilder.getIcon(icon, size);
-        textIcon.getStyleClass().add(styleClass);
-        textIcon.setMouseTransparent(true);
-        return textIcon;
     }
 }

--- a/desktop/src/main/java/haveno/desktop/main/overlays/windows/WelcomeWindow.java
+++ b/desktop/src/main/java/haveno/desktop/main/overlays/windows/WelcomeWindow.java
@@ -21,41 +21,22 @@ import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
 import haveno.common.config.BaseCurrencyNetwork;
 import haveno.common.config.Config;
 import haveno.core.locale.Res;
-import haveno.desktop.components.ExternalHyperlink;
-import haveno.desktop.components.HyperlinkWithIcon;
-import haveno.desktop.main.overlays.Overlay;
-import haveno.desktop.util.FormBuilder;
-import haveno.desktop.util.GUIUtil;
-import javafx.geometry.HPos;
+import java.util.ArrayList;
+import java.util.List;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
-import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
-import javax.annotation.Nullable;
 
 /**
  * First-run welcome window: a headline with icon, feature highlights separated
  * by dividers, and an optional test-funds warning.
  */
-public class WelcomeWindow extends Overlay<WelcomeWindow> {
-
-    private static final String MATRIX_URL = "https://matrix.to/#/#haveno:monero.social";
-
-    // wrap width of feature texts: window width minus window padding, row padding, icon box and gap
-    private static final double WINDOW_HORIZONTAL_PADDING = 128;
-    private static final double FEATURE_HORIZONTAL_PADDING = 48;
-    private static final double FEATURE_ICON_BOX_WIDTH = 44;
-    private static final double FEATURE_TEXT_GAP = 18;
-
-    public WelcomeWindow() {
-        type = Type.Attention;
-    }
+public class WelcomeWindow extends HeroInfoWindow<WelcomeWindow> {
 
     @Override
     public void show() {
@@ -64,137 +45,37 @@ public class WelcomeWindow extends Overlay<WelcomeWindow> {
     }
 
     @Override
-    protected void onShow() {
-        display();
-    }
-
-    @Override
     protected void addMessage() {
         boolean isTestInstance = Config.baseCurrencyNetwork() == BaseCurrencyNetwork.XMR_STAGENET;
         String prefix = isTestInstance ? "welcomeWindow.stagenet" : "welcomeWindow.mainnet";
 
-        // the blue header rule reads heavier than the gray row separators, so give it extra air
-        VBox header = createHeader(Res.get(prefix + ".headline"), Res.get(prefix + ".subtitle"));
-        VBox.setMargin(header, new Insets(0, 0, 6, 0));
+        List<Node> children = new ArrayList<>();
+        children.add(createHeader(MaterialDesignIcon.HUMAN_GREETING,
+                Res.get(prefix + ".headline"),
+                Res.get(prefix + ".subtitle")));
+        children.add(createFeatureRow(isTestInstance ? MaterialDesignIcon.FLASK_OUTLINE : MaterialDesignIcon.SWAP_HORIZONTAL,
+                ACCENT_ORANGE,
+                Res.get(prefix + ".trade.title"),
+                Res.get(prefix + ".trade.body")));
+        children.add(createSeparator());
+        children.add(createFeatureRow(MaterialDesignIcon.ROCKET,
+                ACCENT_GREEN,
+                Res.get(prefix + ".start.title"),
+                Res.get(prefix + ".start.body")));
+        children.add(createSeparator());
+        children.add(createFeatureRow(MaterialDesignIcon.FORUM,
+                ACCENT_PURPLE,
+                Res.get("welcomeWindow.support.title"),
+                Res.get("welcomeWindow.support.body"),
+                Res.get("welcomeWindow.support.link"), MATRIX_URL));
 
-        VBox content = new VBox(10);
-        content.getChildren().addAll(
-                header,
-                createFeatureRow(isTestInstance ? MaterialDesignIcon.FLASK_OUTLINE : MaterialDesignIcon.SWAP_HORIZONTAL,
-                        "welcome-accent-trade",
-                        Res.get(prefix + ".trade.title"),
-                        Res.get(prefix + ".trade.body"),
-                        null, null),
-                createSeparator(),
-                createFeatureRow(MaterialDesignIcon.ROCKET,
-                        "welcome-accent-start",
-                        Res.get(prefix + ".start.title"),
-                        Res.get(prefix + ".start.body"),
-                        null, null),
-                createSeparator(),
-                createFeatureRow(MaterialDesignIcon.FORUM,
-                        "welcome-accent-support",
-                        Res.get("welcomeWindow.support.title"),
-                        Res.get("welcomeWindow.support.body"),
-                        Res.get("welcomeWindow.support.link"), MATRIX_URL));
-
-        String warning = isTestInstance ? Res.get("welcomeWindow.stagenet.warning") : null;
-        if (warning != null) {
-            HBox callout = createWarningCallout(warning);
+        if (isTestInstance) {
+            HBox callout = createWarningCallout(Res.get("welcomeWindow.stagenet.warning"));
             VBox.setMargin(callout, new Insets(8, 0, 0, 0));
-            content.getChildren().add(callout);
+            children.add(callout);
         }
 
-        GridPane.setHalignment(content, HPos.LEFT);
-        GridPane.setHgrow(content, Priority.ALWAYS);
-        GridPane.setMargin(content, new Insets(10, 0, 0, 0));
-        GridPane.setRowIndex(content, ++rowIndex);
-        GridPane.setColumnSpan(content, 2);
-        gridPane.getChildren().add(content);
-    }
-
-    // the lone close button is the primary action
-    @Override
-    protected void addButtons() {
-        super.addButtons();
-        closeButton.getStyleClass().remove("compact-button");
-        closeButton.getStyleClass().add("action-button");
-    }
-
-    private VBox createHeader(String titleText, String subtitleText) {
-        StackPane iconBox = new StackPane(createIcon(MaterialDesignIcon.HUMAN_GREETING, "1.9em", "welcome-header-icon"));
-        iconBox.getStyleClass().add("welcome-header-icon-box");
-        iconBox.setMinWidth(50);
-        iconBox.setMaxWidth(50);
-
-        Label title = new Label(titleText);
-        title.getStyleClass().add("welcome-header-title");
-        title.setWrapText(true);
-
-        Label subtitle = new Label(subtitleText);
-        subtitle.getStyleClass().add("welcome-header-subtitle");
-        subtitle.setWrapText(true);
-
-        VBox titleBox = new VBox(3, title, subtitle);
-        titleBox.setAlignment(Pos.CENTER_LEFT);
-        HBox.setHgrow(titleBox, Priority.ALWAYS);
-
-        HBox header = new HBox(14, iconBox, titleBox);
-        header.setAlignment(Pos.CENTER_LEFT);
-        header.setFillHeight(false);
-
-        Region divider = new Region();
-        divider.getStyleClass().add("welcome-header-divider");
-
-        return new VBox(10, header, divider);
-    }
-
-    private HBox createFeatureRow(MaterialDesignIcon icon,
-                                  String accentClass,
-                                  String titleText,
-                                  String bodyText,
-                                  @Nullable String linkText,
-                                  @Nullable String linkUrl) {
-        double textWidth = width - WINDOW_HORIZONTAL_PADDING - FEATURE_HORIZONTAL_PADDING
-                - FEATURE_ICON_BOX_WIDTH - FEATURE_TEXT_GAP;
-
-        Text iconText = createIcon(icon, "1.65em", "welcome-feature-icon");
-        iconText.getStyleClass().add(accentClass);
-        StackPane iconBox = new StackPane(iconText);
-        iconBox.getStyleClass().addAll("welcome-feature-icon-box", accentClass);
-
-        Label title = new Label(titleText);
-        title.getStyleClass().add("welcome-feature-title");
-        title.setWrapText(true);
-        title.setPrefWidth(textWidth);
-
-        Label body = new Label(bodyText);
-        body.getStyleClass().add("welcome-feature-body");
-        body.setWrapText(true);
-        body.setPrefWidth(textWidth);
-
-        VBox textBox = new VBox(3, title, body);
-        textBox.setMinHeight(Region.USE_PREF_SIZE);
-        HBox.setHgrow(textBox, Priority.ALWAYS);
-
-        if (linkText != null) {
-            HyperlinkWithIcon link = new ExternalHyperlink(linkText);
-            link.setOnAction(e -> GUIUtil.openWebPage(linkUrl));
-            textBox.getChildren().add(link);
-        }
-
-        HBox row = new HBox(FEATURE_TEXT_GAP, iconBox, textBox);
-        row.getStyleClass().add("welcome-feature-row");
-        row.setAlignment(Pos.TOP_LEFT);
-        row.setFillHeight(false);
-        row.setMinHeight(Region.USE_PREF_SIZE);
-        return row;
-    }
-
-    private Region createSeparator() {
-        Region separator = new Region();
-        separator.getStyleClass().add("welcome-separator");
-        return separator;
+        addContent(ACCENT_PRIMARY, children.toArray(new Node[0]));
     }
 
     private HBox createWarningCallout(String text) {
@@ -209,12 +90,5 @@ public class WelcomeWindow extends Overlay<WelcomeWindow> {
         callout.getStyleClass().add("welcome-warning-callout");
         callout.setAlignment(Pos.CENTER_LEFT);
         return callout;
-    }
-
-    private static Text createIcon(MaterialDesignIcon icon, String size, String styleClass) {
-        Text textIcon = FormBuilder.getIcon(icon, size);
-        textIcon.getStyleClass().add(styleClass);
-        textIcon.setMouseTransparent(true);
-        return textIcon;
     }
 }

--- a/desktop/src/main/java/haveno/desktop/main/support/SupportView.java
+++ b/desktop/src/main/java/haveno/desktop/main/support/SupportView.java
@@ -58,7 +58,7 @@ import haveno.desktop.common.view.View;
 import haveno.desktop.common.view.ViewLoader;
 import haveno.desktop.main.MainView;
 import haveno.desktop.main.offer.signedoffer.SignedOfferView;
-import haveno.desktop.main.overlays.popups.Popup;
+import haveno.desktop.main.overlays.windows.SupportInfoWindow;
 import haveno.desktop.main.support.dispute.agent.arbitration.ArbitratorView;
 import haveno.desktop.main.support.dispute.agent.mediation.MediatorView;
 import haveno.desktop.main.support.dispute.agent.refund.RefundAgentView;
@@ -268,8 +268,7 @@ public class SupportView extends ActivatableView<TabPane, Void> {
 
         String key = "supportInfo";
         if (!DevEnv.isDevMode()) {
-            new Popup().backgroundInfo(Res.get("support.backgroundInfo"))
-                    .width(900)
+            new SupportInfoWindow()
                     .dontShowAgainId(key)
                     .show();
         }

--- a/desktop/src/main/java/haveno/desktop/theme-dark.css
+++ b/desktop/src/main/java/haveno/desktop/theme-dark.css
@@ -21,6 +21,9 @@
 
     /* haveno main colors */
     -bs-color-primary-dark: #0c59bd;
+    /* hero window accents, lightened for contrast on dark */
+    -bs-hero-primary: rgb(92, 148, 240);
+    -bs-hero-purple: rgb(155, 124, 216);
     -bs-text-color: white;
     -bs-background-color: black;
     -bs-background-gray: transparent;

--- a/desktop/src/main/java/haveno/desktop/theme-light.css
+++ b/desktop/src/main/java/haveno/desktop/theme-light.css
@@ -1,6 +1,8 @@
 .root {
     -bs-color-primary: rgb(28, 96, 220);
     -bs-color-primary-dark: #0c59bd;
+    -bs-hero-primary: -bs-color-primary;
+    -bs-hero-purple: rgb(126, 87, 194);
     -bs-text-color: #000000;
     -bs-background-color: #ffffff;
     -bs-background-gray: #dddddd;


### PR DESCRIPTION
New SupportInfoWindow styled like the welcome and trade-feedback windows, replacing the plain backgroundInfo text popup.