### PR TITLE
Add WAM Coin (WAM)

### DIFF
--- a/assets/src/main/java/haveno/asset/coins/WAMCoin.java
+++ b/assets/src/main/java/haveno/asset/coins/WAMCoin.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.asset.coins;
+
+import haveno.asset.BitcoinAddressValidator;
+import haveno.asset.Coin;
+import haveno.asset.NetworkParametersAdapter;
+
+public class WAMCoin extends Coin {
+    public WAMCoin() {
+        super("WAM Coin", "WAM", new BitcoinAddressValidator(new WAMCoinMainNetParams()), Network.MAINNET);
+    }
+
+    public static class WAMCoinMainNetParams extends NetworkParametersAdapter {
+        public WAMCoinMainNetParams() {
+            this.addressHeader = 73;         // 'W'
+            this.p2shHeader = 135;           // 'w'
+            this.segwitAddressHrp = "wam";
+        }
+    }
+}

--- a/assets/src/main/resources/META-INF/services/haveno.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/haveno.asset.Asset
@@ -12,6 +12,7 @@ haveno.asset.coins.Monero
 haveno.asset.coins.Ripple
 haveno.asset.coins.Solana
 haveno.asset.coins.Tron
+haveno.asset.coins.WAMCoin
 haveno.asset.coins.Zcash
 haveno.asset.tokens.TetherUSDERC20
 haveno.asset.tokens.TetherUSDTRC20

--- a/assets/src/test/java/haveno/asset/coins/WAMCoinTest.java
+++ b/assets/src/test/java/haveno/asset/coins/WAMCoinTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.asset.coins;
+
+import haveno.asset.AbstractAssetTest;
+import org.junit.jupiter.api.Test;
+
+public class WAMCoinTest extends AbstractAssetTest {
+
+    public WAMCoinTest() {
+        super(new WAMCoin());
+    }
+
+    // Every address below was produced or judged by wamd itself on WAM
+    // mainnet, not written by hand: the valid ones come from getnewaddress,
+    // and validateaddress refuses each of the invalid ones.
+
+    @Test
+    public void testValidAddresses() {
+        // P2PKH, version byte 73
+        assertValidAddress("Wif4JEpEgvgZnneibRBDodYUe1We3ft1j4");
+        assertValidAddress("WWWEvpC98mfzjRMZHtaRaucMjopqH2viQz");
+        assertValidAddress("WNg2svm2qApxheBKndKGQ9sRwporvRgRpT");
+        // P2SH, version byte 135
+        assertValidAddress("wM6b6wkri2n9Ni2KyNC6ftHjfBf6iXoP1n");
+        // P2WPKH, hrp "wam"
+        assertValidAddress("wam1q85enqu8zptx20fzrdr07p5vt5ffx9udnvgv366");
+        assertValidAddress("wam1q4vgyrjdjk742nk5cdztp9fj72g2hspjzm6gf0f");
+        assertValidAddress("wam1qv8amdskgpwg5whapwgdaafe5t7xhs7q5aqkhvq");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        // Bitcoin, whose version byte is not ours
+        assertInvalidAddress("1LgfapHEPhZbRF9pMd5WPT35hFXcZS1USrW");
+        assertInvalidAddress("bc1qxtm55gultqzhqzl2p3ks50hg2478y3hehuj6dz");
+        // WAM testnet, which must not be accepted as mainnet
+        assertInvalidAddress("twam1q8fwe4ucywdzf2p80zqhpucwj8dy9kgk4x4s40m");
+        // A valid address with its last character changed: the checksum fails
+        assertInvalidAddress("WWWEvpC98mfzjRMZHtaRaucMjopqH2viQx");
+        // Right prefix, one character short
+        assertInvalidAddress("Wif4JEpEgvgZnneibRBDodYUe1We3ft1j");
+        assertInvalidAddress("Wif4JEpEgvgZnneibRBDodYUe1We3ft1j4#");
+    }
+}


### PR DESCRIPTION
WAM Coin is a Bitcoin Core v28.1 fork using RandomX proof of work. Address handling, the transaction format, the script language and SegWit are Bitcoin's, so this needs only the three constants BitcoinAddressValidator reads:

  addressHeader    73    'W'
  p2shHeader      135    'w'
  segwitAddressHrp  wam

Every address in the test came from the coin's own node rather than being written by hand: the valid ones from getnewaddress on mainnet, and each invalid one was handed to validateaddress and refused. They cover a Bitcoin address whose version byte differs, a bc1 address whose hrp differs, a testnet twam1 address that must not validate as mainnet, and a valid address with its last character changed so the checksum has to catch it.

Source:   https://github.com/wam-coin-official/wam-coin
Explorer: https://explorer.wamcoin.org

The chain has not launched yet; mainnet is scheduled for 2026-09-15. I am aware the listed set is deliberately small and every coin in it is far larger than this one, so a no is a perfectly reasonable answer and no explanation is owed. The submission is here in case the answer is otherwise, and it costs you only the time to read three constants.