### PR TITLE
Added BLIK payment method

### DIFF
--- a/core/src/main/java/haveno/core/api/model/PaymentAccountForm.java
+++ b/core/src/main/java/haveno/core/api/model/PaymentAccountForm.java
@@ -119,7 +119,8 @@ public final class PaymentAccountForm implements PersistablePayload {
         VERSE,
         SAME_BANK,
         SPECIFIC_BANKS,
-        CAPITUAL;
+        CAPITUAL,
+        BLIK;
 
         public static PaymentAccountForm.FormId fromProto(protobuf.PaymentAccountForm.FormId formId) {
             return ProtoUtil.enumFromProto(PaymentAccountForm.FormId.class, formId.name());

--- a/core/src/main/java/haveno/core/offer/Offer.java
+++ b/core/src/main/java/haveno/core/offer/Offer.java
@@ -451,6 +451,8 @@ public class Offer implements NetworkPayload, PersistablePayload {
             return getExtraDataMap().get(OfferPayload.CASHAPP_EXTRA_INFO);
         else if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.CASH_AT_ATM_EXTRA_INFO))
             return getExtraDataMap().get(OfferPayload.CASH_AT_ATM_EXTRA_INFO);
+        else if (getExtraDataMap() != null && getExtraDataMap().containsKey(OfferPayload.BLIK_EXTRA_INFO))
+            return getExtraDataMap().get(OfferPayload.BLIK_EXTRA_INFO);
         else
             return "";
     }

--- a/core/src/main/java/haveno/core/offer/OfferPayload.java
+++ b/core/src/main/java/haveno/core/offer/OfferPayload.java
@@ -103,6 +103,7 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     public static final String AUSTRALIA_PAYID_EXTRA_INFO = "australiaPayidExtraInfo";
     public static final String PAYPAL_EXTRA_INFO = "payPalExtraInfo";
     public static final String CASH_AT_ATM_EXTRA_INFO = "cashAtAtmExtraInfo";
+    public static final String BLIK_EXTRA_INFO = "blikExtraInfo";
 
     // Comma separated list of ordinal of a haveno.common.app.Capability. E.g. ordinal of
     // Capability.SIGNED_ACCOUNT_AGE_WITNESS is 11 and Capability.MEDIATION is 12 so if we want to signal that maker

--- a/core/src/main/java/haveno/core/offer/OfferUtil.java
+++ b/core/src/main/java/haveno/core/offer/OfferUtil.java
@@ -46,8 +46,10 @@ import static haveno.core.offer.OfferPayload.PAYPAL_EXTRA_INFO;
 import static haveno.core.offer.OfferPayload.REFERRAL_ID;
 import static haveno.core.offer.OfferPayload.XMR_AUTO_CONF;
 import static haveno.core.offer.OfferPayload.XMR_AUTO_CONF_ENABLED_VALUE;
+import static haveno.core.offer.OfferPayload.BLIK_EXTRA_INFO;
 
 import haveno.core.payment.AustraliaPayidAccount;
+import haveno.core.payment.BlikAccount;
 import haveno.core.payment.CashAppAccount;
 import haveno.core.payment.CashAtAtmAccount;
 import haveno.core.payment.F2FAccount;
