### PR TITLE
desktop: harden screen reader support

### DIFF
--- a/desktop/src/main/java/haveno/desktop/components/InputTextField.java
+++ b/desktop/src/main/java/haveno/desktop/components/InputTextField.java
@@ -94,12 +94,8 @@ public class InputTextField extends JFXTextField {
                 validate();
 
                 // announce validation errors to screen readers
-                String help = newValue.isValid ? baseAccessibleHelp
-                        : (this.errorMessage != null ? this.errorMessage : newValue.errorMessage);
-                if (!Objects.equals(help, getAccessibleHelp())) {
-                    setAccessibleHelp(help);
-                    notifyAccessibleAttributeChanged(AccessibleAttribute.HELP);
-                }
+                applyAccessibleHelp(newValue.isValid ? baseAccessibleHelp
+                        : (this.errorMessage != null ? this.errorMessage : newValue.errorMessage));
             }
         });
 
@@ -152,7 +148,14 @@ public class InputTextField extends JFXTextField {
     // help (prompt or popover content) restored when a validation error clears
     public void setBaseAccessibleHelp(String help) {
         baseAccessibleHelp = help;
+        InputValidator.ValidationResult result = validationResult.get();
+        if (result == null || result.isValid) applyAccessibleHelp(help); // don't clobber a live error
+    }
+
+    private void applyAccessibleHelp(String help) {
+        if (Objects.equals(help, getAccessibleHelp())) return;
         setAccessibleHelp(help);
+        notifyAccessibleAttributeChanged(AccessibleAttribute.HELP);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/haveno/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/haveno/desktop/components/PeerInfoIcon.java
@@ -179,7 +179,7 @@ public class PeerInfoIcon extends Group {
                         Res.get("peerInfo.unknownAge") :
                 null;
 
-        Accessibility.asButton(this, tooltipText);
+        Accessibility.asButton(this, null); // tag-aware name already set by refreshTag
         setOnMouseClicked(e -> {
             if (e.getButton().equals(MouseButton.PRIMARY)) {
                 new PeerInfoWithTagEditor(privateNotificationManager, trade, offer, preferences, useDevPrivilegeKeys)

--- a/desktop/src/main/java/haveno/desktop/main/MainView.java
+++ b/desktop/src/main/java/haveno/desktop/main/MainView.java
@@ -80,7 +80,6 @@ import javafx.geometry.Insets;
 import javafx.geometry.NodeOrientation;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
-import javafx.scene.AccessibleRole;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
@@ -837,8 +836,7 @@ public class MainView extends InitializableView<StackPane, MainViewModel>  {
             } else {
                 versionLabel.getStyleClass().add("version");
                 versionLabel.setOnMouseClicked(null);
-                versionLabel.setAccessibleRole(AccessibleRole.TEXT);
-                versionLabel.setFocusTraversable(false);
+                Accessibility.asText(versionLabel, null); // announced by its bound text
             }
         });
         HBox versionBox = new HBox();
@@ -928,9 +926,11 @@ public class MainView extends InitializableView<StackPane, MainViewModel>  {
         });
         Accessibility.asButton(p2PNetworkStatusIcon, Res.get("mainView.networkStatus"));
         p2PNetworkStatusIcon.setOnMouseClicked(e -> {
-            if (p2PNetworkStatusIcon.getId().equalsIgnoreCase("image-alert-round")) {
+            String statusIconId = p2PNetworkStatusIcon.getId();
+            if (statusIconId == null) return; // no status yet (keyboard-activatable before the first update)
+            if (statusIconId.equalsIgnoreCase("image-alert-round")) {
                 new Popup().warning(Res.get("popup.info.p2pStatusIndicator.red", model.getP2pConnectionSummary())).show();
-            } else if (p2PNetworkStatusIcon.getId().equalsIgnoreCase("image-yellow_circle")) {
+            } else if (statusIconId.equalsIgnoreCase("image-yellow_circle")) {
                 new Popup().information(Res.get("popup.info.p2pStatusIndicator.yellow", model.getP2pConnectionSummary())).show();
             } else {
                 new Popup().information(Res.get("popup.info.p2pStatusIndicator.green", model.getP2pConnectionSummary())).show();

--- a/desktop/src/main/java/haveno/desktop/util/Accessibility.java
+++ b/desktop/src/main/java/haveno/desktop/util/Accessibility.java
@@ -81,10 +81,12 @@ public final class Accessibility {
         if (tooltip != null) setName(control, tooltip.getText());
     }
 
-    // exposes an icon-styled node as readable static text (e.g. warning icons)
+    // exposes an icon-styled node as readable static text (e.g. warning icons); reverts asButton focusability
     public static void asText(Node node, String text) {
         node.setAccessibleRole(AccessibleRole.TEXT);
         setName(node, text);
+        node.setFocusTraversable(false);
+        node.getStyleClass().remove(FOCUSABLE_STYLE_CLASS);
     }
 
     // hides a decorative node (e.g. icon glyph) from screen readers; a blank


### PR DESCRIPTION
Fix p2p status icon NPE before first status, error announcements lost to prompt changes, version label button residue, tag-less peer icon names.