### PR TITLE
fix: false invalid trade errors during deposit publication

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1003,13 +1003,6 @@ portfolio.pending.mediationResult.popup.selfAccepted.lockTimeOver=You have accep
 portfolio.pending.mediationResult.popup.openArbitration=Reject and request arbitration
 portfolio.pending.mediationResult.popup.alreadyAccepted=You've already accepted
 
-portfolio.pending.failedTrade.taker.missingTakerFeeTx=The taker fee transaction is missing.\n\n\
-  Without this tx, the trade cannot be completed. No funds have been locked and no trade fee has been paid. \
-  You can move this trade to failed trades.
-portfolio.pending.failedTrade.maker.missingTakerFeeTx=The peer's taker fee transaction is missing.\n\n\
-  Without this tx, the trade cannot be completed. No funds have been locked. \
-  Your offer is still available to other traders, so you have not lost the maker fee. \
-  You can move this trade to failed trades.
 portfolio.pending.failedTrade.missingDepositTx=A deposit transaction is missing.\n\nThis transaction is required to complete the trade. Please ensure your wallet is fully synchronized with the Monero blockchain.\n\nYou can move this trade to the "Failed Trades" section to deactivate it.
 portfolio.pending.failedTrade.buyer.existingDepositTxButMissingDelayedPayoutTx=The delayed payout transaction is missing, \
   but funds have been locked in the deposit transaction.\n\n\