@@ -222,6 +224,10 @@ public class OfferUtil {
 
         if (paymentAccount instanceof CashAtAtmAccount) {
             extraDataMap.put(CASH_AT_ATM_EXTRA_INFO, ((CashAtAtmAccount) paymentAccount).getExtraInfo());
+        }
+
+        if (paymentAccount instanceof BlikAccount) {
+            extraDataMap.put(BLIK_EXTRA_INFO, ((BlikAccount) paymentAccount).getExtraInfo());
         }
 
         extraDataMap.put(CAPABILITIES, Capabilities.app.toStringList());

--- a/core/src/main/java/haveno/core/payment/BlikAccount.java
+++ b/core/src/main/java/haveno/core/payment/BlikAccount.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.payment;
+
+import java.util.List;
+
+import haveno.core.api.model.PaymentAccountFormField;
+import haveno.core.api.model.PaymentAccountFormField.FieldId;
+import haveno.core.locale.Country;
+import haveno.core.locale.CountryUtil;
+import haveno.core.locale.TradeCurrency;
+import haveno.core.locale.TraditionalCurrency;
+import haveno.core.payment.payload.BlikAccountPayload;
+import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.payload.PaymentMethod;
+import lombok.NonNull;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public final class BlikAccount extends CountryBasedPaymentAccount {
+
+    private static final TradeCurrency PLN_CURRENCY = new TraditionalCurrency("PLN");
+    private static final Country COUNTRY = CountryUtil.getCountry("PL");
+
+    private static final List<Country> SUPPORTED_COUNTRIES = List.of(
+        COUNTRY
+    );
+
+    public static final List<TradeCurrency> SUPPORTED_CURRENCIES = List.of(
+        PLN_CURRENCY
+    );
+
+    protected BlikAccount() {
+        super(PaymentMethod.BLIK);
+        country = COUNTRY;
+        acceptedCountries = SUPPORTED_COUNTRIES;
+        setSingleTradeCurrency(PLN_CURRENCY);
+    }
+
+    @Override
+    protected PaymentAccountPayload createPayload() {
+        return new BlikAccountPayload(paymentMethod.getId(), id, SUPPORTED_COUNTRIES);
+    }
+
+    @Override
+    public @NonNull List<TradeCurrency> getSupportedCurrencies() {
+        return SUPPORTED_CURRENCIES;
+    }
+
+    @Override
+    public @NonNull List<FieldId> getInputFieldIds() {
+        return List.of(
+            PaymentAccountFormField.FieldId.TRADE_CURRENCIES,
+            PaymentAccountFormField.FieldId.ACCOUNT_NAME
+        );
+    }
+
+    public void setExtraInfo(String extraInfo) {
+        ((BlikAccountPayload) paymentAccountPayload).setExtraInfo(extraInfo);
+    }
+
+    public String getExtraInfo() {
+        return ((BlikAccountPayload) paymentAccountPayload).getExtraInfo();
+    }  
+}

--- a/core/src/main/java/haveno/core/payment/PaymentAccountFactory.java
+++ b/core/src/main/java/haveno/core/payment/PaymentAccountFactory.java
@@ -152,6 +152,8 @@ public class PaymentAccountFactory {
             // Cannot be deleted as it would break old trade history entries
             case PaymentMethod.OK_PAY_ID:
                 return new OKPayAccount();
+            case PaymentMethod.BLIK_ID:
+                return new BlikAccount();
             default:
                 throw new RuntimeException("Not supported PaymentMethod: " + paymentMethod);
         }

--- a/core/src/main/java/haveno/core/payment/PaymentAccountUtil.java
+++ b/core/src/main/java/haveno/core/payment/PaymentAccountUtil.java
@@ -99,6 +99,7 @@ import static haveno.core.payment.payload.PaymentMethod.VERSE_ID;
 import static haveno.core.payment.payload.PaymentMethod.WECHAT_PAY_ID;
 import static haveno.core.payment.payload.PaymentMethod.WESTERN_UNION_ID;
 import static haveno.core.payment.payload.PaymentMethod.hasChargebackRisk;
+import static haveno.core.payment.payload.PaymentMethod.BLIK_ID;
 
 @Slf4j
 public class PaymentAccountUtil {
@@ -288,6 +289,8 @@ public class PaymentAccountUtil {
                 return TransferwiseUsdAccount.SUPPORTED_CURRENCIES;
             case VERSE_ID:
                 return VerseAccount.SUPPORTED_CURRENCIES;
+            case BLIK_ID:
+                return BlikAccount.SUPPORTED_CURRENCIES;
             default:
                 return Collections.emptyList();
         }

--- a/core/src/main/java/haveno/core/payment/payload/BlikAccountPayload.java
+++ b/core/src/main/java/haveno/core/payment/payload/BlikAccountPayload.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+package haveno.core.payment.payload;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.google.protobuf.Message;
+import haveno.core.locale.Country;
+import haveno.core.locale.Res;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString
+@Setter
+@Getter
+@Slf4j
+public final class BlikAccountPayload extends CountryBasedPaymentAccountPayload {
+
+    private String extraInfo = "";
+
+    public BlikAccountPayload(String paymentMethod, String id, List<Country> acceptedCountries) {
+        super(paymentMethod, id);
+        acceptedCountryCodes = acceptedCountries.stream()
+                .map(e -> e.code)
+                .sorted()
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    private BlikAccountPayload(String paymentMethodId,
+                               String id,
+                               String countryCode,
+                               List<String> acceptedCountryCodes,
+                               String extraInfo,
+                               long maxTradePeriod,
+                               Map<String, String> excludeFromJsonDataMap) 
+    {
+        super(paymentMethodId,id,countryCode,acceptedCountryCodes,maxTradePeriod,excludeFromJsonDataMap);
+
+        this.countryCode = countryCode;
+        this.extraInfo = extraInfo;
+        this.acceptedCountryCodes = acceptedCountryCodes;
+    }
+
+    @Override
+    public Message toProtoMessage() {
+        protobuf.BlikAccountPayload.Builder builder = protobuf.BlikAccountPayload.newBuilder()
+            .setExtraInfo(extraInfo);
+
+        final protobuf.CountryBasedPaymentAccountPayload.Builder countryBasedPaymentAccountPayload = getPaymentAccountPayloadBuilder()
+            .getCountryBasedPaymentAccountPayloadBuilder()
+            .setBlikAccountPayload(builder);
+
+        return getPaymentAccountPayloadBuilder()
+            .setCountryBasedPaymentAccountPayload(countryBasedPaymentAccountPayload)
+            .build();
+    }
+
+    public static PaymentAccountPayload fromProto(protobuf.PaymentAccountPayload proto) {
+        protobuf.CountryBasedPaymentAccountPayload countryBasedPaymentAccountPayload = proto.getCountryBasedPaymentAccountPayload();
+        protobuf.BlikAccountPayload blikAccountPayloadPB = countryBasedPaymentAccountPayload.getBlikAccountPayload();
+
+        return new BlikAccountPayload(proto.getPaymentMethodId(),
+            proto.getId(),
+            countryBasedPaymentAccountPayload.getCountryCode(),
+            new ArrayList<>(countryBasedPaymentAccountPayload.getAcceptedCountryCodesList()),
+            blikAccountPayloadPB.getExtraInfo(),
+            proto.getMaxTradePeriod(),
+            new HashMap<>(proto.getExcludeFromJsonDataMap()));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // API
+    ///////////////////////////////////////////////////////////////////////////////////////////    
+    @Override
+    public String getPaymentDetails() {
+        return Res.get(paymentMethodId) + " - " +
+            Res.getWithCol("payment.shared.extraInfo") + " " + this.extraInfo+ "\n";
+    }
+
+    @Override
+    public String getPaymentDetailsForTradePopup() {
+        return getPaymentDetails();
+    }
+
+    @Override
+    public byte[] getAgeWitnessInputData() {
+        return super.getAgeWitnessInputData(ArrayUtils.addAll(id.getBytes(StandardCharsets.UTF_8)));
+    }    
+}

--- a/core/src/main/java/haveno/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/haveno/core/payment/payload/PaymentMethod.java
@@ -205,6 +205,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static final String VENMO_ID = "VENMO";
     public static final String PAYPAL_ID = "PAYPAL";
     public static final String PAYSAFE_ID = "PAYSAFE";
+    public static final String BLIK_ID = "BLIK";
 
     public static PaymentMethod UPHOLD;
     public static PaymentMethod MONEY_BEAM;
@@ -270,6 +271,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     public static PaymentMethod CASH_APP;
     public static PaymentMethod VENMO;
     public static PaymentMethod PAYSAFE;
+    public static PaymentMethod BLIK;
 
     // Cannot be deleted as it would break old trade history entries
     @Deprecated
@@ -360,6 +362,9 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
             // Thailand
             PROMPT_PAY = new PaymentMethod(PROMPT_PAY_ID, DAY, DEFAULT_TRADE_LIMIT_LOW_RISK, getAssetCodes(PromptPayAccount.SUPPORTED_CURRENCIES)),
 
+            // Poland
+            BLIK = new PaymentMethod(BLIK_ID, TimeUnit.MINUTES.toMillis(10), DEFAULT_TRADE_LIMIT_HIGH_RISK, Arrays.asList()),
+
             // Cryptos
             BLOCK_CHAINS = new PaymentMethod(BLOCK_CHAINS_ID, DAY, DEFAULT_TRADE_LIMIT_CRYPTO, Arrays.asList()),
             
@@ -430,7 +435,8 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
                 INTERAC_E_TRANSFER_ID,
                 US_POSTAL_MONEY_ORDER_ID,
                 PIX_ID,
-                WESTERN_UNION_ID);
+                WESTERN_UNION_ID,
+                BLIK_ID);
         return paymentMethods.stream().filter(paymentMethod -> paymentMethodIds.contains(paymentMethod.getId())).collect(Collectors.toList());
     }
 
@@ -655,7 +661,8 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
                 id.equals(PaymentMethod.CASH_APP_ID) ||
                 id.equals(PaymentMethod.PAYPAL_ID) ||
                 id.equals(PaymentMethod.VENMO_ID) ||
-                id.equals(PaymentMethod.PAYSAFE_ID);
+                id.equals(PaymentMethod.PAYSAFE_ID) ||
+                id.equals(PaymentMethod.BLIK_ID);
     }
 
     public static boolean isRoundedForAtmCash(String id) {

--- a/core/src/main/java/haveno/core/proto/CoreProtoResolver.java
+++ b/core/src/main/java/haveno/core/proto/CoreProtoResolver.java
@@ -28,6 +28,7 @@ import haveno.core.payment.payload.AliPayAccountPayload;
 import haveno.core.payment.payload.AmazonGiftCardAccountPayload;
 import haveno.core.payment.payload.AustraliaPayidAccountPayload;
 import haveno.core.payment.payload.BizumAccountPayload;
+import haveno.core.payment.payload.BlikAccountPayload;
 import haveno.core.payment.payload.CapitualAccountPayload;
 import haveno.core.payment.payload.CashAppAccountPayload;
 import haveno.core.payment.payload.CashAtAtmAccountPayload;
@@ -184,6 +185,8 @@ public class CoreProtoResolver implements ProtoResolver {
                                             "(PB.PaymentAccountPayload.CountryBasedPaymentAccountPayload.IfscBasedPaymentAccount). " +
                                             "messageCase=" + messageCaseIfsc);
                             }
