### PR TITLE
build: silence CDS bootstrap-classpath warning in test JVMs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ configure(rootProject) {
             '-XX:+UseG1GC',
         ]
 
+        // test-only: silence the CDS warning from jacoco/mockito appending to the boot classpath
+        havenoTestJvmArgs = [
+            '-Xshare:off',
+        ]
+
         // headless services (cli, daemon, relay, statsnode, inventory): JVM default heap
         havenoHeadlessJvmArgs = havenoGcJvmArgs + havenoCommonJvmArgs + [
             '-Djava.awt.headless=true',
@@ -249,7 +254,7 @@ configure(subprojects) {
     test {
         useJUnitPlatform()
         maxParallelForks = Math.max(1, Runtime.runtime.availableProcessors().intdiv(2))
-        jvmArgs = rootProject.ext.havenoCommonJvmArgs + rootProject.ext.havenoGcJvmArgs
+        jvmArgs = rootProject.ext.havenoCommonJvmArgs + rootProject.ext.havenoGcJvmArgs + rootProject.ext.havenoTestJvmArgs
         rootProject.ext.configureJavaFxModulePathForTest(it)
     }
 
@@ -852,7 +857,7 @@ configure(project(':desktop')) {
     }
 
     test {
-        jvmArgs = rootProject.ext.havenoDesktopJvmArgs
+        jvmArgs = rootProject.ext.havenoDesktopJvmArgs + rootProject.ext.havenoTestJvmArgs
         systemProperty 'jdk.attach.allowAttachSelf', true
     }
 }


### PR DESCRIPTION
Add -Xshare:off to test tasks; the jacoco/mockito agents append to the boot classpath, which disables CDS and prints a benign VM warning.