### PR TITLE
core: harden direct trade wallet sync

### DIFF
--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -187,6 +187,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
     public BooleanProperty wasWalletPolledProperty = new SimpleBooleanProperty(false);
     public BooleanProperty wasWalletSyncedAndPolledProperty = new SimpleBooleanProperty(false);
     private static final long MISSING_TXS_DELAY_MS = Config.baseCurrencyNetwork().isTestnet() ? 5000 : 30000;
+    private static final long DIRECT_SYNC_TIMEOUT_MS = 60000; // direct sync only refreshes after catching up, so fail fast
     private Long firstDepositTxMissingHeight; // height when we first saw missing deposit txs (to wait for a confirmation before reverting state)
     private Long firstPayoutTxMissingHeight; // height when we first saw missing payout tx (to wait for a confirmation before reverting state)
     private int payoutTxScanAttempts; // attempts to scan a confirmed payout tx missing from the trade wallet
@@ -3736,9 +3737,9 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
             // sync from new wallet height
             walletHeight.set(wallet.getHeight()); // import detaches the blockchain to the last export point
             if (isWalletBehind()) {
-                doSyncWithProgress(logInfoLevel, initialSyncTimeoutMs);
+                doSyncWithProgress(logInfoLevel, initialSyncTimeoutMs); // catch-up reprocesses blocks with the imported info; rescanning spent and pool queries cover the rest
             } else {
-                sync(); // TODO: must sync wallet after import, syncWithProgress() should still refresh even if not behind?
+                sync(); // refresh directly since there are no blocks to reprocess
             }
 
             // rescan spent outputs to update spent status of imported outputs
@@ -3792,9 +3793,14 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
     public MoneroSyncResult sync() {
         synchronized (walletLock) {
             if (!isDepositRequested()) throw new IllegalStateException("Cannot sync trade wallet because deposit txs are not requested for " + getClass().getSimpleName() + ", " + getId());
+
+            // catch up with progress-based sync first, whose timeout extends while progressing, unlike the direct sync's fixed timeout
+            walletHeight.set(wallet.getHeight());
+            if (isWalletBehind()) doSyncWithProgress(true, null);
+
             log.info("Syncing wallet directly for {} {}", getClass().getSimpleName(), getShortId());
             long startTime = System.currentTimeMillis();
-            MoneroSyncResult result = super.sync();
+            MoneroSyncResult result = super.syncWithTimeout(DIRECT_SYNC_TIMEOUT_MS); // shorter timeout to fail fast, since only refreshing after catch-up
             log.info("Done syncing wallet directly for {} {} in {} ms", getClass().getSimpleName(), getShortId(), System.currentTimeMillis() - startTime);
             return result;
         }

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletBase.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletBase.java
@@ -71,6 +71,8 @@ public abstract class XmrWalletBase {
     private Long lastWalletRestartTimestamp;
     protected TaskLooper syncProgressLooper;
     protected CountDownLatch syncProgressLatch;
+    private volatile CountDownLatch backgroundRefreshLatch; // released when the native background sync returns, which can outlive the latch release at target height
+    private volatile MoneroWallet backgroundRefreshWallet; // wallet the background refresh belongs to, to skip stale waits after the wallet is replaced
     protected Exception syncProgressError;
     protected Timer syncProgressTimeout;
     protected long syncProgressTargetHeight;
@@ -97,6 +99,7 @@ public abstract class XmrWalletBase {
 
     public MoneroSyncResult syncWithTimeout(Long syncTimeoutMs) {
         synchronized (walletLock) {
+            awaitBackgroundRefresh(); // otherwise this sync serializes behind it and its work counts against the timeout
             ReentrantLock daemonLock = HavenoUtils.acquireDaemonLock();
             try {
                 ExecutorService executor = Executors.newSingleThreadExecutor();
@@ -139,6 +142,21 @@ public abstract class XmrWalletBase {
         }
     }
 
+    // wait for a released native background sync to finish refreshing, e.g. processing the tx pool
+    private void awaitBackgroundRefresh() {
+        CountDownLatch latch = backgroundRefreshLatch;
+        if (latch == null || latch.getCount() == 0 || backgroundRefreshWallet != wallet) return; // a stale refresh belongs to a replaced wallet
+        log.info("Waiting for background sync to finish before syncing");
+        long startTime = System.currentTimeMillis();
+        try {
+            if (!latch.await(SYNC_TIMEOUT_MS, TimeUnit.MILLISECONDS)) log.warn("Timed out waiting for background sync to finish before syncing");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for background sync to finish", e); // abort instead of starting a sync which can race wallet closure
+        }
+        log.info("Done waiting for background sync in {} ms", System.currentTimeMillis() - startTime);
+    }
+
     protected void setUnknownSyncProgress() {
         UserThread.execute(() -> syncProgressListener.progress(0, -1));
     }
@@ -153,6 +171,10 @@ public abstract class XmrWalletBase {
 
     public void syncWithProgress(Long initialSyncTimeoutMs) {
         synchronized (syncWithProgressLock) {
+
+            // drain a released background refresh so this sync does not serialize behind it, snapshotting the wallet afterwards in case it was replaced while waiting
+            awaitBackgroundRefresh();
+
             MoneroWallet sourceWallet = wallet;
             try {
 
@@ -190,6 +212,9 @@ public abstract class XmrWalletBase {
 
                     // sync in background thread so waiting can time out like rpc wallets
                     CountDownLatch latch = syncProgressLatch;
+                    CountDownLatch refreshLatch = new CountDownLatch(1);
+                    backgroundRefreshWallet = sourceWallet;
+                    backgroundRefreshLatch = refreshLatch;
                     TaskLooper saveProgressLooper = startSaveOnScanProgressLooper(); // saves interleave at native sync chunk boundaries
                     ThreadUtils.submitToPool(() -> {
                         try {
@@ -205,6 +230,7 @@ public abstract class XmrWalletBase {
                             if (latch.getCount() > 0 && syncProgressLatch == latch && syncProgressError == null && !isShutDownStarted) syncProgressError = e; // errors after release are moot
                         } finally {
                             saveProgressLooper.stop();
+                            refreshLatch.countDown();
                             latch.countDown();
                         }
                     });


### PR DESCRIPTION
Catch up with progress-extended sync when behind, shorten the direct sync's refresh-only timeout, and drain a released background sync first.