+                        case BLIK_ACCOUNT_PAYLOAD:
+                            return BlikAccountPayload.fromProto(proto);
                         default:
                             throw new ProtobufferRuntimeException("Unknown proto message case" +
                                     "(PB.PaymentAccountPayload.CountryBasedPaymentAccountPayload)." +

--- a/core/src/main/java/haveno/core/trade/statistics/TradeStatistics3.java
+++ b/core/src/main/java/haveno/core/trade/statistics/TradeStatistics3.java
@@ -215,7 +215,8 @@ public final class TradeStatistics3 implements ProcessOncePersistableNetworkPayl
         TRANSFERWISE_USD,
         ACH_TRANSFER,
         DOMESTIC_WIRE_TRANSFER,
-        PAYPAL
+        PAYPAL,
+        BLIK
     }
 
     @Getter

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -745,6 +745,7 @@ portfolio.pending.step2_buyer.payByMail=Please send {0} using \"Pay by Mail\" to
   See more details about Pay by Mail on the Haveno wiki [HYPERLINK:https://docs.haveno.exchange/overview/payment-methods/Pay-By-Mail].\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.pay=Please pay {0} via the specified payment method to the XMR seller. You'll find the seller's account details on the next screen.\n\n
+portfolio.pending.step2_buyer.pay.blik=Please generate BLIK code for {0} then send generated code to XMR seller via trader chat.\n\n
 # suppress inspection "TrailingSpacesInProperty"
 portfolio.pending.step2_buyer.f2f=Please contact the XMR seller by the provided contact and arrange a meeting to pay {0}.\n\n
 portfolio.pending.step2_buyer.startPaymentUsing=Start payment using {0}
@@ -859,6 +860,8 @@ portfolio.pending.step3_seller.halCash=The buyer has to send you the HalCash cod
 portfolio.pending.step3_seller.amazonGiftCard=The buyer has sent you an Amazon eGift Card by email or by text \
   message to your mobile phone. Please redeem now the Amazon eGift Card at your Amazon account and once accepted \
   confirm the payment receipt.
+portfolio.pending.step3_seller.part.blik=Your trading partner has confirmed that they have sent BLIK code via trader chat. \n\n\
+  Please open chat, copy code and then use it at the payment web page.
 
 portfolio.pending.step3_seller.bankCheck=\n\nPlease also verify that the name of the sender specified on the trade contract matches the name that appears on your bank statement:\nSender's name, per trade contract: {0}\n\n\
   If the names are not exactly the same, {1}
@@ -3432,6 +3435,10 @@ VENMO_SHORT=Venmo
 PAYPAL_SHORT=PayPal
 # suppress inspection "UnusedProperty"
 PAYSAFE_SHORT=Paysafe
+# suppress inspection "UnusedProperty"
+BLIK=BLIK
+# suppress inspection "UnusedProperty"
+BLIK_SHORT=BLIK
 
 
 ####################################################################

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/BlikForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/BlikForm.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.desktop.components.paymentmethods;
+
+import haveno.core.account.witness.AccountAgeWitnessService;
+import haveno.core.payment.BlikAccount;
+import haveno.core.payment.PaymentAccount;
+import haveno.core.util.coin.CoinFormatter;
+import haveno.core.util.validation.InputValidator;
+import javafx.scene.layout.GridPane;
+import haveno.core.locale.Res;
+import haveno.core.locale.TradeCurrency;
+import javafx.scene.control.TextArea;
+import com.jfoenix.controls.JFXTextArea;
+
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextArea;
+import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
+import static haveno.desktop.util.FormBuilder.addTopLabelTextArea;
+import static haveno.desktop.util.FormBuilder.addTopLabelTextField;
+
+public final class BlikForm extends PaymentMethodForm {
+
+    private final BlikAccount blikAccount;
+
+    public BlikForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService,
+            InputValidator inputValidator, GridPane gridPane, int gridRow, CoinFormatter formatter)
+    {
+        super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
+        this.blikAccount = (BlikAccount)paymentAccount;
+    }
+
+    @Override
+    protected void autoFillNameTextField() {
+        setAccountNameWithString(blikAccount.getPaymentMethod().getId());
+    }
+
+    @Override
+    public void addFormForAddAccount() {
+        gridRowFrom = gridRow + 1;
+        
+        addSingleCurrencyInput();
+        addTopLabelTextField(gridPane, ++gridRow, Res.get("shared.country"), blikAccount.getCountry().name);
+
+        addOptionExtraInput();
+        addLimitations(false);
+        addAccountNameTextFieldWithAutoFillToggleButton();
+        setAccountNameWithString(blikAccount.getPaymentMethod().getId());
+    }
+
+    private void addSingleCurrencyInput() {
+        gridRow++;
+
+        TradeCurrency singleTradeCurrency = blikAccount.getSingleTradeCurrency();
+
+        if(singleTradeCurrency == null) {
+            throw new RuntimeException("Could not create form: " +
+                "it is not possible to create single currency input because " +
+                "account type doesn't have selected single trade currency");
+        }
+        String nameAndCode = singleTradeCurrency.getNameAndCode();
+        addCompactTopLabelTextField(gridPane, gridRow, Res.get("shared.currency"), nameAndCode, 20);
+    }
+
+    private void addOptionExtraInput() {
+        gridRow++;
+
+        TextArea extraTextArea = addTopLabelTextArea(gridPane, ++gridRow,
+                Res.get("payment.shared.optionalExtra"), Res.get("payment.shared.extraInfo.prompt.paymentAccount")).second;
+        extraTextArea.setMinHeight(70);
+        ((JFXTextArea) extraTextArea).setLabelFloat(false);
+        extraTextArea.textProperty().addListener((ov, oldValue, newValue) -> {
+            blikAccount.setExtraInfo(newValue);
+            updateFromInputs();
+        });
+    }
+
+    @Override
+    public void addFormForEditAccount() {
+        gridRowFrom = gridRow;
+        addAccountNameTextFieldWithAutoFillToggleButton();
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.paymentMethod"), Res.get(blikAccount.getPaymentMethod().getId()));        
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.currency"), blikAccount.getSingleTradeCurrency().getNameAndCode());
+        addCompactTopLabelTextField(gridPane, ++gridRow, Res.get("shared.country"), blikAccount.getCountry().name);
+        
+        TextArea extraInfoTxtArea = addCompactTopLabelTextArea(gridPane, ++gridRow, Res.get("payment.shared.extraInfo"), "").second;
+        extraInfoTxtArea.setText(blikAccount.getExtraInfo());
+        extraInfoTxtArea.setMinHeight(70);
+        extraInfoTxtArea.setEditable(false);
+
+        addLimitations(true);        
+    }
+
+    @Override
+    protected void updateAllInputsValid() {
+        allInputsValid.set(isAccountNameValid() && blikAccount.getTradeCurrencies().size() > 0);        
+    }    
+}

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -58,6 +58,7 @@ import javafx.util.StringConverter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import java.time.Duration;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -145,28 +146,46 @@ public abstract class PaymentMethodForm {
     public static InfoTextField addOpenTradeDuration(GridPane gridPane,
                                                      int gridRow,
                                                      Offer offer) {
-        long hours = offer.getPaymentMethod().getMaxTradePeriod() / 3600_000;
         final Tuple3<Label, InfoTextField, VBox> labelInfoTextFieldVBoxTuple3 =
                 addTopLabelInfoTextField(gridPane, gridRow, Res.get("payment.maxPeriod"),
-                        getTimeText(hours), -Layout.FLOATING_LABEL_DISTANCE);
+                        getTimeText(offer.getPaymentMethod().getMaxTradePeriod()), -Layout.FLOATING_LABEL_DISTANCE);
         return labelInfoTextFieldVBoxTuple3.second;
     }
 
