### PR TITLE
desktop: redesign open trade view with hero summary and step timeline

### DIFF
--- a/desktop/src/main/java/haveno/desktop/haveno.css
+++ b/desktop/src/main/java/haveno/desktop/haveno.css
@@ -2859,26 +2859,163 @@ textfield */
     -fx-background-radius: 3px, 3px, 2px, 1px;
 }
 
-/* Pending trades */
-#trade-wizard-item-background-disabled {
+/* Pending trades — hero summary card, horizontal step timeline and support band */
+.trade-hero-card,
+.trade-support-band {
+    -fx-background-color: -bs-color-background-pane;
+    -fx-background-radius: 10;
+    -fx-border-radius: 10;
+    -fx-border-color: -bs-offer-card-border;
+    -fx-border-width: 1;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.08), 14, 0, 0, 3);
+}
+
+.trade-hero-card {
+    -fx-padding: 18 22 18 22;
+}
+
+.trade-support-band {
+    -fx-padding: 14 22 14 22;
+}
+
+.trade-hero-amount {
+    -fx-font-size: 1.769em;
+    -fx-font-family: "IBM Plex Sans Medium";
+    -fx-text-fill: -bs-text-color;
+}
+
+.trade-hero-fiat {
+    -fx-font-size: 1em;
+    -fx-text-fill: -bs-color-gray-6;
+}
+
+.trade-hero-chip {
+    -fx-background-color: -bs-combo-popup-hover;
+    -fx-background-radius: 999;
+    -fx-padding: 4 12 4 12;
+    -fx-font-size: 0.85em;
+    -fx-text-fill: -bs-rd-font-dark;
+}
+
+.trade-hero-chat-button {
+    -fx-background-color: linear-gradient(to bottom right, -hero-accent-strong, -hero-accent-faint);
+    -fx-background-radius: 22;
+    -fx-min-width: 44;
+    -fx-pref-width: 44;
+    -fx-max-width: 44;
+    -fx-min-height: 44;
+    -fx-pref-height: 44;
+    -fx-max-height: 44;
+    -fx-cursor: hand;
+}
+
+.trade-hero-chat-button:hover {
+    -fx-background-color: -hero-accent-strong;
+}
+
+.trade-hero-chat-icon {
+    -fx-fill: -hero-accent;
+}
+
+.trade-hero-remaining-title {
+    -fx-font-size: 0.85em;
+    -fx-text-fill: -bs-color-gray-6;
+}
+
+.trade-hero-remaining-value {
+    -fx-font-size: 0.9em;
+    -fx-text-fill: -bs-text-color;
+}
+
+.trade-hero-remaining-value.error-text {
+    -fx-text-fill: -bs-rd-error-red;
+}
+
+/* slim rounded countdown bar; thickness comes from the bar/track padding */
+.trade-hero-progress > .track {
+    -fx-background-color: -bs-progress-bar-track;
+    -fx-background-radius: 999;
+    -fx-background-insets: 0;
+    -fx-padding: 3;
+}
+
+.trade-hero-progress > .bar {
+    -fx-background-color: -bs-color-primary;
+    -fx-background-radius: 999;
+    -fx-background-insets: 0;
+    -fx-padding: 3;
+}
+
+.trade-hero-progress.error > .bar {
+    -fx-background-color: -bs-rd-error-red;
+}
+
+.trade-step-item {
+    -fx-background-radius: 999;
+    -fx-padding: 5 14 5 6;
+}
+
+.trade-step-item.active {
+    -fx-background-color: -hero-accent-faint;
+}
+
+.trade-step-circle {
+    -fx-background-color: -bs-color-gray-ccc;
+    -fx-background-radius: 999;
+    -fx-min-width: 26;
+    -fx-pref-width: 26;
+    -fx-max-width: 26;
+    -fx-min-height: 26;
+    -fx-pref-height: 26;
+    -fx-max-height: 26;
+}
+
+.trade-step-item.active .trade-step-circle,
+.trade-step-item.completed .trade-step-circle {
+    -fx-background-color: -bs-color-primary-dark;
+}
+
+.trade-step-number {
+    -fx-font-size: 0.85em;
+    -fx-font-family: "IBM Plex Sans Medium";
+    -fx-text-fill: white;
+}
+
+.trade-step-check {
+    -fx-fill: white;
+}
+
+.trade-step-title {
+    -fx-font-size: 0.9em;
     -fx-text-fill: -bs-rd-font-light;
 }
 
-#trade-wizard-item-background-active {
-    -fx-text-fill: -bs-text-color;
+.trade-step-item.active .trade-step-title {
     -fx-font-family: "IBM Plex Sans Medium";
+    -fx-text-fill: -bs-text-color;
 }
 
