### PR TITLE
Serialize Monero daemon wallet requests

### DIFF
--- a/core/src/main/java/haveno/core/trade/HavenoUtils.java
+++ b/core/src/main/java/haveno/core/trade/HavenoUtils.java
@@ -121,8 +121,11 @@ public class HavenoUtils {
     }
 
     // synchronize requests to monerod
-    private static boolean SYNC_DAEMON_REQUESTS = false; // sync long requests to daemon (e.g. refresh, update pool) // TODO: performance suffers by syncing daemon requests, but otherwise we sometimes get sporadic errors?
-    private static boolean SYNC_WALLET_REQUESTS = false; // additionally sync wallet functions to daemon (e.g. create txs)
+    // Remote nodes can reject or time out concurrent long requests such as wallet
+    // refreshes, pool updates, and transaction creation. Serialize those calls so
+    // create_tx does not race the wallet's background daemon requests.
+    private static boolean SYNC_DAEMON_REQUESTS = true; // sync long requests to daemon (e.g. refresh, update pool)
+    private static boolean SYNC_WALLET_REQUESTS = true; // additionally sync wallet functions to daemon (e.g. create txs)
     private static boolean SYNC_IMPORT_MULTISIG_REQUESTS = false; // sync import multisig requests to avoid concurrent imports
     private static Object DAEMON_LOCK = new Object();
     private static Object IMPORT_MULTISIG_LOCK = new Object();

--- a/core/src/test/java/haveno/core/trade/HavenoUtilsTest.java
+++ b/core/src/test/java/haveno/core/trade/HavenoUtilsTest.java
@@ -1,0 +1,16 @@
+package haveno.core.trade;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class HavenoUtilsTest {
+
+    @Test
+    public void testDaemonAndWalletFunctionLocksAreShared() {
+        Object daemonLock = HavenoUtils.getDaemonLock();
+
+        assertSame(daemonLock, HavenoUtils.getDaemonLock());
+        assertSame(daemonLock, HavenoUtils.getWalletFunctionLock());
+    }
+}


### PR DESCRIPTION
Addresses #1093.

This enables Haveno’s existing daemon/wallet request serialization for Monero RPC calls. Transaction creation can query the daemon for fee/output distribution data while background wallet sync and tx-pool polling are also talking to the same remote node; serializing these long daemon-backed wallet calls avoids racing remote nodes into transient errors such as `no connection to daemon`, `failed to get output distribution`, and `Failed to get height`.

The patch keeps the existing lock structure and adds a small regression test confirming daemon and wallet-function calls share the same lock.

Testing:
- Not run locally: this environment has no Java Runtime installed.

Bounty payout address (XMR):
`4DSQMNzzq46N1z2pZWAVdeA6JvUL9TCB2bnBiA3ZzoqEdYJnMydt5akCa3vtmapeDsbVKGPFdNkzqTcJS8M8oyK7WGjNk99k1B6CoKjvH5`