### PR TITLE
desktop: keep security deposit percent editable on small offers

### DIFF
--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -532,13 +532,11 @@ createOffer.tac=With publishing this offer I agree to trade with any trader who 
 createOffer.setDeposit=Set buyer's security deposit (%)
 createOffer.setDepositAsBuyer=Set my security deposit as buyer (%)
 createOffer.setDepositForBothTraders=Set both traders' security deposit (%)
-createOffer.securityDepositInfo=Your buyer's security deposit will be {0}
-createOffer.securityDepositInfoAsBuyer=Your security deposit as buyer will be {0}
 createOffer.minSecurityDepositUsed=Minimum security deposit is used
+createOffer.minSecurityDepositApplied=Minimum security deposit of {0} will be applied
 createOffer.isPrivateOffer=Require a passphrase to take this offer
 createOffer.buyerAsTakerWithoutDeposit=No deposit required from buyer
 createOffer.myDeposit=My security deposit (%)
-createOffer.myDepositInfo=Your security deposit will be {0}
 
 
 ####################################################################

--- a/desktop/src/main/java/haveno/desktop/haveno.css
+++ b/desktop/src/main/java/haveno/desktop/haveno.css
@@ -533,6 +533,12 @@ tree-table-view:focused {
     -fx-font-size: 1em;
 }
 
+/* informational note below an input, matching the error label's rendered size but neutral */
+.field-info-label {
+    -fx-text-fill: -bs-rd-font-light;
+    -fx-font-size: 0.962em;
+}
+
 .offer-input {
     -fx-background-color: -bs-color-background-form-field;
     -fx-border-color: -bs-color-border-form-field;

--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferDataModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferDataModel.java
@@ -721,10 +721,6 @@ public abstract class MutableOfferDataModel extends OfferDataModel {
                 GUIUtil.canCreateOrTakeOfferOrShowPopup(user, navigation);
     }
 
-    public boolean isMinSecurityDeposit() {
-        return getSecurityDeposit().compareTo(Restrictions.getMinSecurityDeposit()) <= 0;
-    }
-
     public ReadOnlyObjectProperty<String> getExtraInfo() {
         return extraInfo;
     }

--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferView.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferView.java
@@ -120,6 +120,7 @@ import static haveno.desktop.util.FormBuilder.getIconButton;
 import static haveno.desktop.util.FormBuilder.getIconForLabel;
 import static haveno.desktop.util.FormBuilder.getSmallIconForLabel;
 import static haveno.desktop.util.FormBuilder.getTradeInputBox;
+import static javafx.beans.binding.Bindings.createBooleanBinding;
 import static javafx.beans.binding.Bindings.createStringBinding;
 
 public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> extends ActivatableViewAndModel<AnchorPane, M> implements ClosableView, SelectableView {
@@ -149,7 +150,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private Label amountDescriptionLabel, priceCurrencyLabel, priceDescriptionLabel, volumeDescriptionLabel,
             waitingForFundsLabel, marketBasedPriceLabel, percentagePriceDescriptionLabel, tradeFeeDescriptionLabel,
             resultLabel, tradeFeeInXmrLabel, xLabel, fakeXLabel, securityDepositLabel,
-            securityDepositPercentageLabel, triggerPriceCurrencyLabel, triggerPriceDescriptionLabel;
+            securityDepositPercentageLabel, minSecurityDepositLabel, triggerPriceCurrencyLabel, triggerPriceDescriptionLabel;
     protected Label amountBtcLabel, volumeCurrencyLabel, minAmountBtcLabel;
     private ComboBox<PaymentAccount> paymentAccountsComboBox;
     private ComboBox<TradeCurrency> currencyComboBox;
@@ -167,7 +168,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             isMinSecurityDepositListener, isPrivateOfferListener, buyerAsTakerWithoutDepositListener, triggerPriceFocusedListener, extraInfoFocusedListener;
     private ChangeListener<BigInteger> missingCoinListener;
     private ChangeListener<String> tradeCurrencyCodeListener, errorMessageListener,
-            marketPriceMarginListener, volumeListener, securityDepositInXMRListener, extraInfoListener;
+            marketPriceMarginListener, volumeListener, extraInfoListener;
     private ChangeListener<Number> marketPriceAvailableListener;
     private EventHandler<ActionEvent> currencyComboBoxSelectionHandler, paymentAccountsComboBoxSelectionHandler;
     private OfferView.CloseHandler closeHandler;
@@ -177,8 +178,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     private final List<Node> editOfferElements = new ArrayList<>();
     private final HashMap<String, Boolean> paymentAccountWarningDisplayed = new HashMap<>();
     private boolean zelleWarningDisplayed, fasterPaymentsWarningDisplayed, isActivated;
-    private InfoInputTextField marketBasedPriceInfoInputTextField, volumeInfoInputTextField,
-            securityDepositInfoInputTextField, triggerPriceInfoInputTextField;
+    private InfoInputTextField marketBasedPriceInfoInputTextField, volumeInfoInputTextField, triggerPriceInfoInputTextField;
     private Text xIcon, fakeXIcon;
 
     @Setter
@@ -595,6 +595,12 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         addressTextField.amountAsProperty().bind(model.getDataModel().getMissingCoin());
         securityDepositInputTextField.textProperty().bindBidirectional(model.securityDeposit);
         securityDepositLabel.textProperty().bind(model.securityDepositLabel);
+        minSecurityDepositLabel.textProperty().bind(model.minSecurityDepositMessage);
+        // show the note only while the field has no validation error, which renders in the same place
+        minSecurityDepositLabel.visibleProperty().bind(model.minSecurityDepositMessage.isNotEmpty()
+                .and(createBooleanBinding(() -> model.securityDepositValidationResult.get() == null || model.securityDepositValidationResult.get().isValid,
+                        model.securityDepositValidationResult)));
+        minSecurityDepositLabel.managedProperty().bind(minSecurityDepositLabel.visibleProperty());
         tradeFeeInXmrLabel.textProperty().bind(model.tradeFeeInXmrWithFiat);
         tradeFeeDescriptionLabel.textProperty().bind(model.tradeFeeDescription);
         tradeFeeInXmrLabel.visibleProperty().bind(model.isTradeFeeVisible);
@@ -648,6 +654,9 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         addressTextField.amountAsProperty().unbind();
         securityDepositInputTextField.textProperty().unbindBidirectional(model.securityDeposit);
         securityDepositLabel.textProperty().unbind();
+        minSecurityDepositLabel.textProperty().unbind();
+        minSecurityDepositLabel.visibleProperty().unbind();
+        minSecurityDepositLabel.managedProperty().unbind();
         tradeFeeInXmrLabel.textProperty().unbind();
         tradeFeeDescriptionLabel.textProperty().unbind();
         tradeFeeInXmrLabel.visibleProperty().unbind();
@@ -799,14 +808,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             }
         };
 