-    private static String getTimeText(long hours) {
-        String time = hours + " " + Res.get("time.hours");
-        if (hours == 1)
-            time = Res.get("time.1hour");
-        else if (hours == 24)
-            time = Res.get("time.1day");
-        else if (hours > 24)
-            time = hours / 24 + " " + Res.get("time.days");
+    private static String getTimeText(long maxTradePeriod) {
+        Duration maxTradePeriodDuration = Duration.ofMillis(maxTradePeriod);
+        
+        long hours = maxTradePeriodDuration.toHours();
+        long minutes = maxTradePeriodDuration.minusHours(hours).toMinutes();
+
+        StringBuilder textTimeBuilder = new StringBuilder();
+
+        if (hours > 0)
+        {            
+            if (hours == 1)
+                textTimeBuilder.append(Res.get("time.1hour"));
+            else if (hours == 24)
+                textTimeBuilder.append(Res.get("time.1day"));
+            else if (hours > 24)
+                textTimeBuilder.append(hours / 24 + " " + Res.get("time.days"));
+            else textTimeBuilder.append(hours + " " + Res.get("time.hours"));
+        }
+
+        if (minutes > 0)
+        {
+            if (minutes == 1)
+                textTimeBuilder.append(String.format("%2d %s", minutes, Res.get("time.minute")));
+            else
+                textTimeBuilder.append(String.format("%2d %s", minutes, Res.get("time.minutes")));
+        }
+
+        String time = textTimeBuilder.toString();
 
         return time;
     }
 
     protected String getLimitationsText() {
         final PaymentAccount paymentAccount = getPaymentAccount();
-        long hours = paymentAccount.getMaxTradePeriod() / 3600_000;
         final TradeCurrency tradeCurrency;
         if (paymentAccount.getSingleTradeCurrency() != null)
             tradeCurrency = paymentAccount.getSingleTradeCurrency();
@@ -183,12 +202,12 @@ public abstract class PaymentMethodForm {
 
         final String limitationsText = paymentAccount instanceof AssetAccount ?
                 Res.get("payment.maxPeriodAndLimitCrypto",
-                        getTimeText(hours),
+                        getTimeText(paymentAccount.getMaxTradePeriod()),
                         HavenoUtils.formatXmr(accountAgeWitnessService.getMyTradeLimit(
                             paymentAccount, tradeCurrency.getCode(), OfferDirection.BUY, false), true))
                 :
                 Res.get("payment.maxPeriodAndLimit",
-                        getTimeText(hours),
+                        getTimeText(paymentAccount.getMaxTradePeriod()),
                         HavenoUtils.formatXmr(accountAgeWitnessService.getMyTradeLimit(
                                 paymentAccount, tradeCurrency.getCode(), OfferDirection.BUY, false), true),
                         HavenoUtils.formatXmr(accountAgeWitnessService.getMyTradeLimit(

--- a/desktop/src/main/java/haveno/desktop/main/account/content/traditionalaccounts/TraditionalAccountsView.java
+++ b/desktop/src/main/java/haveno/desktop/main/account/content/traditionalaccounts/TraditionalAccountsView.java
@@ -81,6 +81,7 @@ import haveno.desktop.components.paymentmethods.AliPayForm;
 import haveno.desktop.components.paymentmethods.AmazonGiftCardForm;
 import haveno.desktop.components.paymentmethods.AustraliaPayidForm;
 import haveno.desktop.components.paymentmethods.BizumForm;
+import haveno.desktop.components.paymentmethods.BlikForm;
 import haveno.desktop.components.paymentmethods.CapitualForm;
 import haveno.desktop.components.paymentmethods.CashAppForm;
 import haveno.desktop.components.paymentmethods.CashAtAtmForm;
@@ -705,6 +706,8 @@ public class TraditionalAccountsView extends PaymentAccountsView<GridPane, Tradi
                 return new CashAppForm(paymentAccount, accountAgeWitnessService, cashAppValidator, inputValidator, root, gridRow, formatter);
             case PaymentMethod.PAYSAFE_ID:
                 return new PaysafeForm(paymentAccount, accountAgeWitnessService, inputValidator, root, gridRow, formatter);
+            case PaymentMethod.BLIK_ID:
+                return new BlikForm(paymentAccount, accountAgeWitnessService, inputValidator, root, gridRow, formatter);
             default:
                 log.error("Not supported PaymentMethod: " + paymentMethod);
                 return null;

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/buyer/BuyerStep2View.java
@@ -26,6 +26,7 @@ import haveno.core.offer.Offer;
 import haveno.core.payment.PaymentAccount;
 import haveno.core.payment.PaymentAccountUtil;
 import haveno.core.payment.payload.AssetAccountPayload;
+import haveno.core.payment.payload.BlikAccountPayload;
 import haveno.core.payment.payload.CashDepositAccountPayload;
 import haveno.core.payment.payload.F2FAccountPayload;
 import haveno.core.payment.payload.FasterPaymentsAccountPayload;
@@ -763,7 +764,9 @@ public class BuyerStep2View extends TradeStepView {
                 message += Res.get("portfolio.pending.step2_buyer.pay", amount) +
                         refTextWarn + "\n\n" +
                         Res.get("portfolio.pending.step2_buyer.fees.swift");
-            } else {
+            } else if (paymentAccountPayload instanceof BlikAccountPayload)
+                message += Res.get("portfolio.pending.step2_buyer.pay.blik", amount);
+            else {
                 message += Res.get("portfolio.pending.step2_buyer.pay", amount) +
                         refTextWarn + "\n\n" +
                         fees;

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/seller/SellerStep3View.java
@@ -28,6 +28,7 @@ import haveno.core.payment.PaymentAccountUtil;
 import haveno.core.payment.payload.AmazonGiftCardAccountPayload;
 import haveno.core.payment.payload.AssetAccountPayload;
 import haveno.core.payment.payload.BankAccountPayload;
+import haveno.core.payment.payload.BlikAccountPayload;
 import haveno.core.payment.payload.PayByMailAccountPayload;
 import haveno.core.payment.payload.CashDepositAccountPayload;
 import haveno.core.payment.payload.F2FAccountPayload;
@@ -404,7 +405,9 @@ public class SellerStep3View extends TradeStepView {
                 message = Res.get("portfolio.pending.step3_seller.postal", part1, tradeVolumeWithCode);
             } else if (paymentAccountPayload instanceof PayByMailAccountPayload) {
                     message = Res.get("portfolio.pending.step3_seller.payByMail", part1, tradeVolumeWithCode);
-            } else if (!(paymentAccountPayload instanceof WesternUnionAccountPayload) &&
+            } else if (paymentAccountPayload instanceof BlikAccountPayload)
+                message = Res.get("portfolio.pending.step3_seller.part.blik");
+            else if (!(paymentAccountPayload instanceof WesternUnionAccountPayload) &&
                     !(paymentAccountPayload instanceof HalCashAccountPayload) &&
                     !(paymentAccountPayload instanceof F2FAccountPayload) &&
                     !(paymentAccountPayload instanceof AmazonGiftCardAccountPayload)) {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -888,7 +888,7 @@ message PaymentAccountPayload {
         VerseAccountPayload verse_account_payload = 39;
         CashAtAtmAccountPayload cash_at_atm_account_payload = 40;
         PayPalAccountPayload paypal_account_payload = 41;
-        PaysafeAccountPayload paysafe_account_payload = 42;
+        PaysafeAccountPayload paysafe_account_payload = 42;        
     }
 }
 
@@ -936,6 +936,7 @@ message CountryBasedPaymentAccountPayload {
         GcashAccountPayload gcash_account_payload = 22;
         MomoAccountPayload momo_account_payload = 23;
         SpeiAccountPayload spei_account_payload = 24;
+        BlikAccountPayload blik_account_payload = 25;
     }
 }
 
@@ -1276,6 +1277,10 @@ message SwiftAccountPayload {
 
 message PaysafeAccountPayload {
     string email = 1;
+}
+
+message BlikAccountPayload {
+    string extra_info = 1;
 }
 
 message PersistableEnvelope {
@@ -2012,6 +2017,7 @@ message PaymentAccountForm {
         SAME_BANK = 59;
         SPECIFIC_BANKS = 60;
         CAPITUAL = 61;
+        BLIK = 62;
     }
     FormId id = 1;
     repeated PaymentAccountFormField fields = 2;


### PR DESCRIPTION
BLIK is popular payment method in Poland, there is [xmrbazaar listing](https://xmrbazaar.com/listing/6MvC/).
BLIK allows for buying stuff online/offline, ATM withdraws and regular money transfer between two peers without sharing personal information between them. "ExtraInfo" might be used to inform that, for example, ATM withdraw is not supported or XMR buyer doesn't want such transaction.
Whole trade, after offer accepted, utilizes trader chat for communication: seller of BLIK code(XMR buyer) opens bank app, generates 6-digits code and sends this code via trader chat.
When code is used by XMR seller(PLN buyer), seller should confirm transaction and the whole trade is done.

Main problem in this method that might occur is that XMR seller succesfully uses provided code but refuses to confirm it. In that case, during dispute process, XMR buyer might provide bank account confirmation of transaction.
If XMR buyer provides invalid code, XMR seller might provide email from BLIk with failed transaction or/and screenshot of payment page.

Regarding changes in PaymentMethodForm: whole BLIK payment should take max 2 minutes(after XMR confirmations), so text during account setup should be dispalayed in minutes, not hours. Same applies to information provided in popup with offer.

Code tested locally according to [docs](https://github.com/haveno-dex/haveno/blob/master/docs/installing.md#run-a-local-test-network)

related:
Official site of [BLIK](https://www.blik.com/en)
related [issue](https://github.com/haveno-dex/listing/issues/63) for new FIAT currency "PLN".