### PR TITLE
Fix offer stuck in edit mode after synchronous P2P exception

### DIFF
--- a/core/src/main/java/haveno/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/haveno/core/offer/OpenOfferManager.java
@@ -92,6 +92,7 @@ import haveno.network.p2p.AckMessageSourceType;
 import haveno.network.p2p.BootstrapListener;
 import haveno.network.p2p.DecryptedDirectMessageListener;
 import haveno.network.p2p.DecryptedMessageWithPubKey;
+import haveno.network.p2p.NetworkNotReadyException;
 import haveno.network.p2p.NodeAddress;
 import haveno.network.p2p.P2PService;
 import haveno.network.p2p.SendDirectMessageListener;
@@ -738,13 +739,18 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         offersToBeEdited.put(openOffer.getId(), openOffer);
 
         if (openOffer.isAvailable()) {
-            deactivateOpenOffer(openOffer,
-                    false,
-                    resultHandler,
-                    errorMessage -> {
-                        offersToBeEdited.remove(openOffer.getId());
-                        errorMessageHandler.handleErrorMessage(errorMessage);
-                    });
+            try {
+                deactivateOpenOffer(openOffer,
+                        false,
+                        resultHandler,
+                        errorMessage -> {
+                            offersToBeEdited.remove(openOffer.getId());
+                            errorMessageHandler.handleErrorMessage(errorMessage);
+                        });
+            } catch (NetworkNotReadyException e) {
+                offersToBeEdited.remove(openOffer.getId());
+                errorMessageHandler.handleErrorMessage(e.getMessage());
+            }
         } else {
             resultHandler.handleResult();
         }

--- a/core/src/test/java/haveno/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/haveno/core/offer/OpenOfferManagerTest.java
@@ -9,6 +9,7 @@ import haveno.common.persistence.PersistenceManager;
 import haveno.core.api.CoreContext;
 import haveno.core.api.XmrConnectionService;
 import haveno.core.trade.TradableList;
+import haveno.network.p2p.NetworkNotReadyException;
 import haveno.network.p2p.P2PService;
 import haveno.network.p2p.peers.PeerManager;
 import org.junit.jupiter.api.AfterEach;
@@ -23,6 +24,7 @@ import static haveno.core.offer.OfferMaker.btcUsdOffer;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -182,6 +184,57 @@ public class OpenOfferManagerTest {
 
         manager.editOpenOfferStart(openOffer, resultHandler, null);
         assertTrue(startEditOfferSuccessful.get());
+    }
+
+    @Test
+    public void testStartEditOfferClearsEditStateOnSynchronousDeactivateException() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+
+        final OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+
+        doThrow(new NetworkNotReadyException())
+                .when(offerBookService).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        AtomicBoolean firstEditErrorHandled = new AtomicBoolean(false);
+        manager.editOpenOfferStart(openOffer, () -> {
+        }, errorMessage -> firstEditErrorHandled.set(true));
+        assertTrue(firstEditErrorHandled.get());
+
+        doAnswer(invocation -> {
+            ((ResultHandler) invocation.getArgument(1)).handleResult();
+            return null;
+        }).when(offerBookService).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        AtomicBoolean secondEditSuccessful = new AtomicBoolean(false);
+        manager.editOpenOfferStart(openOffer, () -> secondEditSuccessful.set(true), null);
+        assertTrue(secondEditSuccessful.get());
+        verify(offerBookService, times(2)).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
     }
 
 }


### PR DESCRIPTION
An offer can get stuck in edit mode until the next restart if a P2P
call throws synchronously while editing.

editOpenOfferStart puts the offer into offersToBeEdited and then calls
deactivateOpenOffer, which reaches P2PService.removeData. That throws
NetworkNotReadyException synchronously when the network is not
bootstrapped (for example editing an offer right after startup, or
during a short connectivity gap), so the error handler that would
remove the offer from offersToBeEdited is never invoked. The offer
then stays in edit mode and can neither be activated nor removed until
a restart.

This catches NetworkNotReadyException in editOpenOfferStart and clears
the edit state, routing the failure to the existing error handler.

A regression test makes deactivateOffer throw NetworkNotReadyException
and verifies that a subsequent edit is not blocked (it reaches
deactivateOffer again instead of short-circuiting on the "already in
edit mode" check). The test fails without the fix.