### PR TITLE
p2p: bound connection write-lock wait to prevent send-pool starvation

### DIFF
--- a/p2p/src/main/java/haveno/network/p2p/network/HavenoRuntimeException.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/HavenoRuntimeException.java
@@ -18,6 +18,10 @@
 package haveno.network.p2p.network;
 
 class HavenoRuntimeException extends RuntimeException {
+    HavenoRuntimeException(String message) {
+        super(message);
+    }
+
     HavenoRuntimeException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/p2p/src/main/java/haveno/network/p2p/network/NetworkNode.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/NetworkNode.java
@@ -55,6 +55,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -69,6 +70,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public abstract class NetworkNode implements MessageListener {
     private static final Logger log = LoggerFactory.getLogger(NetworkNode.class);
     private static final int CREATE_SOCKET_TIMEOUT = (int) TimeUnit.SECONDS.toMillis(120);
+    private static final long REJECTION_LOG_INTERVAL_MS = TimeUnit.SECONDS.toMillis(30);
 
     final int servicePort;
     private final NetworkProtoResolver networkProtoResolver;
@@ -81,6 +83,8 @@ public abstract class NetworkNode implements MessageListener {
     final Set<SetupListener> setupListeners = Collections.newSetFromMap(new ConcurrentHashMap<SetupListener, Boolean>());
     private final ListeningExecutorService connectionExecutor;
     private final ListeningExecutorService sendMessageExecutor;
+    private final AtomicLong lastRejectionLogTs = new AtomicLong();
+    private final AtomicInteger suppressedRejectionLogs = new AtomicInteger();
     private Server server;
 
     @Getter
@@ -322,11 +326,24 @@ public abstract class NetworkNode implements MessageListener {
 
         } catch (RejectedExecutionException exception) {
             if (!executor.isShutdown()) {
-                log.error("RejectedExecutionException at sendMessage: ", exception);
+                logSendMessageRejection(exception);
                 UserThread.execute(() -> resolveWithException(resultFuture, exception));
             }
         }
         return resultFuture;
+    }
+
+    // Rejections come in bursts when a send pool saturates, so keep the full trace but throttle it.
+    private void logSendMessageRejection(RejectedExecutionException exception) {
+        long now = System.currentTimeMillis();
+        long last = lastRejectionLogTs.get();
+        if (now - last > REJECTION_LOG_INTERVAL_MS && lastRejectionLogTs.compareAndSet(last, now)) {
+            int suppressed = suppressedRejectionLogs.getAndSet(0);
+            log.warn("RejectedExecutionException at sendMessage (send pool saturated){}: ",
+                    suppressed > 0 ? "; " + suppressed + " similar suppressed since last log" : "", exception);
+        } else {
+            suppressedRejectionLogs.incrementAndGet();
+        }
     }
 
     private void resolveWithException(SettableFuture<?> future, Throwable exception) {

--- a/p2p/src/main/java/haveno/network/p2p/network/ProtoOutputStream.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/ProtoOutputStream.java
@@ -37,6 +37,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 class ProtoOutputStream {
     private static final Logger log = LoggerFactory.getLogger(ProtoOutputStream.class);
+    private static final long WRITE_LOCK_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(120);
 
     private final OutputStream outputStream;
     private final Statistic statistic;
@@ -50,7 +51,13 @@ class ProtoOutputStream {
     }
 
     void writeEnvelope(NetworkEnvelope envelope, protobuf.NetworkEnvelope proto) {
-        lock.lock();
+        // Bound the lock wait so senders cannot pile up behind a write stalled on a dead socket.
+        if (!tryToAcquireLock(WRITE_LOCK_TIMEOUT_MS)) {
+            if (!isConnectionActive.get()) {
+                return;
+            }
+            throw new HavenoRuntimeException("Timed out waiting to write " + envelope.getClass().getSimpleName() + ", connection write side appears stalled");
+        }
 
         try {
             writeEnvelopeOrThrow(envelope, proto);
@@ -71,7 +78,7 @@ class ProtoOutputStream {
     void onConnectionShutdown() {
         isConnectionActive.set(false);
 
-        boolean acquiredLock = tryToAcquireLock();
+        boolean acquiredLock = tryToAcquireLock(Connection.getShutdownTimeout());
         if (!acquiredLock) {
             return;
         }
@@ -103,11 +110,11 @@ class ProtoOutputStream {
         }
     }
 
-    private boolean tryToAcquireLock() {
-        long shutdownTimeout = Connection.getShutdownTimeout();
+    private boolean tryToAcquireLock(long timeoutMs) {
         try {
-            return lock.tryLock(shutdownTimeout, TimeUnit.MILLISECONDS);
+            return lock.tryLock(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             return false;
         }
     }


### PR DESCRIPTION
Senders piling up behind a write stalled on a dead socket exhausted the send executors; a timed-out sender now closes the stalled connection.