### PR TITLE
core: fixes for native wallets

### DIFF
--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -3485,7 +3485,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
                                 else log.warn(errorMsg);
                                 handleWalletError(e, false, false, sourceConnection, i + 1);
                                 if (i == MAX_SYNC_ATTEMPTS - 1) throw e;
-                                initialSyncTimeoutMs = Math.min(XmrWalletBase.SYNC_TIMEOUT_MS * 1000, initialSyncTimeoutMs * 2);
+                                initialSyncTimeoutMs = Math.min(XmrWalletBase.SYNC_TIMEOUT_MS, initialSyncTimeoutMs * 2);
                                 HavenoUtils.waitFor(TradeProtocol.REPROCESS_DELAY_MS); // wait before retrying
                             }
                         }

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletBase.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletBase.java
@@ -167,12 +167,26 @@ public abstract class XmrWalletBase {
                 // native wallet provides sync notifications
                 if (wallet instanceof MoneroWalletFull) {
                     if (testReconnectOnStartup) HavenoUtils.waitFor(1000); // delay sync to test
-                    wallet.sync(new MoneroWalletListener() {
-                        @Override
-                        public void onSyncProgress(long height, long startHeight, long endHeight, double percentDone, String message) {
-                            updateSyncProgress(height, endHeight);
+
+                    // sync in background thread so waiting can time out like rpc wallets
+                    CountDownLatch latch = syncProgressLatch;
+                    ThreadUtils.submitToPool(() -> {
+                        try {
+                            sourceWallet.sync(new MoneroWalletListener() {
+                                @Override
+                                public void onSyncProgress(long height, long startHeight, long endHeight, double percentDone, String message) {
+                                    if (syncProgressLatch == latch) updateSyncProgress(height, endHeight);
+                                }
+                            });
+                        } catch (Exception e) {
+                            if (syncProgressLatch == latch && syncProgressError == null && !isShutDownStarted) syncProgressError = e;
+                        } finally {
+                            latch.countDown();
                         }
                     });
+
+                    // wait for sync to complete or timeout
+                    HavenoUtils.awaitLatch(latch);
                     onDoneSyncWithProgress();
                     return;
                 }

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
@@ -57,11 +57,17 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -119,6 +125,8 @@ public class XmrWalletService extends XmrWalletBase {
     private static final int NUM_WALLET_BACKUPS = 3;
     private static final boolean PRINT_RPC_STACK_TRACE = false;
     private static final long SHUTDOWN_TIMEOUT_MS = 60000;
+    private static final long FORCE_CLOSE_TIMEOUT_MS = 15000; // bounded wait since native close can block draining a stalled network request
+    private static final long PENDING_CLOSE_TIMEOUT_MS = 240000; // max wait to reopen, covering wallet2's 3.5 minute rpc timeout
     private static final long NUM_BLOCKS_BEHIND_TOLERANCE = 5;
     private static final long POLL_TXS_TOLERANCE_MS = 1000 * 60 * 3; // request connection switch if txs not updated within 3 minutes
     private static final boolean TEST_STARTUP_SYNC_ERROR = false;
@@ -158,6 +166,7 @@ public class XmrWalletService extends XmrWalletBase {
     private EventThrottler logPollErrorRateThrottler = new EventThrottler(HavenoUtils.LOG_POLL_ERROR_PERIOD_MS, TimeUnit.MILLISECONDS);
     private long lastPollTxsTimestamp; 
     private final Object pollLock = new Object();
+    private final Map<String, Future<?>> pendingWalletCloses = new ConcurrentHashMap<>(); // wallets force closing in background by path
     private Long cachedHeight;
     private BigInteger cachedBalance;
     private BigInteger cachedAvailableBalance = null;
@@ -372,7 +381,40 @@ public class XmrWalletService extends XmrWalletBase {
         if (wallet instanceof MoneroWalletRpc) {
             MONERO_WALLET_RPC_MANAGER.stopInstance((MoneroWalletRpc) wallet, path, true);
         } else {
-            wallet.close(false);
+
+            // close natively in background with bounded wait, since closing can block draining a stalled network request
+            ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "force-close-wallet");
+                thread.setDaemon(true); // do not block application exit
+                return thread;
+            });
+            Future<?> closeTask = executor.submit(() -> wallet.close(false));
+            executor.shutdown();
+            if (path != null) pendingWalletCloses.put(path, closeTask);
+            try {
+                closeTask.get(FORCE_CLOSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                log.warn("Timeout force closing wallet after {} ms, path={}, will finish closing in background", FORCE_CLOSE_TIMEOUT_MS, path);
+            } catch (Exception e) {
+                log.warn("Error force closing wallet, path={}: {}", path, e.getMessage());
+            } finally {
+                if (path != null && closeTask.isDone()) pendingWalletCloses.remove(path, closeTask); // keep entry if still closing so reopening awaits it
+            }
+        }
+    }
+
+    // reopening before a background close finishes fails on the wallet keys file lock, so await any pending close
+    private void awaitPendingWalletClose(String path) {
+        if (path == null) return;
+        Future<?> pendingClose = pendingWalletCloses.remove(path);
+        if (pendingClose == null || pendingClose.isDone()) return;
+        log.warn("Waiting for wallet to finish closing in background before opening, path={}", path);
+        long startTime = System.currentTimeMillis();
+        try {
+            pendingClose.get(PENDING_CLOSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            log.info("Done waiting {} ms for wallet to close, path={}", System.currentTimeMillis() - startTime, path);
+        } catch (Exception e) {
+            log.warn("Error waiting for wallet to finish closing, path={}: {}", path, e.getMessage());
         }
     }
 
@@ -1458,6 +1500,7 @@ public class XmrWalletService extends XmrWalletBase {
     }
 
     private MoneroWalletFull createWalletFull(MoneroWalletConfig config, boolean applyProxyUri) {
+        awaitPendingWalletClose(config.getPath());
 
         // must be connected to daemon
         if (!Boolean.TRUE.equals(xmrConnectionService.isConnected())) throw new RuntimeException("Must be connected to daemon before creating wallet");
@@ -1487,6 +1530,7 @@ public class XmrWalletService extends XmrWalletBase {
     }
 
     private MoneroWalletFull openWalletFull(MoneroWalletConfig config, boolean applyProxyUri) {
+        awaitPendingWalletClose(config.getPath());
         MoneroWalletFull walletFull = null;
         try {
 
@@ -1916,6 +1960,7 @@ public class XmrWalletService extends XmrWalletBase {
     }
 
     private void forceCloseMainWallet() {
+        log.warn("Force closing main wallet");
         stopPolling();
         if (wallet != null) {
             MoneroWallet walletRef = wallet;

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
@@ -2114,18 +2114,21 @@ public class XmrWalletService extends XmrWalletBase {
 
             // fetch transactions and store to cache
             // TODO: ideally wallet should sync every poll and then avoid updating from pool on fetching txs?
-            synchronized (HavenoUtils.getDaemonLock()) {
-                if (lastPollTxsTimestamp == 0) lastPollTxsTimestamp = System.currentTimeMillis(); // set initial timestamp
-                try {
-                    cachedTxs = wallet.getTxs(new MoneroTxQuery().setIncludeOutputs(true));
-                    lastPollTxsTimestamp = System.currentTimeMillis();
-                } catch (Exception e) { // fetch from pool can fail
-                    if (!isShutDownStarted && wallet == sourceWallet) {
+            synchronized (walletLock) { // lock wallet to prevent concurrent close
+                if (wallet == null || isShutDownStarted) return;
+                synchronized (HavenoUtils.getDaemonLock()) {
+                    if (lastPollTxsTimestamp == 0) lastPollTxsTimestamp = System.currentTimeMillis(); // set initial timestamp
+                    try {
+                        cachedTxs = wallet.getTxs(new MoneroTxQuery().setIncludeOutputs(true));
+                        lastPollTxsTimestamp = System.currentTimeMillis();
+                    } catch (Exception e) { // fetch from pool can fail
+                        if (!isShutDownStarted && wallet == sourceWallet) {
 
-                        // throttle error handling
-                        if (!logPollErrorRateThrottler.onEvent().throttled) {
-                            log.warn("Error polling main wallet's transactions from the pool: {}", e.getMessage());
-                            if (System.currentTimeMillis() - lastPollTxsTimestamp > POLL_TXS_TOLERANCE_MS) ThreadUtils.submitToPool(() -> requestConnectionSwitchSynchronous(sourceConnection));
+                            // throttle error handling
+                            if (!logPollErrorRateThrottler.onEvent().throttled) {
+                                log.warn("Error polling main wallet's transactions from the pool: {}", e.getMessage());
+                                if (System.currentTimeMillis() - lastPollTxsTimestamp > POLL_TXS_TOLERANCE_MS) ThreadUtils.submitToPool(() -> requestConnectionSwitchSynchronous(sourceConnection));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Sync native wallets on a background thread and await the sync latch so the timeout applies like rpc wallets. Also fix trade sync retry timeout cap units.