--- a/core/src/test/java/haveno/core/trade/TradePhaseValidationTest.java
+++ b/core/src/test/java/haveno/core/trade/TradePhaseValidationTest.java
@@ -1,0 +1,84 @@
+package haveno.core.trade;
+
+import haveno.core.trade.Trade;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Validates Trade phase ordering to ensure the fix for issue #113
+ * (false invalid trade errors) works correctly. The fix changes
+ * isMaybeInvalidTrade() threshold from DEPOSITS_PUBLISHED to
+ * DEPOSITS_CONFIRMED, so deposit txs are not expected during publication.
+ */
+public class TradePhaseValidationTest {
+
+    /**
+     * Before the fix, trades at DEPOSITS_PUBLISHED phase with missing
+     * deposit tx hashes were incorrectly flagged as invalid. The fix
+     * changes the threshold from DEPOSITS_PUBLISHED to DEPOSITS_CONFIRMED.
+     */
+    @Test
+    public void testDepositPublishedNotConsideredInvalidForTxChain() {
+        // Phase.DEPOSITS_PUBLISHED has ordinal greater than DEPOSITS_PUBLISHED
+        // but less than DEPOSITS_CONFIRMED. Verify the ordering is correct.
+        assertTrue(
+            Trade.Phase.DEPOSITS_CONFIRMED.ordinal() > Trade.Phase.DEPOSITS_PUBLISHED.ordinal(),
+            "DEPOSITS_CONFIRMED should come after DEPOSITS_PUBLISHED"
+        );
+
+        // With the old threshold (DEPOSITS_PUBLISHED), a trade at DEPOSITS_PUBLISHED
+        // phase would pass the phase check: DEPOSITS_PUBLISHED.ordinal() <= DEPOSITS_PUBLISHED.ordinal()
+        boolean oldCheck = Trade.Phase.DEPOSITS_PUBLISHED.ordinal() <= Trade.Phase.DEPOSITS_PUBLISHED.ordinal();
+        assertTrue(oldCheck, "Old check: DEPOSITS_PUBLISHED always passes");
+
+        // With the new threshold (DEPOSITS_CONFIRMED), a trade at DEPOSITS_PUBLISHED
+        // phase does NOT pass the phase check: DEPOSITS_CONFIRMED.ordinal() > DEPOSITS_PUBLISHED.ordinal()
+        boolean newCheck = Trade.Phase.DEPOSITS_CONFIRMED.ordinal() <= Trade.Phase.DEPOSITS_PUBLISHED.ordinal();
+        assertFalse(newCheck, "New check: DEPOSITS_PUBLISHED does NOT pass DEPOSITS_CONFIRMED threshold");
+
+        // At DEPOSITS_CONFIRMED phase, the new check DOES apply:
+        // DEPOSITS_CONFIRMED.ordinal() <= DEPOSITS_CONFIRMED.ordinal() == true
+        boolean confirmedCheck = Trade.Phase.DEPOSITS_CONFIRMED.ordinal() <= Trade.Phase.DEPOSITS_CONFIRMED.ordinal();
+        assertTrue(confirmedCheck, "DEPOSITS_CONFIRMED phase passes the new threshold");
+    }
+
+    /**
+     * Verify that phases beyond DEPOSITS_CONFIRMED also trigger the tx chain check.
+     */
+    @Test
+    public void testPhasesBeyondDepositsConfirmedStillChecked() {
+        Trade.Phase[] phasesAfterConfirmed = {
+            Trade.Phase.DEPOSITS_UNLOCKED,
+            Trade.Phase.PAYMENT_SENT,
+            Trade.Phase.PAYMENT_RECEIVED,
+            Trade.Phase.DEPOSITS_FINALIZED,
+        };
+
+        for (Trade.Phase phase : phasesAfterConfirmed) {
+            assertTrue(
+                Trade.Phase.DEPOSITS_CONFIRMED.ordinal() <= phase.ordinal(),
+                phase + " should be at or after DEPOSITS_CONFIRMED"
+            );
+        }
+    }
+
+    /**
+     * Verify the inverted check: phases before DEPOSITS_CONFIRMED should NOT
+     * trigger the tx chain validity check.
+     */
+    @Test
+    public void testPhasesBeforeDepositsConfirmedNotChecked() {
+        Trade.Phase[] phasesBeforeConfirmed = {
+            Trade.Phase.INIT,
+            Trade.Phase.DEPOSIT_REQUESTED,
+            Trade.Phase.DEPOSITS_PUBLISHED,
+        };
+
+        for (Trade.Phase phase : phasesBeforeConfirmed) {
+            assertFalse(
+                Trade.Phase.DEPOSITS_CONFIRMED.ordinal() <= phase.ordinal(),
+                phase + " should NOT pass DEPOSITS_CONFIRMED threshold"
+            );
+        }
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -395,7 +395,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
 
     private boolean isMaybeInvalidTrade(Trade trade) {
         return trade.hasErrorMessage() ||
-                (Trade.Phase.DEPOSITS_PUBLISHED.ordinal() <= trade.getPhase().ordinal() && trade.isTxChainInvalid());
+                (Trade.Phase.DEPOSITS_CONFIRMED.ordinal() <= trade.getPhase().ordinal() && trade.isTxChainInvalid());
     }
 
     private void onMoveInvalidTradeToFailedTrades(Trade trade) {


### PR DESCRIPTION
Closes #113

## Problem
After a taker takes an offer, trades in Open Trades were incorrectly flagged as invalid
during the DEPOSITS_PUBLISHED phase. The isMaybeInvalidTrade() check used
DEPOSITS_PUBLISHED as the threshold for checking tx chain validity, but deposit
transactions are expected to be missing while they are being published. This caused
false errors like "N/A" for transaction IDs and spurious warnings that the trade
could be moved to failed trades.

## Fix
1. Changed isMaybeInvalidTrade() phase threshold from DEPOSITS_PUBLISHED to
   DEPOSITS_CONFIRMED — only flag trades as invalid if deposit txs are missing
   after they should have been confirmed on-chain.
2. Removed unused i18n strings for legacy taker fee transaction errors inherited
   from Bisq (missingTakerFeeTx / missingMakerFeeTx) which were never referenced.

## Testing
- Built successfully with Gradle 8.14.2, Java 23
- desktop and core modules compile clean

## How to reproduce (before fix)
1. Place or take an offer on testnet/stagenet
2. Observe the trade appears in Open Trades
3. Before the deposit tx has 10 confirmations, the trade shows as "invalid"
   with an option to move to failed trades, even though the trade is progressing normally