-.trade-step-label {
-    -fx-text-fill: -bs-background-color;
+.trade-step-item.completed .trade-step-title {
+    -fx-text-fill: -bs-text-color;
 }
 
-.trade-step-disabled-bg {
-    -fx-fill: -bs-color-gray-ccc;
+.trade-step-connector {
+    -fx-background-color: -bs-rd-separator;
+    -fx-background-radius: 999;
+    -fx-min-width: 12;
+    -fx-min-height: 2;
+    -fx-pref-height: 2;
+    -fx-max-height: 2;
 }
 
-.trade-step-active-bg {
-    -fx-fill: -bs-color-primary-dark;
+.trade-step-connector.completed {
+    -fx-background-color: -bs-color-primary-dark;
+}
+
+.trade-support-title {
+    -fx-font-size: 1em;
+    -fx-font-family: "IBM Plex Sans Medium";
+    -fx-text-fill: -bs-text-color;
 }
 
 .trade-msg-state-undefined {

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/BuyerSubView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/BuyerSubView.java
@@ -54,13 +54,7 @@ public class BuyerSubView extends TradeSubView {
         step3 = new TradeWizardItem(BuyerStep3View.class, Res.get("portfolio.pending.step3_buyer.waitPaymentArrived"), "3");
         step4 = new TradeWizardItem(BuyerStep4View.class, Res.get("portfolio.pending.step5.completed"), "4");
 
-        addWizardsToGridPane(step1);
-        addLineSeparatorToGridPane();
-        addWizardsToGridPane(step2);
-        addLineSeparatorToGridPane();
-        addWizardsToGridPane(step3);
-        addLineSeparatorToGridPane();
-        addWizardsToGridPane(step4);
+        addWizardItems(step1, step2, step3, step4);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/SellerSubView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/SellerSubView.java
@@ -54,13 +54,7 @@ public class SellerSubView extends TradeSubView {
         step3 = new TradeWizardItem(SellerStep3View.class, Res.get("portfolio.pending.step3_seller.confirmPaymentReceived"), "3");
         step4 = new TradeWizardItem(SellerStep4View.class, Res.get("portfolio.pending.step5.completed"), "4");
 
-        addWizardsToGridPane(step1);
-        addLineSeparatorToGridPane();
-        addWizardsToGridPane(step2);
-        addLineSeparatorToGridPane();
-        addWizardsToGridPane(step3);
-        addLineSeparatorToGridPane();
-        addWizardsToGridPane(step4);
+        addWizardItems(step1, step2, step3, step4);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/TradeStepInfo.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/TradeStepInfo.java
@@ -21,10 +21,9 @@ import haveno.core.locale.Res;
 import haveno.core.trade.Trade;
 import haveno.desktop.components.AutoTooltipButton;
 import haveno.desktop.components.SimpleMarkdownLabel;
-import haveno.desktop.components.TitledGroupBg;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
-import javafx.scene.layout.GridPane;
+import javafx.scene.control.Label;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -53,7 +52,7 @@ public class TradeStepInfo {
         TRADE_COMPLETED
     }
 
-    private final TitledGroupBg titledGroupBg;
+    private final Label titleLabel;
     private final SimpleMarkdownLabel label;
     private final SimpleMarkdownLabel footerLabel;
     private final AutoTooltipButton button;
@@ -66,23 +65,16 @@ public class TradeStepInfo {
     private Supplier<String> periodOverWarnTextSupplier = () -> "";
     private Supplier<String> depositTxMissingWarnTextSupplier = () -> "";
 
-    TradeStepInfo(TitledGroupBg titledGroupBg,
+    TradeStepInfo(Label titleLabel,
                   SimpleMarkdownLabel label,
                   AutoTooltipButton button,
                   SimpleMarkdownLabel footerLabel) {
-        this.titledGroupBg = titledGroupBg;
+        this.titleLabel = titleLabel;
         this.label = label;
         this.button = button;
         this.footerLabel = footerLabel;
-        GridPane.setColumnIndex(button, 0);
 
         setState(State.SHOW_GET_HELP_BUTTON);
-    }
-
-    void removeItselfFrom(GridPane leftGridPane) {
-        leftGridPane.getChildren().remove(titledGroupBg);
-        leftGridPane.getChildren().remove(label);
-        leftGridPane.getChildren().remove(button);
     }
 
     public void setOnAction(EventHandler<ActionEvent> e) {
@@ -108,7 +100,7 @@ public class TradeStepInfo {
                 break;
             case SHOW_GET_HELP_BUTTON:
                 // grey button
-                titledGroupBg.setText(Res.get("portfolio.pending.support.headline.getHelp"));
+                titleLabel.setText(Res.get("portfolio.pending.support.headline.getHelp"));
                 label.updateContent("");
                 button.setText(Res.get("portfolio.pending.support.button.getHelp").toUpperCase());
                 button.setId(null);
@@ -118,7 +110,7 @@ public class TradeStepInfo {
             case IN_ARBITRATION_SELF_REQUESTED:
                 // red button
                 String text = trade.getDisputeState().isOpen() ? Res.get("portfolio.pending.supportTicketOpened") : Res.get("portfolio.pending.arbitrationRequested");
-                titledGroupBg.setText(text);
+                titleLabel.setText(text);
                 label.updateContent(Res.get("portfolio.pending.disputeOpenedByUser", Res.get("portfolio.pending.communicateWithArbitrator")));
                 button.setText(text.toUpperCase());
                 button.setId("open-dispute-button");
@@ -128,7 +120,7 @@ public class TradeStepInfo {
             case IN_ARBITRATION_PEER_REQUESTED:
                 // red button
                 text = trade.getDisputeState().isOpen() ? Res.get("portfolio.pending.supportTicketOpened") : Res.get("portfolio.pending.arbitrationRequested");
-                titledGroupBg.setText(text);
+                titleLabel.setText(text);
                 label.updateContent(Res.get("portfolio.pending.disputeOpenedByPeer", Res.get("portfolio.pending.communicateWithArbitrator")));
                 button.setText(text.toUpperCase());
                 button.setId("open-dispute-button");
@@ -137,7 +129,7 @@ public class TradeStepInfo {
                 break;
             case MEDIATION_RESULT:
                 // green button
-                titledGroupBg.setText(Res.get("portfolio.pending.mediationResult.headline"));
+                titleLabel.setText(Res.get("portfolio.pending.mediationResult.headline"));
                 label.updateContent(Res.get("portfolio.pending.mediationResult.info.noneAccepted"));
                 button.setText(Res.get("portfolio.pending.mediationResult.button").toUpperCase());
                 button.setId(null);
@@ -146,7 +138,7 @@ public class TradeStepInfo {
                 break;
             case MEDIATION_RESULT_SELF_ACCEPTED:
                 // green button deactivated
-                titledGroupBg.setText(Res.get("portfolio.pending.mediationResult.headline"));
+                titleLabel.setText(Res.get("portfolio.pending.mediationResult.headline"));
                 label.updateContent(Res.get("portfolio.pending.mediationResult.info.selfAccepted"));
                 button.setText(Res.get("portfolio.pending.mediationResult.button").toUpperCase());
                 button.setId(null);
@@ -155,7 +147,7 @@ public class TradeStepInfo {
                 break;
             case MEDIATION_RESULT_PEER_ACCEPTED:
                 // green button
-                titledGroupBg.setText(Res.get("portfolio.pending.mediationResult.headline"));
+                titleLabel.setText(Res.get("portfolio.pending.mediationResult.headline"));
                 label.updateContent(Res.get("portfolio.pending.mediationResult.info.peerAccepted"));
                 button.setText(Res.get("portfolio.pending.mediationResult.button").toUpperCase());
                 button.setId(null);
@@ -164,7 +156,7 @@ public class TradeStepInfo {
                 break;
             case IN_REFUND_REQUEST_SELF_REQUESTED:
                 // red button
-                titledGroupBg.setText(Res.get("portfolio.pending.refundRequested"));
+                titleLabel.setText(Res.get("portfolio.pending.refundRequested"));
                 label.updateContent(Res.get("portfolio.pending.disputeOpenedByUser", Res.get("portfolio.pending.communicateWithArbitrator")));
                 button.setText(Res.get("portfolio.pending.refundRequested").toUpperCase());
                 button.setId("open-dispute-button");
@@ -173,7 +165,7 @@ public class TradeStepInfo {
                 break;
             case IN_REFUND_REQUEST_PEER_REQUESTED:
                 // red button
-                titledGroupBg.setText(Res.get("portfolio.pending.refundRequested"));
+                titleLabel.setText(Res.get("portfolio.pending.refundRequested"));
                 label.updateContent(Res.get("portfolio.pending.disputeOpenedByPeer", Res.get("portfolio.pending.communicateWithArbitrator")));
                 button.setText(Res.get("portfolio.pending.refundRequested").toUpperCase());
                 button.setId("open-dispute-button");
@@ -182,7 +174,7 @@ public class TradeStepInfo {
                 break;
             case WARN_HALF_PERIOD:
                 // orange button
-                titledGroupBg.setText(Res.get("portfolio.pending.support.headline.halfPeriodOver"));
+                titleLabel.setText(Res.get("portfolio.pending.support.headline.halfPeriodOver"));
                 label.updateContent(firstHalfOverWarnTextSupplier.get());
                 button.setText(Res.get("portfolio.pending.support.button.getHelp").toUpperCase());
                 button.setId(null);
@@ -191,7 +183,7 @@ public class TradeStepInfo {
                 break;
             case WARN_PERIOD_OVER:
                 // red button
-                titledGroupBg.setText(Res.get("portfolio.pending.support.headline.periodOver"));
+                titleLabel.setText(Res.get("portfolio.pending.support.headline.periodOver"));
                 label.updateContent(periodOverWarnTextSupplier.get());
                 button.setText(Res.get("portfolio.pending.openSupport").toUpperCase());
                 button.setId("open-dispute-button");
@@ -200,7 +192,7 @@ public class TradeStepInfo {
                 break;
             case DEPOSIT_MISSING:
                 // red button
-                titledGroupBg.setText(Res.get("portfolio.pending.support.headline.depositTxMissing"));
+                titleLabel.setText(Res.get("portfolio.pending.support.headline.depositTxMissing"));
                 label.updateContent(depositTxMissingWarnTextSupplier.get());
                 button.setText(Res.get("portfolio.pending.openSupport").toUpperCase());
                 button.setId("open-dispute-button");
@@ -209,8 +201,8 @@ public class TradeStepInfo {
                 break;
             case TRADE_COMPLETED:
                 // hide group and release its space so it doesn't stretch the step view
-                titledGroupBg.setVisible(false);
-                titledGroupBg.setManaged(false);
+                titleLabel.setVisible(false);
+                titleLabel.setManaged(false);
                 label.setVisible(false);
                 label.setManaged(false);
                 button.setVisible(false);

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/TradeSubView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/TradeSubView.java
@@ -17,40 +17,52 @@
 
 package haveno.desktop.main.portfolio.pendingtrades;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
+import haveno.common.ClockWatcher;
+import haveno.common.UserThread;
+import haveno.core.locale.CurrencyUtil;
 import haveno.core.locale.Res;
 import haveno.core.trade.Trade;
+import haveno.core.trade.TradeUtil;
+import haveno.core.util.FormattingUtils;
 import haveno.desktop.components.AutoTooltipButton;
 import haveno.desktop.components.SimpleMarkdownLabel;
-import haveno.desktop.components.TitledGroupBg;
 import haveno.desktop.main.portfolio.pendingtrades.steps.TradeStepView;
 import haveno.desktop.main.portfolio.pendingtrades.steps.TradeWizardItem;
-import haveno.desktop.util.Layout;
-import javafx.geometry.HPos;
-import javafx.geometry.Insets;
-import javafx.geometry.Orientation;
-import javafx.scene.control.Separator;
+import haveno.desktop.util.Accessibility;
+import haveno.desktop.util.FormBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.GridPane;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
 import lombok.extern.slf4j.Slf4j;
+import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.Subscription;
 
-import static haveno.desktop.util.FormBuilder.addButtonAfterGroup;
-import static haveno.desktop.util.FormBuilder.addSimpleMarkdownLabel;
-import static haveno.desktop.util.FormBuilder.addTitledGroupBg;
-
 @Slf4j
-public abstract class TradeSubView extends HBox {
+public abstract class TradeSubView extends VBox {
     protected final PendingTradesViewModel model;
-    protected VBox leftVBox;
+    protected final Trade trade;
+    protected TradeStepInfo tradeStepInfo;
+    private final List<TradeWizardItem> wizardItems = new ArrayList<>();
     private AnchorPane contentPane;
     private TradeStepView tradeStepView;
-    protected TradeStepInfo tradeStepInfo;
-    private GridPane leftGridPane;
-    private TitledGroupBg tradeProcessTitledGroupBg;
-    private int leftGridPaneRowIndex = 0;
+    private HBox timelineBox;
+    private HBox countdownRow;
+    private Label remainingTimeLabel;
+    private ProgressBar timeLeftProgressBar;
+    private final ClockWatcher.Listener clockListener;
+    private Subscription tradeStateSubscription;
     Subscription viewStateSubscription;
     private PendingTradesView.ChatCallback chatCallback;
     private Runnable closeCallback;
@@ -62,50 +74,150 @@ public abstract class TradeSubView extends HBox {
 
     public TradeSubView(PendingTradesViewModel model) {
         this.model = model;
-        HBox.setHgrow(this, Priority.ALWAYS);
-        setSpacing(Layout.PADDING_WINDOW);
+        this.trade = checkNotNull(model.dataModel.getTrade(), "Trade must not be null at TradeSubView");
+        setSpacing(10);
         buildViews();
+
+        clockListener = new ClockWatcher.Listener() {
+            @Override
+            public void onSecondTick() {
+            }
+
+            @Override
+            public void onMinuteTick() {
+                updateTimeLeft();
+            }
+        };
     }
 
     protected void activate() {
+        model.clockWatcher.addListener(clockListener);
+        tradeStateSubscription = EasyBind.subscribe(trade.stateProperty(), state -> UserThread.execute(this::updateTimeLeft));
     }
 
     protected void deactivate() {
         if (viewStateSubscription != null)
             viewStateSubscription.unsubscribe();
 
+        if (tradeStateSubscription != null)
+            tradeStateSubscription.unsubscribe();
+
+        model.clockWatcher.removeListener(clockListener);
+
         if (tradeStepView != null)
             tradeStepView.deactivate();
-
-        if (tradeStepInfo != null)
-            tradeStepInfo.removeItselfFrom(leftGridPane);
     }
 
     private void buildViews() {
-        addLeftBox();
-        addContentPane();
-
-        leftGridPane = new GridPane();
-        leftGridPane.setPrefWidth(340);
-        leftGridPane.setHgap(Layout.GRID_GAP);
-        leftGridPane.setVgap(Layout.GRID_GAP);
-        VBox.setMargin(leftGridPane, new Insets(0, 10, 10, 10));
-        leftVBox.getChildren().add(leftGridPane);
-
-        leftGridPaneRowIndex = 0;
-        tradeProcessTitledGroupBg = addTitledGroupBg(leftGridPane, leftGridPaneRowIndex, 1, Res.get("portfolio.pending.tradeProcess"));
-        tradeProcessTitledGroupBg.getStyleClass().add("last");
-
         addWizards();
+        getChildren().addAll(createHeroCard(), createSupportBand(), createContentPane());
+        updateTimeLeft();
+    }
 
-        TitledGroupBg titledGroupBg = addTitledGroupBg(leftGridPane, ++leftGridPaneRowIndex, 1, "", 10);
-        titledGroupBg.getStyleClass().add("last");
+    // summary card: amount, chips, step timeline and trade period countdown
+    private VBox createHeroCard() {
+        Label amountLabel = new Label(model.getTradeVolume());
+        amountLabel.getStyleClass().add("trade-hero-amount");
+        String fiatVolume = model.getFiatVolume();
+        String priceLine = FormattingUtils.formatPrice(trade.getPrice()) + " "
+                + CurrencyUtil.getCurrencyPair(checkNotNull(trade.getOffer()).getCounterCurrencyCode());
+        Label fiatLabel = new Label(fiatVolume.isEmpty() ? priceLine : fiatVolume + "  ·  " + priceLine);
+        fiatLabel.getStyleClass().add("trade-hero-fiat");
+        VBox amountBox = new VBox(2, amountLabel, fiatLabel);
 
-        SimpleMarkdownLabel label = addSimpleMarkdownLabel(leftGridPane, ++leftGridPaneRowIndex);
-        AutoTooltipButton button = (AutoTooltipButton) addButtonAfterGroup(leftGridPane, ++leftGridPaneRowIndex, "");
-        SimpleMarkdownLabel footerLabel = addSimpleMarkdownLabel(leftGridPane, ++leftGridPaneRowIndex, Res.get("portfolio.pending.stillNotResolved"), 10);
+        Text chatIcon = FormBuilder.getIcon(MaterialDesignIcon.COMMENT_MULTIPLE_OUTLINE, "1.4em");
+        chatIcon.getStyleClass().add("trade-hero-chat-icon");
+        AutoTooltipButton chatButton = new AutoTooltipButton("", chatIcon);
+        chatButton.getStyleClass().add("trade-hero-chat-button");
+        chatButton.setTooltip(new Tooltip(Res.get("tradeChat.openChat")));
+        Accessibility.nameFromTooltip(chatButton);
+        chatButton.setOnAction(e -> {
+            if (chatCallback != null)
+                chatCallback.onOpenChat(trade);
+        });
+
+        Region topSpacer = new Region();
+        HBox.setHgrow(topSpacer, Priority.ALWAYS);
+        HBox topRow = new HBox(16, amountBox, topSpacer, chatButton);
+        topRow.setAlignment(Pos.CENTER_LEFT);
+
+        FlowPane chipsRow = new FlowPane(8, 6,
+                createChip(TradeUtil.getRole(trade)),
+                createChip(trade.getOffer().getPaymentMethodNameWithCountryCode()),
+                createChip(Res.get("shared.tradeId") + ": " + trade.getShortId()));
+
+        Region separator = new Region();
+        separator.getStyleClass().add("hero-separator");
+
+        Label remainingTitleLabel = new Label(Res.get("portfolio.pending.remainingTime"));
+        remainingTitleLabel.getStyleClass().add("trade-hero-remaining-title");
+        remainingTimeLabel = new Label();
+        remainingTimeLabel.getStyleClass().add("trade-hero-remaining-value");
+        Region countdownSpacer = new Region();
+        HBox.setHgrow(countdownSpacer, Priority.ALWAYS);
+        countdownRow = new HBox(16, remainingTitleLabel, countdownSpacer, remainingTimeLabel);
+        countdownRow.setAlignment(Pos.CENTER_LEFT);
+
+        timeLeftProgressBar = new ProgressBar(0);
+        timeLeftProgressBar.getStyleClass().add("trade-hero-progress");
+        timeLeftProgressBar.setMaxWidth(Double.MAX_VALUE);
+
+        VBox heroCard = new VBox(14, topRow, chipsRow, separator, timelineBox, countdownRow, timeLeftProgressBar);
+        heroCard.getStyleClass().addAll("trade-hero-card", "hero-accent-primary");
+        return heroCard;
+    }
+
+    private Label createChip(String text) {
+        Label chip = new Label(text);
+        chip.getStyleClass().add("trade-hero-chip");
+        return chip;
+    }
+
+    // help/dispute band; state and texts are driven by TradeStepInfo and the active step view
+    private HBox createSupportBand() {
+        Label titleLabel = new Label();
+        titleLabel.getStyleClass().add("trade-support-title");
+        SimpleMarkdownLabel messageLabel = new SimpleMarkdownLabel(null);
+        SimpleMarkdownLabel footerLabel = new SimpleMarkdownLabel(Res.get("portfolio.pending.stillNotResolved"));
         footerLabel.getStyleClass().add("medium-text");
-        tradeStepInfo = new TradeStepInfo(titledGroupBg, label, button, footerLabel);
+        AutoTooltipButton button = new AutoTooltipButton("");
+
+        VBox textBox = new VBox(4, titleLabel, messageLabel, footerLabel);
+        HBox.setHgrow(textBox, Priority.ALWAYS);
+        HBox band = new HBox(16, textBox, button);
+        band.setAlignment(Pos.CENTER_LEFT);
+        band.getStyleClass().add("trade-support-band");
+        band.visibleProperty().bind(titleLabel.visibleProperty());
+        band.managedProperty().bind(titleLabel.visibleProperty());
+
+        tradeStepInfo = new TradeStepInfo(titleLabel, messageLabel, button, footerLabel);
+        return band;
+    }
+
+    private AnchorPane createContentPane() {
+        contentPane = new AnchorPane();
+        return contentPane;
+    }
+
+    void addWizardItems(TradeWizardItem... items) {
+        timelineBox = new HBox(8);
+        timelineBox.getStyleClass().add("trade-timeline");
+        timelineBox.setAlignment(Pos.CENTER);
+        for (TradeWizardItem item : items) {
+            if (!wizardItems.isEmpty()) {
+                Region connector = new Region();
+                connector.getStyleClass().add("trade-step-connector");
+                HBox.setHgrow(connector, Priority.ALWAYS);
+                wizardItems.get(wizardItems.size() - 1).stateProperty().addListener((observable, oldState, newState) -> {
+                    connector.getStyleClass().remove("completed");
+                    if (newState == TradeWizardItem.State.COMPLETED)
+                        connector.getStyleClass().add("completed");
+                });
+                timelineBox.getChildren().add(connector);
+            }
+            wizardItems.add(item);
+            timelineBox.getChildren().add(item);
+        }
     }
 
     void showItem(TradeWizardItem item) {
@@ -119,23 +231,37 @@ public abstract class TradeSubView extends HBox {
         tradeStepInfo.setTrade(model.getTrade());
     }
 
-    void addWizardsToGridPane(TradeWizardItem tradeWizardItem) {
-        if (leftGridPaneRowIndex == 0)
-            GridPane.setMargin(tradeWizardItem, new Insets(Layout.FIRST_ROW_DISTANCE + Layout.FLOATING_LABEL_DISTANCE, 0, 0, 0));
+    private void updateTimeLeft() {
+        if (model.dataModel.getTrade() == null || !trade.isInitialized()) return;
 
-        GridPane.setRowIndex(tradeWizardItem, leftGridPaneRowIndex++);
-        leftGridPane.getChildren().add(tradeWizardItem);
-        GridPane.setRowSpan(tradeProcessTitledGroupBg, leftGridPaneRowIndex);
-        GridPane.setFillWidth(tradeWizardItem, true);
+        // completed trades no longer have a running trade period
+        boolean showCountdown = !trade.isPayoutPublished();
+        countdownRow.setVisible(showCountdown);
+        countdownRow.setManaged(showCountdown);
+        timeLeftProgressBar.setVisible(showCountdown);
+        timeLeftProgressBar.setManaged(showCountdown);
+        if (!showCountdown) return;
+
+        String remainingTime = model.getRemainingTradeDurationAsWords();
+        timeLeftProgressBar.setProgress(model.getRemainingTradeDurationAsPercentage());
+        if (!remainingTime.isEmpty()) {
+            remainingTimeLabel.setText(trade.isDepositsFinalized() ?
+                    Res.get("portfolio.pending.remainingTimeDetail", remainingTime, model.getDateForOpenDispute()) :
+                    Res.get("portfolio.pending.remainingTimeDetail.startsAfter", Trade.NUM_BLOCKS_DEPOSITS_FINALIZED));
+            setCountdownError(model.showWarning() || model.showDispute());
+        } else {
+            remainingTimeLabel.setText(Res.get("portfolio.pending.tradeNotCompleted", model.getDateForOpenDispute()));
+            setCountdownError(true);
+        }
     }
 
-    void addLineSeparatorToGridPane() {
-        final Separator separator = new Separator(Orientation.VERTICAL);
-        separator.setMinHeight(10);
-        GridPane.setMargin(separator, new Insets(0, 0, 0, 13));
-        GridPane.setHalignment(separator, HPos.LEFT);
-        GridPane.setRowIndex(separator, leftGridPaneRowIndex++);
-        leftGridPane.getChildren().add(separator);
+    private void setCountdownError(boolean error) {
+        remainingTimeLabel.getStyleClass().remove("error-text");
+        timeLeftProgressBar.getStyleClass().remove("error");
+        if (error) {
+            remainingTimeLabel.getStyleClass().add("error-text");
+            timeLeftProgressBar.getStyleClass().add("error");
+        }
     }
 
     private void createAndAddTradeStepView(Class<? extends TradeStepView> viewClass) {
@@ -161,19 +287,6 @@ public abstract class TradeSubView extends HBox {
         }
     }
 
-    private void addLeftBox() {
-        leftVBox = new VBox();
-        leftVBox.setSpacing(Layout.SPACING_V_BOX);
-        leftVBox.setMinWidth(290);
-        getChildren().add(leftVBox);
-    }
-
-    private void addContentPane() {
-        contentPane = new AnchorPane();
-        HBox.setHgrow(contentPane, Priority.SOMETIMES);
-        getChildren().add(contentPane);
-    }
-
 
     public interface ChatCallback {
         void onOpenChat(Trade trade);
@@ -187,5 +300,3 @@ public abstract class TradeSubView extends HBox {
         this.closeCallback = closeCallback;
     }
 }
-
-

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -20,7 +20,6 @@ package haveno.desktop.main.portfolio.pendingtrades.steps;
 import static com.google.common.base.Preconditions.checkNotNull;
 import haveno.desktop.util.GlyphsDude;
 import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import haveno.common.ClockWatcher;
 import haveno.common.UserThread;
 import haveno.common.util.Tuple3;
 import haveno.core.locale.CurrencyUtil;
@@ -44,7 +43,6 @@ import haveno.desktop.main.overlays.popups.Popup;
 import haveno.desktop.main.portfolio.pendingtrades.PendingTradesViewModel;
 import haveno.desktop.main.portfolio.pendingtrades.TradeStepInfo;
 import haveno.desktop.main.portfolio.pendingtrades.TradeSubView;
-import static haveno.desktop.util.FormBuilder.addCompactTopLabelTextField;
 import static haveno.desktop.util.FormBuilder.addMultilineLabel;
 import static haveno.desktop.util.FormBuilder.addTitledGroupBg;
 import static haveno.desktop.util.FormBuilder.addTopLabelTxIdTextField;
@@ -52,14 +50,11 @@ import static haveno.desktop.util.FormBuilder.addTopLabelTxIdTextField;
 import haveno.desktop.util.Layout;
 import haveno.network.p2p.BootstrapListener;
 import java.util.Optional;
-import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Insets;
 import javafx.scene.control.Label;
-import javafx.scene.control.ProgressBar;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.control.TextField;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
@@ -81,14 +76,11 @@ public abstract class TradeStepView extends AnchorPane {
 
     private Subscription tradePeriodStateSubscription, tradeStateSubscription, disputeStateSubscription, mediationResultStateSubscription, syncUpdateSubscription;
     protected int gridRow = 0;
-    private TextField timeLeftTextField;
-    private ProgressBar timeLeftProgressBar;
     private TxIdTextField selfTxIdTextField;
     private TxIdTextField peerTxIdTextField;
     private TradeStepInfo tradeStepInfo;
     private Subscription selfTxIdSubscription;
     private Subscription peerTxIdSubscription;
-    private ClockWatcher.Listener clockListener;
     private final ChangeListener<String> errorMessageListener;
     protected Label infoLabel;
     private Popup acceptMediationResultPopup;
@@ -120,7 +112,7 @@ public abstract class TradeStepView extends AnchorPane {
 
         AnchorPane.setLeftAnchor(scrollPane, 0d);
         AnchorPane.setRightAnchor(scrollPane, 0d);
-        AnchorPane.setTopAnchor(scrollPane, 10d);
+        AnchorPane.setTopAnchor(scrollPane, 0d);
         AnchorPane.setBottomAnchor(scrollPane, 0d);
 
         getChildren().add(scrollPane);
@@ -143,7 +135,7 @@ public abstract class TradeStepView extends AnchorPane {
 
         AnchorPane.setLeftAnchor(this, 0d);
         AnchorPane.setRightAnchor(this, 0d);
-        AnchorPane.setTopAnchor(this, -10d);
+        AnchorPane.setTopAnchor(this, 0d);
         AnchorPane.setBottomAnchor(this, 0d);
 
         addContent();
@@ -152,17 +144,6 @@ public abstract class TradeStepView extends AnchorPane {
             if (newValue != null) {
                 log.warn("Showing popup for trade error {} {}", trade.getClass().getSimpleName(), trade.getId(), new RuntimeException(newValue));
                 new Popup().error(newValue).show();
-            }
-        };
-
-        clockListener = new ClockWatcher.Listener() {
-            @Override
-            public void onSecondTick() {
-            }
-
-            @Override
-            public void onMinuteTick() {
-                updateTimeLeft();
             }
         };
     }
@@ -222,8 +203,6 @@ public abstract class TradeStepView extends AnchorPane {
                 UserThread.execute(() -> updateTradePeriodState(newValue));
             }
         });
-
-        model.clockWatcher.addListener(clockListener);
 
         if (infoLabel != null) {
             infoLabel.setText(getInfoText());
@@ -353,9 +332,6 @@ public abstract class TradeStepView extends AnchorPane {
         if (tradeStateSubscription != null)
             tradeStateSubscription.unsubscribe();
 
-        if (clockListener != null)
-            model.clockWatcher.removeListener(clockListener);
-
         if (tradeStepInfo != null)
             tradeStepInfo.setOnAction(null);
 
@@ -434,25 +410,6 @@ public abstract class TradeStepView extends AnchorPane {
                     model.dataModel.getTrade().getOffer());
             infoTextField.setContentForInfoPopOver(createInfoPopover());
         }
-
-        final Tuple3<Label, TextField, VBox> labelTextFieldVBoxTuple3 = addCompactTopLabelTextField(gridPane, gridRow,
-                1, Res.get("portfolio.pending.remainingTime"), "");
-
-        timeLeftTextField = labelTextFieldVBoxTuple3.second;
-        timeLeftTextField.setMinWidth(400);
-
-        timeLeftProgressBar = new ProgressBar(0);
-        timeLeftProgressBar.setOpacity(0.7);
-        timeLeftProgressBar.setMinHeight(9);
-        timeLeftProgressBar.setMaxHeight(9);
-        timeLeftProgressBar.setMaxWidth(Double.MAX_VALUE);
-
-        GridPane.setRowIndex(timeLeftProgressBar, ++gridRow);
-        GridPane.setColumnSpan(timeLeftProgressBar, 2);
-        GridPane.setFillWidth(timeLeftProgressBar, true);
-        gridPane.getChildren().add(timeLeftProgressBar);
-
-        updateTimeLeft();
     }
 
     protected void addInfoBlock() {
@@ -474,39 +431,6 @@ public abstract class TradeStepView extends AnchorPane {
 
     protected String getInfoBlockTitle() {
         return "";
-    }
-
-    private void updateTimeLeft() {
-        if (!trade.isInitialized()) return;
-        if (timeLeftTextField != null) {
-
-            // TODO (woodser): extra TradeStepView created but not deactivated on trade.setState(), so deactivate when model's trade is null
-            if (model.dataModel.getTrade() == null) {
-                log.warn("deactivating TradeStepView because model's trade is null");
-
-                // schedule deactivation to avoid concurrent modification of clock listeners
-                Platform.runLater(() -> deactivate());
-                return;
-            }
-
-            String remainingTime = model.getRemainingTradeDurationAsWords();
-            timeLeftProgressBar.setProgress(model.getRemainingTradeDurationAsPercentage());
-            if (!remainingTime.isEmpty()) {
-                boolean isDepositsFinalized = trade.isDepositsFinalized();
-                timeLeftTextField.setText(isDepositsFinalized ?
-                        Res.get("portfolio.pending.remainingTimeDetail", remainingTime, model.getDateForOpenDispute()) :
-                        Res.get("portfolio.pending.remainingTimeDetail.startsAfter", Trade.NUM_BLOCKS_DEPOSITS_FINALIZED));
-                if (model.showWarning() || model.showDispute()) {
-                    timeLeftTextField.getStyleClass().add("error-text");
-                    timeLeftProgressBar.getStyleClass().add("error");
-                }
-            } else {
-                timeLeftTextField.setText(Res.get("portfolio.pending.tradeNotCompleted",
-                        model.getDateForOpenDispute()));
-                timeLeftTextField.getStyleClass().add("error-text");
-                timeLeftProgressBar.getStyleClass().add("error");
-            }
-        }
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -862,7 +786,6 @@ public abstract class TradeStepView extends AnchorPane {
     }
 
     private void updateTradeState(Trade.State tradeState) {
-        updateTimeLeft();
         if (!trade.getDisputeState().isOpen() && trade.isMissingUnlockedDepositTx()) {
             tradeStepInfo.setState(TradeStepInfo.State.DEPOSIT_MISSING);
         }

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/TradeWizardItem.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/TradeWizardItem.java
@@ -19,61 +19,84 @@ package haveno.desktop.main.portfolio.pendingtrades.steps;
 
 import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
 import haveno.common.UserThread;
+import haveno.desktop.util.FormBuilder;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
-import org.jetbrains.annotations.NotNull;
 
-import static haveno.desktop.util.FormBuilder.getBigIcon;
+// one step of the horizontal trade timeline: numbered circle plus title, check mark when completed
+public class TradeWizardItem extends HBox {
 
-public class TradeWizardItem extends Label {
-    private final String iconLabel;
+    public enum State {
+        DISABLED,
+        ACTIVE,
+        COMPLETED
+    }
+
+    private final Class<? extends TradeStepView> viewClass;
+    private final ObjectProperty<State> state = new SimpleObjectProperty<>(State.DISABLED);
+    private final StackPane circle;
+    private final Label numberLabel;
+    private final Label titleLabel;
+
+    public TradeWizardItem(Class<? extends TradeStepView> viewClass, String title, String iconLabel) {
+        this.viewClass = viewClass;
+
+        numberLabel = new Label(iconLabel);
+        numberLabel.getStyleClass().add("trade-step-number");
+        circle = new StackPane(numberLabel);
+        circle.getStyleClass().add("trade-step-circle");
+
+        titleLabel = new Label(title);
+        titleLabel.getStyleClass().add("trade-step-title");
+        titleLabel.setWrapText(true);
+        titleLabel.setMaxWidth(170);
+
+        getStyleClass().add("trade-step-item");
+        setAlignment(Pos.CENTER_LEFT);
+        setSpacing(10);
+        setMouseTransparent(true);
+        getChildren().addAll(circle, titleLabel);
+    }
 
     public Class<? extends TradeStepView> getViewClass() {
         return viewClass;
     }
 
-    private final Class<? extends TradeStepView> viewClass;
-
-    public TradeWizardItem(Class<? extends TradeStepView> viewClass, String title, String iconLabel) {
-        this.viewClass = viewClass;
-        this.iconLabel = iconLabel;
-
-        setMouseTransparent(true);
-        setText(title);
-//        setPrefHeight(40);
-        setPrefWidth(360);
-        setAlignment(Pos.CENTER_LEFT);
-        setDisabled();
+    public ReadOnlyObjectProperty<State> stateProperty() {
+        return state;
     }
 
     public void setDisabled() {
-        setId("trade-wizard-item-background-disabled");
-        UserThread.execute(() -> setGraphic(getStackPane("trade-step-disabled-bg")));
+        UserThread.execute(() -> applyState(State.DISABLED));
     }
 
-
     public void setActive() {
-        setId("trade-wizard-item-background-active");
-        UserThread.execute(() -> setGraphic(getStackPane("trade-step-active-bg")));
+        UserThread.execute(() -> applyState(State.ACTIVE));
     }
 
     public void setCompleted() {
-        setId("trade-wizard-item-background-active");
-        final Text icon = getBigIcon(MaterialDesignIcon.CHECK_CIRCLE);
-        icon.getStyleClass().add("trade-step-active-bg");
-        UserThread.execute(() -> setGraphic(icon));
+        UserThread.execute(() -> applyState(State.COMPLETED));
     }
 
-    @NotNull
-    private StackPane getStackPane(String styleClass) {
-        StackPane stackPane = new StackPane();
-        final Label label = new Label(iconLabel);
-        label.getStyleClass().add("trade-step-label");
-        final Text icon = getBigIcon(MaterialDesignIcon.CIRCLE);
-        icon.getStyleClass().add(styleClass);
-        stackPane.getChildren().addAll(icon, label);
-        return stackPane;
+    private void applyState(State newState) {
+        getStyleClass().removeAll("active", "completed");
+        if (newState == State.ACTIVE) {
+            getStyleClass().add("active");
+            circle.getChildren().setAll(numberLabel);
+        } else if (newState == State.COMPLETED) {
+            getStyleClass().add("completed");
+            Text checkIcon = FormBuilder.getIcon(MaterialDesignIcon.CHECK, "1em");
+            checkIcon.getStyleClass().add("trade-step-check");
+            circle.getChildren().setAll(checkIcon);
+        } else {
+            circle.getChildren().setAll(numberLabel);
+        }
+        state.set(newState);
     }
 }


### PR DESCRIPTION
Replace the left wizard rail with a trade summary card (amount, chips, chat, countdown), a horizontal step timeline, and a support band.