-        securityDepositInXMRListener = (observable, oldValue, newValue) -> {
-            if (!newValue.equals("")) {
-                updateSecurityDepositLabels();
-            } else {
-                securityDepositInfoInputTextField.setContentForInfoPopOver(null);
-            }
-        };
-
         volumeListener = (observable, oldValue, newValue) -> {
             if (!newValue.equals("") && CurrencyUtil.isFiatCurrency(model.tradeCurrencyCode.get())) {
                 Label popOverLabel = OfferViewUtil.createPopOverLabel(Res.get("offerbook.info.roundedFiatVolume"));
@@ -908,10 +909,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
             securityDepositPercentageLabel.setText("%");
             securityDepositInputTextField.setDisable(model.getDataModel().buyerAsTakerWithoutDeposit.get());
         }
-        if (model.securityDepositInXMR.get() != null && !model.securityDepositInXMR.get().equals("")) {
-            Label depositInBTCInfo = OfferViewUtil.createPopOverLabel(model.getSecurityDepositPopOverLabel(model.securityDepositInXMR.get()));
-            securityDepositInfoInputTextField.setContentForInfoPopOver(depositInBTCInfo);
-        }
     }
 
     private void updateQrCode() {
@@ -947,8 +944,8 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         model.marketPriceMargin.addListener(marketPriceMarginListener);
         model.volume.addListener(volumeListener);
         model.getDataModel().missingCoin.addListener(missingCoinListener);
-        model.securityDepositInXMR.addListener(securityDepositInXMRListener);
         model.isMinSecurityDeposit.addListener(isMinSecurityDepositListener);
+        updateSecurityDepositLabels();
         model.getDataModel().isPrivateOffer.addListener(isPrivateOfferListener);
         model.getDataModel().buyerAsTakerWithoutDeposit.addListener(buyerAsTakerWithoutDepositListener);
         model.getDataModel().extraInfo.addListener(extraInfoListener);
@@ -983,7 +980,6 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         model.marketPriceMargin.removeListener(marketPriceMarginListener);
         model.volume.removeListener(volumeListener);
         model.getDataModel().missingCoin.removeListener(missingCoinListener);
-        model.securityDepositInXMR.removeListener(securityDepositInXMRListener);
         model.isMinSecurityDeposit.removeListener(isMinSecurityDepositListener);
         model.getDataModel().isPrivateOffer.removeListener(isPrivateOfferListener);
         model.getDataModel().buyerAsTakerWithoutDeposit.removeListener(buyerAsTakerWithoutDepositListener);
@@ -1321,10 +1317,9 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
     }
 
     private VBox getSecurityDepositBox() {
-        Tuple3<HBox, InfoInputTextField, Label> tuple = getEditableValueBoxWithInfo(
+        Tuple3<HBox, InputTextField, Label> tuple = getEditableValueBox(
                 Res.get("createOffer.securityDeposit.prompt"));
-        securityDepositInfoInputTextField = tuple.second;
-        securityDepositInputTextField = securityDepositInfoInputTextField.getInputTextField();
+        securityDepositInputTextField = tuple.second;
         securityDepositPercentageLabel = tuple.third;
         // getEditableValueBox delivers BTC, so we overwrite it with %
         securityDepositPercentageLabel.setText("%");
@@ -1336,6 +1331,11 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
 
         editOfferElements.add(securityDepositInputTextField);
         editOfferElements.add(securityDepositPercentageLabel);
+
+        minSecurityDepositLabel = new Label();
+        minSecurityDepositLabel.getStyleClass().add("field-info-label");
+        minSecurityDepositLabel.setWrapText(true);
+        depositBox.getChildren().add(minSecurityDepositLabel);
 
         return depositBox;
     }

--- a/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/offer/MutableOfferViewModel.java
@@ -115,9 +115,9 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     public final StringProperty amount = new SimpleStringProperty();
     public final StringProperty minAmount = new SimpleStringProperty();
-    protected final StringProperty securityDeposit = new SimpleStringProperty();
-    final StringProperty securityDepositInXMR = new SimpleStringProperty();
-    final StringProperty securityDepositLabel = new SimpleStringProperty();
+    public final StringProperty securityDeposit = new SimpleStringProperty();
+    public final StringProperty minSecurityDepositMessage = new SimpleStringProperty();
+    public final StringProperty securityDepositLabel = new SimpleStringProperty();
 
     // Price in the viewModel is always dependent on fiat/crypto: Fiat Fiat/BTC, for cryptos we use inverted price.
     // The domain (dataModel) uses always the same price model (otherCurrencyBTC)
@@ -154,7 +154,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     final BooleanProperty showPayFundsScreenDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty showTransactionPublishedScreen = new SimpleBooleanProperty();
     final BooleanProperty isWaitingForFunds = new SimpleBooleanProperty();
-    final BooleanProperty isMinSecurityDeposit = new SimpleBooleanProperty();
+    public final BooleanProperty isMinSecurityDeposit = new SimpleBooleanProperty();
 
     final ObjectProperty<InputValidator.ValidationResult> amountValidationResult = new SimpleObjectProperty<>();
     final ObjectProperty<InputValidator.ValidationResult> minAmountValidationResult = new SimpleObjectProperty<>();
@@ -247,6 +247,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         addBindings();
         addListeners();
 
+        updateSecurityDeposit();
         updateButtonDisableState();
 
         updateMarketPriceAvailable();
@@ -418,7 +419,10 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
         securityDepositStringListener = (ov, oldValue, newValue) -> {
             if (!ignoreSecurityDepositStringListener) {
-                if (securityDepositValidator.validate(newValue).isValid) {
+                InputValidator.ValidationResult result = securityDepositValidator.validate(newValue);
+                if (!isMinSecurityDeposit.get())
+                    securityDepositValidationResult.set(result);
+                if (result.isValid) {
                     setSecurityDepositToModel();
                     dataModel.calculateTotalToPay();
                 }
@@ -429,10 +433,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         amountListener = (ov, oldValue, newValue) -> {
             if (newValue != null) {
                 amount.set(HavenoUtils.formatXmr(newValue));
-                securityDepositInXMR.set(HavenoUtils.formatXmr(dataModel.getSecurityDeposit(), true));
             } else {
                 amount.set("");
-                securityDepositInXMR.set("");
             }
 
             applyMakerFee();
@@ -470,13 +472,10 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         securityDepositAsDoubleListener = (ov, oldValue, newValue) -> {
             if (newValue != null) {
                 securityDeposit.set(FormattingUtils.formatToPercent((double) newValue));
-                if (dataModel.getAmount().get() != null) {
-                    securityDepositInXMR.set(HavenoUtils.formatXmr(dataModel.getSecurityDeposit(), true));
-                }
                 updateSecurityDeposit();
             } else {
                 securityDeposit.set("");
-                securityDepositInXMR.set("");
+                minSecurityDepositMessage.set("");
             }
         };
 
@@ -1074,15 +1073,9 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     public String getSecurityDepositLabel() {
         return dataModel.buyerAsTakerWithoutDeposit.get() && dataModel.isSellOffer() ? Res.get("createOffer.myDeposit") :
-                dataModel.isMinSecurityDeposit() ? Res.get("createOffer.minSecurityDepositUsed") :
+                isMinSecurityDeposit.get() ? Res.get("createOffer.minSecurityDepositUsed") :
                 Preferences.USE_SYMMETRIC_SECURITY_DEPOSIT ? Res.get("createOffer.setDepositForBothTraders") :
                 dataModel.isBuyOffer() ? Res.get("createOffer.setDepositAsBuyer") : Res.get("createOffer.setDeposit");
-    }
-
-    public String getSecurityDepositPopOverLabel(String depositInXMR) {
-        return dataModel.buyerAsTakerWithoutDeposit.get() && dataModel.isSellOffer() ? Res.get("createOffer.myDepositInfo", depositInXMR) :
-                dataModel.isBuyOffer() ? Res.get("createOffer.securityDepositInfoAsBuyer", depositInXMR) :
-                Res.get("createOffer.securityDepositInfo", depositInXMR);
     }
 
     public String getSecurityDepositInfo() {
@@ -1295,18 +1288,32 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         isWaitingForFunds.set(!waitingForFundsText.get().isEmpty());
     }
 
-    private void updateSecurityDeposit() {
-        isMinSecurityDeposit.set(dataModel.isMinSecurityDeposit());
+    protected void updateSecurityDeposit() {
+        String amountText = amount.get();
+        BigInteger amountValue = amountText != null && amountText.isEmpty() ? null : dataModel.getAmount().get();
+        double floorAsPercent = amountValue != null && amountValue.signum() > 0
+                ? CoinUtil.getAsPercentPerXmr(Restrictions.getMinSecurityDeposit(), amountValue)
+                : Double.MAX_VALUE;
+        boolean percentIrrelevant = floorAsPercent >= Restrictions.getMaxSecurityDepositPct();
+        isMinSecurityDeposit.set(percentIrrelevant);
         securityDepositLabel.set(getSecurityDepositLabel());
-        if (dataModel.isMinSecurityDeposit()) {
+        if (percentIrrelevant) {
             securityDeposit.set(HavenoUtils.formatXmr(Restrictions.getMinSecurityDeposit()));
             securityDepositValidationResult.set(new ValidationResult(true));
         } else {
+            // percents below the floor stay valid; the data model floors the actual deposit at the min XMR amount
             boolean hasBuyerAsTakerWithoutDeposit = dataModel.buyerAsTakerWithoutDeposit.get() && dataModel.isSellOffer();
             securityDeposit.set(FormattingUtils.formatToPercent(hasBuyerAsTakerWithoutDeposit ?
                     Restrictions.getDefaultSecurityDepositPct() : // use default percent if no deposit from buyer
                     dataModel.getSecurityDepositPct().get()));
+            securityDepositValidationResult.set(securityDepositValidator.validate(securityDeposit.get()));
         }
+
+        // note when the min deposit will override the entered percent
+        boolean floorBinds = !percentIrrelevant && amountValue != null && amountValue.signum() > 0 &&
+                dataModel.getSecurityDeposit().compareTo(Restrictions.getMinSecurityDeposit()) <= 0;
+        minSecurityDepositMessage.set(floorBinds ? Res.get("createOffer.minSecurityDepositApplied",
+                HavenoUtils.formatXmr(Restrictions.getMinSecurityDeposit(), true)) : "");
     }
 
     void updateButtonDisableState() {
@@ -1326,8 +1333,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             inputDataValid = inputDataValid && triggerPriceValidationResult.get().isValid;
         }
 
-        // validating the percentage deposit value only makes sense if it is actually used
-        if (!dataModel.isMinSecurityDeposit()) {
+        // validating the percentage deposit value only makes sense while the field holds a percentage
+        if (!isMinSecurityDeposit.get()) {
             inputDataValid = inputDataValid && securityDepositValidator.validate(securityDeposit.get()).isValid;
         }
 

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/cloneoffer/CloneOfferViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/cloneoffer/CloneOfferViewModel.java
@@ -75,6 +75,7 @@ class CloneOfferViewModel extends MutableOfferViewModel<CloneOfferDataModel> {
         super.activate();
 
         dataModel.populateData();
+        updateSecurityDeposit();
 
         long triggerPriceAsLong = dataModel.getTriggerPrice();
         dataModel.setTriggerPrice(triggerPriceAsLong);
@@ -105,7 +106,8 @@ class CloneOfferViewModel extends MutableOfferViewModel<CloneOfferDataModel> {
     }
 
     public boolean isSecurityDepositValid() {
-        return securityDepositValidator.validate(securityDeposit.get()).isValid;
+        // in the locked state the field holds a fixed XMR amount, not a percentage
+        return isMinSecurityDeposit.get() || securityDepositValidator.validate(securityDeposit.get()).isValid;
     }
 
     @Override

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/editoffer/EditOfferViewModel.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/editoffer/EditOfferViewModel.java
@@ -72,6 +72,7 @@ class EditOfferViewModel extends MutableOfferViewModel<EditOfferDataModel> {
         super.activate();
 
         dataModel.populateData();
+        updateSecurityDeposit();
 
         long triggerPriceAsLong = dataModel.getTriggerPrice();
         dataModel.setTriggerPrice(triggerPriceAsLong);
@@ -111,7 +112,8 @@ class EditOfferViewModel extends MutableOfferViewModel<EditOfferDataModel> {
     }
 
     public boolean isSecurityDepositValid() {
-        return securityDepositValidator.validate(securityDeposit.get()).isValid;
+        // in the locked state the field holds a fixed XMR amount, not a percentage
+        return isMinSecurityDeposit.get() || securityDepositValidator.validate(securityDeposit.get()).isValid;
     }
 
     @Override

--- a/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
+++ b/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
@@ -33,6 +33,7 @@ import haveno.core.payment.validation.SecurityDepositValidator;
 import haveno.core.payment.validation.XmrValidator;
 import haveno.core.provider.price.MarketPrice;
 import haveno.core.provider.price.PriceFeedService;
+import haveno.core.trade.HavenoUtils;
 import haveno.core.trade.statistics.TradeStatisticsManager;
 import haveno.core.user.Preferences;
 import haveno.core.user.User;
@@ -42,6 +43,7 @@ import haveno.core.util.validation.AmountValidator8Decimals;
 import haveno.core.util.validation.AmountValidator4Decimals;
 import haveno.core.util.validation.InputValidator;
 import haveno.core.xmr.model.XmrAddressEntry;
+import haveno.core.xmr.wallet.Restrictions;
 import haveno.core.xmr.wallet.XmrWalletService;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.collections.FXCollections;
@@ -54,7 +56,10 @@ import java.util.UUID;
 
 import static haveno.desktop.maker.PreferenceMakers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -221,5 +226,66 @@ public class CreateOfferViewModelTest {
         assertEquals("0.00", model.marketPriceMargin.get());
         assertEquals("126.84045000", model.volume.get());
         assertEquals("12684.04500000", model.price.get());
+    }
+
+    @Test
+    public void testClearedAmountLocksSecurityDepositAtMin() {
+        assertTrue(model.isMinSecurityDeposit.get());
+
+        model.amount.set("1");
+        assertFalse(model.isMinSecurityDeposit.get());
+
+        model.amount.set("");
+        assertTrue(model.isMinSecurityDeposit.get());
+    }
+
+    @Test
+    public void testSecurityDepositLocksOnlyWhenPercentIsIrrelevant() {
+        model.amount.set("0.1");
+        assertTrue(model.isMinSecurityDeposit.get());
+
+        // floor equals the 50% max: no editable room, still locked
+        model.amount.set("0.2");
+        assertTrue(model.isMinSecurityDeposit.get());
+
+        model.amount.set("1");
+        assertFalse(model.isMinSecurityDeposit.get());
+    }
+
+    @Test
+    public void testSecurityDepositKeepsPercentWhenFloorApplies() {
+        model.amount.set("1");
+        assertEquals("15.00", model.securityDeposit.get());
+
+        // floor (0.1 XMR = 20%) binds in the data model without raising the displayed percent
+        model.amount.set("0.5");
+        assertFalse(model.isMinSecurityDeposit.get());
+        assertEquals("15.00", model.securityDeposit.get());
+    }
+
+    @Test
+    public void testMinSecurityDepositMessage() {
+        // floor overrides 15% of 0.5: note shown
+        model.amount.set("0.5");
+        assertEquals(Res.get("createOffer.minSecurityDepositApplied",
+                HavenoUtils.formatXmr(Restrictions.getMinSecurityDeposit(), true)), model.minSecurityDepositMessage.get());
+
+        // percent deposit above the floor: no note
+        model.amount.set("1");
+        assertEquals("", model.minSecurityDepositMessage.get());
+
+        // locked state shows the min in the field itself: no note
+        model.amount.set("0.2");
+        assertEquals("", model.minSecurityDepositMessage.get());
+    }
+
+    @Test
+    public void testSecurityDepositLabelTracksLockedState() {
+        model.amount.set("0.2");
+        assertEquals(Res.get("createOffer.minSecurityDepositUsed"), model.securityDepositLabel.get());
+
+        // floor still binds in the data model, but the field holds an editable percent
+        model.amount.set("0.5");
+        assertNotEquals(Res.get("createOffer.minSecurityDepositUsed"), model.securityDepositLabel.get());
     }
 }

--- a/desktop/src/test/java/haveno/desktop/util/validation/SecurityDepositValidatorTest.java
+++ b/desktop/src/test/java/haveno/desktop/util/validation/SecurityDepositValidatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.desktop.util.validation;
+
+import haveno.common.config.BaseCurrencyNetwork;
+import haveno.common.config.Config;
+import haveno.core.locale.CurrencyUtil;
+import haveno.core.locale.Res;
+import haveno.core.payment.validation.SecurityDepositValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SecurityDepositValidatorTest {
+
+    private SecurityDepositValidator validator;
+
+    @BeforeEach
+    public void setup() {
+        final BaseCurrencyNetwork baseCurrencyNetwork = Config.baseCurrencyNetwork();
+        final String currencyCode = baseCurrencyNetwork.getCurrencyCode();
+        Res.setBaseCurrencyCode(currencyCode);
+        Res.setBaseCurrencyName(baseCurrencyNetwork.getCurrencyName());
+        CurrencyUtil.setBaseCurrencyCode(currencyCode);
+        validator = new SecurityDepositValidator();
+    }
+
+    @Test
+    public void testValidate() {
+        assertFalse(validator.validate("14.99").isValid);
+        assertTrue(validator.validate("15.00").isValid);
+        assertTrue(validator.validate("30.00").isValid);
+        assertTrue(validator.validate("50.00").isValid);
+        assertFalse(validator.validate("50.01").isValid);
+
+        assertFalse(validator.validate(null).isValid);
+        assertFalse(validator.validate("").isValid);
+        assertFalse(validator.validate("0").isValid);
+        assertFalse(validator.validate("-15").isValid);
+        assertFalse(validator.validate("abc").isValid);
+    }
+}


### PR DESCRIPTION
Lock the field only when even the max percent stays below the minimum deposit, and floor the displayed percent at the effective minimum.