### PR TITLE
common: warn on high memory only when usage stays high after GC

### DIFF
--- a/common/src/main/java/haveno/common/util/Profiler.java
+++ b/common/src/main/java/haveno/common/util/Profiler.java
@@ -20,6 +20,10 @@ package haveno.common.util;
 import haveno.common.UserThread;
 import lombok.extern.slf4j.Slf4j;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -49,16 +53,36 @@ public class Profiler {
             if (max <= 0) {
                 return;
             }
-            long used = runtime.totalMemory() - runtime.freeMemory();
+            // measure usage after the last GC (the retained set); transient pre-GC peaks are normal
+            long used = getUsedMemoryAfterLastGcInBytes();
+            if (used < 0) {
+                used = runtime.totalMemory() - runtime.freeMemory();
+            }
             double ratio = (double) used / max;
             if (ratio >= HIGH_MEMORY_THRESHOLD) {
-                log.warn("Memory usage critically high: {} used of {} max ({}%). An OutOfMemoryError may be imminent, " +
-                        "which terminates the application immediately and writes a heap dump.",
+                log.warn("Memory usage critically high: {} of {} max ({}%) still used after garbage collection. " +
+                        "An OutOfMemoryError may be imminent, which terminates the application immediately.",
                         Utilities.readableFileSize(used), Utilities.readableFileSize(max), Math.round(ratio * 100));
             }
         } catch (Throwable t) {
             log.warn("Error checking memory usage", t);
         }
+    }
+
+    // heap used after the most recent GC, or -1 if the JVM does not report it
+    private static long getUsedMemoryAfterLastGcInBytes() {
+        long sum = -1;
+        for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
+            if (pool.getType() != MemoryType.HEAP) {
+                continue;
+            }
+            MemoryUsage usage = pool.getCollectionUsage();
+            if (usage == null) {
+                continue;
+            }
+            sum = Math.max(sum, 0) + usage.getUsed();
+        }
+        return sum;
     }
 
     public static void printSystemLoad() {


### PR DESCRIPTION
Measure the post-GC retained set via MemoryPoolMXBean collection usage so transient pre-GC peaks on a small heap no longer spam warnings.