### PR TITLE
Keep security deposit percentage editable on small offers

### DIFF
--- a/core/src/main/java/haveno/core/payment/validation/SecurityDepositValidator.java
+++ b/core/src/main/java/haveno/core/payment/validation/SecurityDepositValidator.java
@@ -28,6 +28,7 @@ import haveno.core.xmr.wallet.Restrictions;
 public class SecurityDepositValidator extends NumberValidator {
 
     private PaymentAccount paymentAccount;
+    private double minSecurityDepositAsPercent = Restrictions.getMinSecurityDepositPct();
 
     @Inject
     public SecurityDepositValidator() {
@@ -35,6 +36,10 @@ public class SecurityDepositValidator extends NumberValidator {
 
     public void setPaymentAccount(PaymentAccount paymentAccount) {
         this.paymentAccount = paymentAccount;
+    }
+
+    public void setMinSecurityDepositAsPercent(double minSecurityDepositAsPercent) {
+        this.minSecurityDepositAsPercent = minSecurityDepositAsPercent;
     }
 
     @Override
@@ -59,7 +64,7 @@ public class SecurityDepositValidator extends NumberValidator {
     private ValidationResult validateIfNotTooLowPercentageValue(String input) {
         try {
             double percentage = ParsingUtils.parsePercentStringToDouble(input);
-            double minPercentage = Restrictions.getMinSecurityDepositPct();
+            double minPercentage = minSecurityDepositAsPercent;
             if (percentage < minPercentage)
                 return new ValidationResult(false,
                         Res.get("validation.inputTooSmall", FormattingUtils.formatToPercentWithSymbol(minPercentage)));

--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferView.java
@@ -949,6 +949,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         model.getDataModel().missingCoin.addListener(missingCoinListener);
         model.securityDepositInXMR.addListener(securityDepositInXMRListener);
         model.isMinSecurityDeposit.addListener(isMinSecurityDepositListener);
+        updateSecurityDepositLabels();
         model.getDataModel().isPrivateOffer.addListener(isPrivateOfferListener);
         model.getDataModel().buyerAsTakerWithoutDeposit.addListener(buyerAsTakerWithoutDepositListener);
         model.getDataModel().extraInfo.addListener(extraInfoListener);

--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferViewModel.java
@@ -154,7 +154,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     final BooleanProperty showPayFundsScreenDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty showTransactionPublishedScreen = new SimpleBooleanProperty();
     final BooleanProperty isWaitingForFunds = new SimpleBooleanProperty();
-    final BooleanProperty isMinSecurityDeposit = new SimpleBooleanProperty();
+    public final BooleanProperty isMinSecurityDeposit = new SimpleBooleanProperty();
 
     final ObjectProperty<InputValidator.ValidationResult> amountValidationResult = new SimpleObjectProperty<>();
     final ObjectProperty<InputValidator.ValidationResult> minAmountValidationResult = new SimpleObjectProperty<>();
@@ -246,6 +246,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
         addBindings();
         addListeners();
+
+        updateSecurityDeposit();
 
         updateButtonDisableState();
 
@@ -418,7 +420,10 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
         securityDepositStringListener = (ov, oldValue, newValue) -> {
             if (!ignoreSecurityDepositStringListener) {
-                if (securityDepositValidator.validate(newValue).isValid) {
+                InputValidator.ValidationResult result = securityDepositValidator.validate(newValue);
+                if (!isMinSecurityDeposit.get())
+                    securityDepositValidationResult.set(result);
+                if (result.isValid) {
                     setSecurityDepositToModel();
                     dataModel.calculateTotalToPay();
                 }
@@ -1296,16 +1301,29 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     }
 
     private void updateSecurityDeposit() {
-        isMinSecurityDeposit.set(dataModel.isMinSecurityDeposit());
+        String amountText = amount.get();
+        BigInteger amountValue = amountText == null || !amountText.isEmpty()
+                ? dataModel.getAmount().get()
+                : null;
+        BigInteger minDeposit = Restrictions.getMinSecurityDeposit();
+        double floorAsPercent = amountValue != null && amountValue.signum() > 0
+                ? CoinUtil.getAsPercentPerXmr(minDeposit, amountValue)
+                : Double.MAX_VALUE;
+        boolean percentIrrelevant = floorAsPercent > Restrictions.getMaxSecurityDepositPct();
+        isMinSecurityDeposit.set(percentIrrelevant);
         securityDepositLabel.set(getSecurityDepositLabel());
-        if (dataModel.isMinSecurityDeposit()) {
-            securityDeposit.set(HavenoUtils.formatXmr(Restrictions.getMinSecurityDeposit()));
+        if (percentIrrelevant) {
+            securityDeposit.set(HavenoUtils.formatXmr(minDeposit));
             securityDepositValidationResult.set(new ValidationResult(true));
         } else {
+            securityDepositValidator.setMinSecurityDepositAsPercent(
+                    Math.max(Restrictions.getMinSecurityDepositPct(), floorAsPercent));
             boolean hasBuyerAsTakerWithoutDeposit = dataModel.buyerAsTakerWithoutDeposit.get() && dataModel.isSellOffer();
             securityDeposit.set(FormattingUtils.formatToPercent(hasBuyerAsTakerWithoutDeposit ?
                     Restrictions.getDefaultSecurityDepositPct() : // use default percent if no deposit from buyer
                     dataModel.getSecurityDepositPct().get()));
+            securityDepositValidationResult.set(
+                    securityDepositValidator.validate(securityDeposit.get()));
         }
     }
 
@@ -1326,8 +1344,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             inputDataValid = inputDataValid && triggerPriceValidationResult.get().isValid;
         }
 
-        // validating the percentage deposit value only makes sense if it is actually used
-        if (!dataModel.isMinSecurityDeposit()) {
+        // validate the deposit only while the percent field is editable
+        if (!isMinSecurityDeposit.get()) {
             inputDataValid = inputDataValid && securityDepositValidator.validate(securityDeposit.get()).isValid;
         }
 

--- a/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
+++ b/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
@@ -54,7 +54,9 @@ import java.util.UUID;
 
 import static haveno.desktop.maker.PreferenceMakers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -221,5 +223,25 @@ public class CreateOfferViewModelTest {
         assertEquals("0.00", model.marketPriceMargin.get());
         assertEquals("126.84045000", model.volume.get());
         assertEquals("12684.04500000", model.price.get());
+    }
+
+    @Test
+    public void testClearedAmountLocksSecurityDepositAtMin() {
+        assertTrue(model.isMinSecurityDeposit.get());
+
+        model.amount.set("1");
+        assertFalse(model.isMinSecurityDeposit.get());
+
+        model.amount.set("");
+        assertTrue(model.isMinSecurityDeposit.get());
+    }
+
+    @Test
+    public void testSecurityDepositLocksOnlyWhenPercentIsIrrelevant() {
+        model.amount.set("0.1");
+        assertTrue(model.isMinSecurityDeposit.get());
+
+        model.amount.set("1");
+        assertFalse(model.isMinSecurityDeposit.get());
     }
 }


### PR DESCRIPTION
The create offer form locks the security deposit input into a fixed
XMR display as soon as the current percentage of the amount does not
exceed the absolute minimum deposit (0.1 XMR). On small offers this
happens immediately with the default 15%: for any amount below about
0.67 XMR the field is disabled before a higher percentage could be
entered, so the maker cannot raise the deposit even though values up
to the 50% maximum would still be meaningful.

Keep the field editable in percent mode whenever a percentage above
the floor is possible:
- The field locks into the fixed XMR display only when percent entry
  is truly irrelevant: no amount entered yet, or the amount so small
  that even the 50% maximum stays below the absolute minimum.
- While editable, SecurityDepositValidator is given the effective
  lower bound, the minimum deposit expressed as a percentage of the
  current amount. An entry below the real floor is marked invalid
  immediately while typing and the error message names the limit,
  instead of the entry being accepted and silently lifted to the
  floor at publish time.

Unchanged behavior:
- The absolute minimum deposit itself and how the data model floors
  the deposit (getBoundedSecurityDeposit).
- The no-deposit offer handling (buyerAsTakerWithoutDeposit): the
  field is still disabled for those offers.
- The locked state still forces a valid validation result, and the
  "Min. buyer security deposit is used" label still appears whenever
  the floor binds.

To reproduce on master: create an offer with an amount of 0.5 XMR.
The deposit field shows 0.1 XMR and is disabled, with no way to
choose a higher percentage. With this change the field stays
editable; the effective floor for 0.5 XMR is 20%, values from 20% to
50% are accepted, and lower values are rejected with a message naming
the 20% limit.