### PR TITLE
Security: harden gRPC ShutdownService, Connection DoS, RefundAgent pubkey scoping, Encryption mode

### DIFF
--- a/common/src/main/java/haveno/common/util/ZipUtils.java
+++ b/common/src/main/java/haveno/common/util/ZipUtils.java
@@ -21,8 +21,10 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -98,12 +100,32 @@ public class ZipUtils {
      * @param bufferSize The buffer used to read from efficiently.
      */
     public static void unzipToDir(File dir, InputStream inputStream, int bufferSize) throws Exception {
+        // Resolve the target directory to its canonical path once, so every entry
+        // can be containment-checked against the same baseline. The canonical path
+        // also normalizes platform-specific separators and trailing dots that some
+        // filesystems would otherwise treat as escape sequences.
+        final Path canonicalDir = dir.getCanonicalFile().toPath();
         try (ZipInputStream zipStream = new ZipInputStream(inputStream)) {
             ZipEntry entry;
             byte[] buffer = new byte[bufferSize];
             int count;
             while ((entry = zipStream.getNextEntry()) != null) {
                 File file = new File(dir, entry.getName());
+                // Reject any entry whose canonicalized path escapes the target
+                // directory (zip slip). An attacker who controls the zip stream
+                // can otherwise write files anywhere the JVM user can write by
+                // embedding entries like `../../etc/cron.d/evil`.
+                Path canonicalEntry;
+                try {
+                    canonicalEntry = file.getCanonicalFile().toPath();
+                } catch (IOException e) {
+                    throw new java.util.zip.ZipException(
+                            "Zip entry has an unresolvable name: " + entry.getName());
+                }
+                if (!canonicalEntry.startsWith(canonicalDir)) {
+                    throw new java.util.zip.ZipException(
+                            "Zip entry escapes target directory: " + entry.getName());
+                }
                 if (entry.isDirectory()) {
                     file.mkdirs();
                 } else {

--- a/core/src/main/java/haveno/core/notifications/MobileNotificationService.java
+++ b/core/src/main/java/haveno/core/notifications/MobileNotificationService.java
@@ -189,13 +189,15 @@ public class MobileNotificationService {
         if (!doSend)
             return false;
 
-        log.info("Send message: '{}'", message.getMessage());
+        // Drop the prior INFO-level dump of the plaintext message and the
+        // full JSON: those carry the trade/dispute text and any other
+        // sensitive fields the mobile payload would carry. Demote to debug
+        // with length-only metadata so production logs are clean by
+        // default.
+        log.debug("sendMessage type={} msgLen={}", message.getMobileMessageType(), message.getMessage().length());
 
-
-        log.info("sendMessage message={}", message);
         Gson gson = new Gson();
         String json = gson.toJson(message);
-        log.info("json " + json);
 
         StringBuilder padded = new StringBuilder(json);
         while (padded.length() % 16 != 0) {
@@ -209,9 +211,12 @@ public class MobileNotificationService {
         String iv = uuid.substring(0, 16);
 
         String cipher = mobileMessageEncryption.encrypt(json, iv);
-        log.info("key = " + mobileModel.getKey());
-        log.info("iv = " + iv);
-        log.info("encryptedJson = " + cipher);
+        // Never log the mobile AES key, the IV, or the ciphertext: the
+        // AES key is the long-lived pairing key and is sufficient on its
+        // own to decrypt every captured push payload, and the logback
+        // default root level is TRACE in desktop/daemon, so the values
+        // would otherwise be written to haveno.log by default.
+        log.debug("MobileNotification cipher length={}", cipher.length());
 
         doSendMessage(iv, cipher, useSound, resultHandler, errorHandler);
         return true;
@@ -282,10 +287,13 @@ public class MobileNotificationService {
                 "&token=" + tokenAsHex + "&" +
                 "msg=" + msgAsHex;
 
-        log.info("Send: token={}", mobileModel.getToken());
-        log.info("Send: msg={}", msg);
-        log.info("Send: isAndroid={}\nuseSound={}\ntokenAsHex={}\nmsgAsHex={}",
-                isAndroid, useSound, tokenAsHex, msgAsHex);
+        // Drop the prior INFO-level dump of the device push token and the
+        // (decoded) message body: the token is a long-lived secret that
+        // identifies the user's mobile install and the msg contains the
+        // plaintext trade/dispute text. Keep diagnostics at debug with
+        // length-only previews.
+        log.debug("Send: isAndroid={} useSound={} tokenLen={} msgLen={}",
+                isAndroid, useSound, tokenAsHex.length(), msgAsHex.length());
 
         String threadName = "sendMobileNotification-" + msgAsHex.substring(0, 5) + "...";
         ListenableFuture<String> future = executorService.submit(() -> {

--- a/core/src/main/java/haveno/core/support/dispute/refund/refundagent/RefundAgentManager.java
+++ b/core/src/main/java/haveno/core/support/dispute/refund/refundagent/RefundAgentManager.java
@@ -19,6 +19,7 @@ package haveno.core.support.dispute.refund.refundagent;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import haveno.common.config.Config;
 import haveno.common.crypto.KeyRing;
 import haveno.core.filter.FilterManager;
 import haveno.core.support.dispute.agent.DisputeAgentManager;
@@ -41,23 +42,35 @@ public class RefundAgentManager extends DisputeAgentManager<RefundAgent> {
 
     @Override
     protected List<String> getPubKeyList() {
-        return List.of("02a25798e256b800d7ea71c31098ac9a47cb20892176afdfeb051f5ded382d44af",
-                "0360455d3cffe00ef73cc1284c84eedacc8c5c3374c43f4aac8ffb95f5130b9ef5",
-                "03b0513afbb531bc4551b379eba027feddd33c92b5990fd477b0fa6eff90a5b7db",
-                "03533fd75fda29c351298e50b8ea696656dcb8ce4e263d10618c6901a50450bf0e",
-                "028124436482aa4c61a4bc4097d60c80b09f4285413be3b023a37a0164cbd5d818",
-                "0384fcf883116d8e9469720ed7808cc4141f6dc6a5ed23d76dd48f2f5f255590d7",
-                "029bd318ecee4e212ff06a4396770d600d72e9e0c6532142a428bdb401491e9721",
-                "02e375b4b24d0a858953f7f94666667554d41f78000b9c8a301294223688b29011",
-                "0232c088ae7c070de89d2b6c8d485b34bf0e3b2a964a2c6622f39ca501260c23f7",
-                "033e047f74f2aa1ce41e8c85731f97ab83d448d65dc8518ab3df4474a5d53a3d19",
-                "02f52a8cf373c8cbddb318e523b7f111168bf753fdfb6f8aa81f88c950ede3a5ce",
-                "039784029922c54bcd0f0e7f14530f586053a5f4e596e86b3474cd7404657088ae",
-                "037969f9d5ab2cc609104c6e61323df55428f8f108c11aab7c7b5f953081d39304",
-                "031bd37475b8c5615ac46d6816e791c59d806d72a0bc6739ae94e5fe4545c7f8a6",
-                "021bb92c636feacf5b082313eb071a63dfcd26501a48b3cd248e35438e5afb7daf");
-
-
+        // Pubkey allow-list MUST be scoped to the active base currency network,
+        // otherwise an agent that registered on stagenet or testnet with one of
+        // these pubkeys is implicitly trusted as a refund agent on mainnet by
+        // every peer (a single shared list leaks trust across networks).
+        // XMR_MAINNET is intentionally empty pending real refund-agent registration,
+        // matching the existing pattern in ArbitratorManager.
+        switch (Config.baseCurrencyNetwork()) {
+        case XMR_LOCAL:
+        case XMR_STAGENET:
+            return List.of("02a25798e256b800d7ea71c31098ac9a47cb20892176afdfeb051f5ded382d44af",
+                    "0360455d3cffe00ef73cc1284c84eedacc8c5c3374c43f4aac8ffb95f5130b9ef5",
+                    "03b0513afbb531bc4551b379eba027feddd33c92b5990fd477b0fa6eff90a5b7db",
+                    "03533fd75fda29c351298e50b8ea696656dcb8ce4e263d10618c6901a50450bf0e",
+                    "028124436482aa4c61a4bc4097d60c80b09f4285413be3b023a37a0164cbd5d818",
+                    "0384fcf883116d8e9469720ed7808cc4141f6dc6a5ed23d76dd48f2f5f255590d7",
+                    "029bd318ecee4e212ff06a4396770d600d72e9e0c6532142a428bdb401491e9721",
+                    "02e375b4b24d0a858953f7f94666667554d41f78000b9c8a301294223688b29011",
+                    "0232c088ae7c070de89d2b6c8d485b34bf0e3b2a964a2c6622f39ca501260c23f7",
+                    "033e047f74f2aa1ce41e8c85731f97ab83d448d65dc8518ab3df4474a5d53a3d19",
+                    "02f52a8cf373c8cbddb318e523b7f111168bf753fdfb6f8aa81f88c950ede3a5ce",
+                    "039784029922c54bcd0f0e7f14530f586053a5f4e596e86b3474cd7404657088ae",
+                    "037969f9d5ab2cc609104c6e61323df55428f8f108c11aab7c7b5f953081d39304",
+                    "031bd37475b8c5615ac46d6816e791c59d806d72a0bc6739ae94e5fe4545c7f8a6",
+                    "021bb92c636feacf5b082313eb071a63dfcd26501a48b3cd248e35438e5afb7daf");
+        case XMR_MAINNET:
+            return List.of();
+        default:
+            throw new RuntimeException("Unhandled base currency network: " + Config.baseCurrencyNetwork());
+        }
     }
 
     @Override

--- a/daemon/src/main/java/haveno/daemon/grpc/GrpcAccountService.java
+++ b/daemon/src/main/java/haveno/daemon/grpc/GrpcAccountService.java
@@ -70,6 +70,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GrpcAccountService extends AccountImplBase {
 
+    // Hard cap on a single restore-account payload. The wire-level gRPC message
+    // size defaults to 4 MiB, but the chunked upload aggregates many messages
+    // into one in-memory buffer, so we cap the assembled buffer independently
+    // and at a value well above any plausible backup size (real backups are
+    // tens of MiB) to prevent a single RestoreAccount call from reserving
+    // multi-GB heap before any byte is read.
+    private static final int MAX_RESTORE_ACCOUNT_BYTES = 256 * 1024 * 1024;
+
     private final CoreApi coreApi;
     private final GrpcExceptionHandler exceptionHandler;
 
@@ -225,6 +233,17 @@ public class GrpcAccountService extends AccountImplBase {
             // If the entire zip is in memory, no need to write to disk.
             // Restore the account directly from the zip stream.
             if (!req.getHasMore() && req.getOffset() == 0) {
+                // Reject oversized single-message restores before we hand the
+                // bytes to the unzip path. gRPC's default inbound message cap
+                // is 4 MiB so a single !hasMore restore above that is already
+                // misconfigured; an attacker who has bumped the server cap
+                // would otherwise be able to allocate arbitrary heap here.
+                int singleSize = req.getZipBytes().size();
+                if (singleSize > MAX_RESTORE_ACCOUNT_BYTES) {
+                    throw new IllegalArgumentException(
+                            "RestoreAccount payload too large: " + singleSize
+                                    + " > " + MAX_RESTORE_ACCOUNT_BYTES);
+                }
                 var inputStream = req.getZipBytes().newInput();
                 coreApi.restoreAccount(inputStream, 1024 * 64, () -> {
                     var reply = RestoreAccountReply.newBuilder().build();
@@ -233,14 +252,31 @@ public class GrpcAccountService extends AccountImplBase {
                 });
             } else {
                 if (req.getOffset() == 0) {
+                    // totalLength comes from the client and is uint64; cap it
+                    // before casting to int and pre-allocating the buffer, so
+                    // a malicious client can't reserve multi-GB heap on a
+                    // single call.
+                    long totalLength = req.getTotalLength();
+                    if (totalLength <= 0 || totalLength > MAX_RESTORE_ACCOUNT_BYTES) {
+                        throw new IllegalArgumentException(
+                                "RestoreAccount totalLength out of range: " + totalLength
+                                        + " (max " + MAX_RESTORE_ACCOUNT_BYTES + ")");
+                    }
                     log.info("RestoreAccount starting new chunked zip");
-                    restoreStream = new ByteArrayOutputStream((int) req.getTotalLength());
+                    restoreStream = new ByteArrayOutputStream((int) totalLength);
                 }
                 if (restoreStream.size() != req.getOffset()) {
                     log.warn("Stream offset doesn't match current position");
                     IllegalStateException cause = new IllegalStateException("Stream offset doesn't match current position");
                     exceptionHandler.handleException(log, cause, responseObserver);
                 } else {
+                    // Enforce the cap on every appended chunk too: a client
+                    // could lie about totalLength=1, then send enough chunks
+                    // to push the assembled buffer past the cap.
+                    if (restoreStream.size() + req.getZipBytes().size() > MAX_RESTORE_ACCOUNT_BYTES) {
+                        throw new IllegalArgumentException(
+                                "RestoreAccount assembled payload exceeds " + MAX_RESTORE_ACCOUNT_BYTES + " bytes");
+                    }
                     log.info("RestoreAccount writing chunk size " + req.getZipBytes().size());
                     req.getZipBytes().writeTo(restoreStream);
                 }

--- a/daemon/src/main/java/haveno/daemon/grpc/GrpcServer.java
+++ b/daemon/src/main/java/haveno/daemon/grpc/GrpcServer.java
@@ -59,8 +59,8 @@ public class GrpcServer {
                       GrpcXmrConnectionService moneroConnectionsService,
                       GrpcXmrNodeService moneroNodeService) {
         this.server = ServerBuilder.forPort(config.apiPort)
-                .addService(shutdownService)
                 .intercept(passwordAuthInterceptor)
+                .addService(interceptForward(shutdownService, interceptors()))
                 .addService(interceptForward(accountService, config.disableRateLimits ? interceptors() : accountService.interceptors()))
                 .addService(interceptForward(disputeAgentsService, config.disableRateLimits ? interceptors() : disputeAgentsService.interceptors()))
                 .addService(interceptForward(disputesService, config.disableRateLimits ? interceptors() : disputesService.interceptors()))

--- a/daemon/src/main/java/haveno/daemon/grpc/GrpcXmrConnectionService.java
+++ b/daemon/src/main/java/haveno/daemon/grpc/GrpcXmrConnectionService.java
@@ -243,7 +243,20 @@ class GrpcXmrConnectionService extends XmrConnectionsImplBase {
 
     private static String validateUri(String url) throws MalformedURLException {
         if (url.isEmpty()) throw new IllegalArgumentException("URL is required");
-        return new URL(url).toString(); // validate and return
+        // Only http(s) is meaningful for a Monero RPC endpoint. Without this
+        // gate, a gRPC caller (after authenticating against PasswordAuthInterceptor)
+        // can hand `file:`, `jar:`, `ftp:`, or arbitrary http URLs to the wallet
+        // RPC layer — including cloud IMDS addresses like
+        // http://169.254.169.254/latest/meta-data or loopback endpoints that
+        // the daemon should never be told to use as a wallet.
+        java.net.URL parsed = new URL(url);
+        String protocol = parsed.getProtocol();
+        if (protocol == null
+                || (!protocol.equalsIgnoreCase("http") && !protocol.equalsIgnoreCase("https"))) {
+            throw new IllegalArgumentException(
+                    "Monero RPC URL must be http(s); got '" + protocol + "' for " + url);
+        }
+        return parsed.toString();
     }
 
     private static String nullIfEmpty(String value) {

--- a/p2p/src/main/java/haveno/network/p2p/network/BoundedInputStream.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/BoundedInputStream.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.network.p2p.network;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Wraps an underlying stream and allows only a fixed number of bytes to be
+ * read from it before it returns EOF. Used to feed protobuf's CodedInputStream
+ * exactly the byte budget advertised in the varint length prefix, so a remote
+ * peer cannot force protobuf to allocate beyond the declared envelope size.
+ */
+final class BoundedInputStream extends FilterInputStream {
+
+    private long remaining;
+
+    BoundedInputStream(InputStream in, long maxBytes) {
+        super(in);
+        this.remaining = maxBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (remaining <= 0) return -1;
+        int b = in.read();
+        if (b >= 0) remaining--;
+        return b;
+    }
+
+    @Override
+    public int read(byte[] buf, int off, int len) throws IOException {
+        if (remaining <= 0) return -1;
+        int toRead = (int) Math.min(len, remaining);
+        int read = in.read(buf, off, toRead);
+        if (read > 0) remaining -= read;
+        return read;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long toSkip = Math.min(n, remaining);
+        long skipped = in.skip(toSkip);
+        remaining -= skipped;
+        return skipped;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return (int) Math.min(in.available(), remaining);
+    }
+}

--- a/p2p/src/main/java/haveno/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/Connection.java
@@ -38,6 +38,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Inject;
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.InvalidProtocolBufferException;
 import haveno.common.Proto;
 import haveno.common.ThreadUtils;
@@ -920,8 +921,29 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
                         return;
                     }
 
-                    // Blocking read from the inputStream
-                    protobuf.NetworkEnvelope proto = protobuf.NetworkEnvelope.parseDelimitedFrom(protoInputStream);
+                    // Read the varint length prefix and enforce our size cap BEFORE
+                    // handing the body to protobuf, so an attacker cannot force a
+                    // ~64 MiB allocation per inbound message.
+                    int declaredSize = readVarInt(protoInputStream);
+                    if (declaredSize < 0) {
+                        if (stopped) return;
+                        if (protoInputStream.read() == -1) {
+                            // expected EOF on clean shutdown
+                        } else {
+                            throttleWarn("proto is null. protoInputStream.read()=" + protoInputStream.read());
+                        }
+                        shutDown(CloseConnectionReason.NO_PROTO_BUFFER_ENV);
+                        return;
+                    }
+                    if (declaredSize > MAX_PERMITTED_MESSAGE_SIZE) {
+                        String errorMessage = "Declared size out of range. declaredSize=" + declaredSize;
+                        if (reportInvalidRequest(RuleViolation.MAX_MSG_SIZE_EXCEEDED, errorMessage))
+                            return;
+                    }
+                    CodedInputStream codedInput = CodedInputStream.newInstance(
+                            new BoundedInputStream(protoInputStream, declaredSize));
+                    codedInput.setSizeLimit(MAX_PERMITTED_MESSAGE_SIZE);
+                    protobuf.NetworkEnvelope proto = protobuf.NetworkEnvelope.parseFrom(codedInput);
 
                     long ts = System.currentTimeMillis();
 
@@ -1107,6 +1129,31 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
     private String getSenderNodeAddressAsString(NetworkEnvelope networkEnvelope) {
         NodeAddress nodeAddress = getSenderNodeAddress(networkEnvelope);
         return nodeAddress == null ? "null" : nodeAddress.getFullAddress();
+    }
+
+    /**
+     * Read a base-128 varint (the length prefix protobuf uses for delimited messages)
+     * from the given stream. Returns -1 on EOF before any byte is read.
+     * Throws IOException if the varint exceeds 5 bytes (i.e. would decode to a
+     * length > Integer.MAX_VALUE).
+     */
+    static int readVarInt(InputStream in) throws IOException {
+        int result = 0;
+        int shift = 0;
+        int b;
+        do {
+            b = in.read();
+            if (b < 0) {
+                if (shift == 0) return -1;
+                throw new IOException("Truncated varint");
+            }
+            if (shift == 28 && (b & 0xF0) != 0) {
+                throw new IOException("Varint too long");
+            }
+            result |= (b & 0x7F) << shift;
+            shift += 7;
+        } while ((b & 0x80) != 0);
+        return result;
     }
 
     private void throttleWarn(String msg) {


### PR DESCRIPTION
## Summary

This PR addresses seven security issues identified by a multi-agent code review of the Haveno codebase. The first three commits (the original three) cover gRPC ShutdownService auth, P2P protobuf allocation DoS, and RefundAgent pubkey network scoping. Four additional commits (this update) cover ZIP slip in the restore-account path, a heap-exhaustion DoS in the same gRPC endpoint, an AES-key / push-token log leak in `MobileNotificationService`, and an SSRF in the Monero RPC URL setter.

- **P1 - gRPC ShutdownService is unauthenticated** (`9044cd80`): the ShutdownServer service was registered before the PasswordAuthInterceptor, so any client reaching the API port could stop the daemon.
- **P1 - Inbound protobuf parsing before size limit** (`36c31f4e`): Connection.run() calls parseDelimitedFrom before the 200 KiB / 10 MiB cap is checked, allowing ~64 MiB protobuf allocation per inbound connection.
- **P1 - RefundAgent pubkey list is not network-scoped** (`03709143`): RefundAgentManager.getPubKeyList() returns the same 15 keys for XMR_MAINNET, XMR_STAGENET, and XMR_LOCAL, letting a stagenet/testnet refund agent be implicitly trusted on mainnet.
- **P1 - ZIP slip in `ZipUtils.unzipToDir`** (`60137f79`): no path-containment check on zip entries, so a crafted entry escapes the target directory. Reachable through the gRPC `RestoreAccount` endpoint.
- **P1 - Heap-exhaustion DoS in `GrpcAccountService.restoreAccount`** (`60121be1`): chunked-upload buffer pre-allocated with a client-controlled `uint64 totalLength`; one call can reserve ~2 GB before any byte is read.
- **P1 - Plaintext AES key + push token + payload in `MobileNotificationService` logs** (`37add87e`): the symmetric AES pairing key, IV, ciphertext, plaintext JSON, and push token were emitted at INFO level — and the default logback root level in desktop/daemon is TRACE.
- **P1 - Unrestricted URL scheme on Monero RPC gRPC setters** (`25f78139`): `validateUri` only checked `new URL(url).toString()`, so file/jar/ftp and arbitrary hosts reached the wallet RPC layer.

## Detailed findings

### P1 - daemon/grpc/GrpcServer.java:62 - unauthenticated ShutdownService

The ShutdownServer gRPC service is registered with `.addService(shutdownService)` BEFORE `.intercept(passwordAuthInterceptor)`. In gRPC, ServerBuilder.intercept() only applies interceptors to services added AFTER the call, so the shutdown service is reachable by any client that can reach the API port (default 8080) without supplying the configured apiPassword. A network-reachable attacker can invoke `stop()` with an empty password header and forcibly terminate the headless daemon, stranding in-flight trades, open multisig wallets, and ongoing disputes.

**Fix:** wrap shutdownService in the password auth interceptor and move the registration after the .intercept() call.

### P1 - p2p/network/Connection.java:924 - DoS via pre-validation protobuf parsing

`protobuf.NetworkEnvelope.parseDelimitedFrom(protoInputStream)` is called BEFORE the size check at line 982. protobuf-java parseDelimitedFrom honors its default CodedInputStream size limit (~64 MiB), so an attacker who sends a varint-prefixed 64 MiB message body will cause the full envelope to be parsed in memory before the PERMITTED_MESSAGE_SIZE (200 KiB) cap is evaluated. With N parallel connections a node can be OOM'd even though legitimate protocol messages are supposed to be capped at 200 KiB.

**Fix:** read the varint length prefix first and reject anything larger than MAX_PERMITTED_MESSAGE_SIZE before protobuf materialization. Feed the body through a new BoundedInputStream that allows exactly declaredSize bytes to be read, so protobuf cannot over-read the underlying socket into the next message's frame.

### P1 - core/support/dispute/refund/refundagent/RefundAgentManager.java:43 - pubkey list not network-scoped

`RefundAgentManager.getPubKeyList()` did not switch on `Config.baseCurrencyNetwork()` and returned the same 15 hardcoded pubkeys for XMR_MAINNET, XMR_STAGENET, and XMR_LOCAL. Any refund agent that registered on stagenet/testnet with one of those pubkeys was auto-trusted as a RefundAgent by mainnet peers. (ArbitratorManager does it correctly per-network.)

**Fix:** scope getPubKeyList() on Config.baseCurrencyNetwork(), with explicit per-network lists. XMR_MAINNET returns an empty list (matching the existing ArbitratorManager pattern for launch); XMR_STAGENET and XMR_LOCAL keep the historical 15 keys.

### P1 - common/util/ZipUtils.java:106 - ZIP slip in unzipToDir

`unzipToDir` constructed `new File(dir, entry.getName())` and wrote there with no path-containment check, so a crafted zip entry like `../../etc/cron.d/evil` was extracted to a path outside the target directory. Reachable through `CoreAccountService.restoreAccount` (called from `GrpcAccountService.restoreAccount` and the local `BackupView` restore flow), so a gRPC-authenticated attacker could write arbitrary files anywhere the JVM user can write when the operator imports a malicious backup.

**Fix:** canonicalize the target directory once and reject every entry whose canonicalized path does not start with that baseline, before mkdirs / write. The canonical resolver also normalizes absolute paths and symlinks.

### P1 - daemon/grpc/GrpcAccountService.java:237 - heap-exhaustion DoS in restoreAccount

The chunked-upload buffer was pre-allocated with `new ByteArrayOutputStream((int) req.getTotalLength())`, where `totalLength` is a client-controlled uint64 field on `RestoreAccountRequest`. A single RestoreAccount call with `totalLength` near Integer.MAX_VALUE reserved ~2 GB of JVM heap before any zip byte was actually read; with N concurrent calls the daemon OOM'd. The single-message fast path had the same exposure.

**Fix:** cap both paths at `MAX_RESTORE_ACCOUNT_BYTES = 256 MiB` (well above any plausible backup size — real backups are tens of MiB), validate `totalLength` against the cap before pre-allocation, and re-check the running buffer size after each appended chunk.

### P1 - core/notifications/MobileNotificationService.java:212 - plaintext AES key + push token in logs

`sendMessage` emitted the symmetric AES pairing key (`log.info("key = " + mobileModel.getKey())`), the per-message IV, the base64 ciphertext, the plaintext trade/dispute JSON, and the device push token + hex-encoded token at INFO level. The default logback root level in desktop/daemon is TRACE, so every push notification wrote those values to haveno.log by default — the AES key alone is sufficient to decrypt any captured payload, past or future.

**Fix:** demote every line that emitted the AES key, IV, ciphertext, plaintext JSON, push token, or hex-encoded token to debug, with length-only previews. The INFO-level call-result log is kept.

### P1 - daemon/grpc/GrpcXmrConnectionService.java:244 - unrestricted URL scheme on Monero RPC setters

`validateUri` only verified that `new URL(url)` parsed, so it accepted arbitrary schemes (file:, jar:, ftp:, gopher:) and any host. The result was handed straight to `MoneroRpcConnection` as the wallet RPC endpoint, so an authenticated gRPC caller could point the wallet at cloud-IMDS URLs (e.g. `http://169.254.169.254/latest/meta-data/iam/security-credentials/`) or at loopback services the daemon should never be told to speak to.

**Fix:** restrict `validateUri` to the `http` and `https` schemes; everything else is rejected at the gRPC boundary with a clear error.

## Verification

Each fix is scoped to the smallest necessary change. The original multi-agent review surfaced an additional finding around `Cipher.getInstance("AES")` defaulting to AES/ECB in `Encryption.java`; that change is format-breaking for persisted state and in-flight peer payloads, so it is intentionally scoped out of this PR and left for a coordinated migration release. The follow-up review surfaced four more issues (AES/CBC/NOPadding + no MAC in `MobileMessageEncryption`, non-constant-time `apiPassword` compare in `PasswordAuthInterceptor`, unauthenticated `senderNodeAddress` on inbound P2P envelopes, and Scrypt N=32768 in `ScryptUtil`) — each is deferred with a short note in the summary comment because they all need a coordinated release (mobile app update, scrypt parameter migration, or a per-connection handshake design).
