### PR TITLE
core: freeze split outputs until spent by offer reserve tx

### DIFF
--- a/core/src/main/java/haveno/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/haveno/core/offer/OpenOfferManager.java
@@ -67,6 +67,7 @@ import haveno.core.offer.messages.SignOfferResponse;
 import haveno.core.offer.placeoffer.PlaceOfferModel;
 import haveno.core.offer.placeoffer.PlaceOfferProtocol;
 import haveno.core.offer.placeoffer.tasks.ValidateOffer;
+import haveno.core.provider.price.MarketPrice;
 import haveno.core.provider.price.PriceFeedService;
 import haveno.core.support.dispute.arbitration.arbitrator.Arbitrator;
 import haveno.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
@@ -110,6 +111,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -165,7 +167,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     private final FilterManager filterManager;
     private final Broadcaster broadcaster;
     private final PersistenceManager<TradableList<OpenOffer>> persistenceManager;
-    private final Map<String, OpenOffer> offersToBeEdited = new HashMap<>();
+    private final Map<String, OpenOffer> offersToBeEdited = new ConcurrentHashMap<>();
     private final TradableList<OpenOffer> openOffers = new TradableList<>();
     private final SignedOfferList signedOffers = new SignedOfferList();
     private final PersistenceManager<SignedOfferList> signedOfferPersistenceManager;
@@ -355,7 +357,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
             openOffersList = new ArrayList<>(openOffers);
         }
 
-        openOffersList.forEach(openOffer -> removeOpenOfferAux(openOffer, true, () -> {
+        openOffersList.forEach(openOffer -> removeOpenOfferAux(openOffer, OnReserved.SKIP, () -> {
                 }, errorMessage -> {
                     log.warn("Error removing open offer: " + errorMessage);
                 }));
@@ -606,6 +608,11 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         removeOffer(openOffer.getOffer(), resultHandler, errorMessageHandler);
     }
 
+    // cancel and remove the offer even if reserved for a trade, e.g. removing the offer after its trade fails
+    public void forceRemoveOpenOffer(OpenOffer openOffer) {
+        removeOpenOfferAux(openOffer, OnReserved.CANCEL, null, null);
+    }
+
     public void removeOffer(Offer offer, ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
         Optional<OpenOffer> openOfferOptional = getOpenOffer(offer.getId());
         if (openOfferOptional.isPresent()) {
@@ -618,53 +625,70 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         }
     }
 
+    // cancellation behavior when the offer is reserved for a trade in process
+    private enum OnReserved { REJECT, SKIP, CANCEL }
+
     private void removeOpenOfferAux(OpenOffer openOffer,
                                 ResultHandler resultHandler,
                                 ErrorMessageHandler errorMessageHandler) {
-        removeOpenOfferAux(openOffer, false, resultHandler, errorMessageHandler);
+        removeOpenOfferAux(openOffer, OnReserved.REJECT, resultHandler, errorMessageHandler);
     }
 
-    // claimIfUnreserved skips cancellation atomically if the offer is concurrently reserved for a trade
     private void removeOpenOfferAux(OpenOffer openOffer,
-                                boolean claimIfUnreserved,
+                                OnReserved onReserved,
                                 ResultHandler resultHandler,
                                 ErrorMessageHandler errorMessageHandler) {
         log.info("Canceling and removing open offer: {}", openOffer.getId());
         try {
-            if (!offersToBeEdited.containsKey(openOffer.getId())) {
 
-                // cancel state atomically with reservation so cancellation cannot override a concurrent reservation
-                boolean wasOnOfferBook;
-                synchronized (openOffers.getList()) {
-                    if (claimIfUnreserved && (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.getState() == OpenOffer.State.RESERVED || openOffer.getState() == OpenOffer.State.CANCELED)) {
-                        log.warn("Skipping cancellation of open offer {} because it is reserved for a trade or no longer open, state={}", openOffer.getId(), openOffer.getState());
+            // cancel state atomically with reservation so cancellation cannot override a concurrent reservation
+            boolean wasOnOfferBook;
+            boolean wasBeingEdited;
+            synchronized (openOffers.getList()) {
+                OpenOffer currentOpenOffer = getOpenOffer(openOffer.getId()).orElse(null);
+                if (currentOpenOffer != openOffer) {
+                    if (currentOpenOffer == null) {
+                        log.warn("Skipping cancellation of open offer {} because it is no longer open, state={}", openOffer.getId(), openOffer.getState());
                         if (resultHandler != null) resultHandler.handleResult();
-                        return;
+                    } else {
+                        log.warn("Rejecting cancellation of open offer {} because it was replaced while being edited", openOffer.getId());
+                        if (errorMessageHandler != null) errorMessageHandler.handleErrorMessage("The offer with ID " + openOffer.getId() + " was replaced while being edited, so it cannot be canceled.");
                     }
-                    wasOnOfferBook = isOnOfferBook(openOffer); // record before canceling state
-                    openOffer.setState(OpenOffer.State.CANCELED);
+                    return;
                 }
-
-                if (wasOnOfferBook) {
-                    offerBookService.removeOffer(openOffer.getOffer().getOfferPayload(),
-                            () -> {
-                                ThreadUtils.submitToPool(() -> { // TODO: this runs off thread and then shows popup when done. should show overlay spinner until done
-                                    doCancelOffer(openOffer);
-                                    if (resultHandler != null) resultHandler.handleResult();
-                                });
-                            },
-                            errorMessageHandler);
-                } else {
-                    ThreadUtils.submitToPool(() -> {
-                        doCancelOffer(openOffer);
+                if (openOffer.getState() == OpenOffer.State.RESERVED && onReserved != OnReserved.CANCEL) {
+                    if (onReserved == OnReserved.REJECT) {
+                        log.warn("Rejecting cancellation of open offer {} because it is reserved for a trade in process", openOffer.getId());
+                        if (errorMessageHandler != null) errorMessageHandler.handleErrorMessage("The offer with ID " + openOffer.getId() + " is reserved for a trade in process, so it cannot be canceled.");
+                    } else {
+                        log.warn("Skipping cancellation of open offer {} because it is reserved for a trade in process", openOffer.getId());
                         if (resultHandler != null) resultHandler.handleResult();
-                    });
+                    }
+                    return;
                 }
-            } else {
+                wasBeingEdited = offersToBeEdited.remove(openOffer.getId()) != null;
+                wasOnOfferBook = !wasBeingEdited && isOnOfferBook(openOffer); // record before canceling state
+                openOffer.setState(OpenOffer.State.CANCELED);
+            }
+
+            if (wasBeingEdited) {
                 log.warn("Canceling offer {} which is currently in edit mode.", openOffer.getId());
-                offersToBeEdited.remove(openOffer.getId());
                 doCancelOffer(openOffer);
                 if (resultHandler != null) resultHandler.handleResult();
+            } else if (wasOnOfferBook) {
+                offerBookService.removeOffer(openOffer.getOffer().getOfferPayload(),
+                        () -> {
+                            ThreadUtils.submitToPool(() -> { // TODO: this runs off thread and then shows popup when done. should show overlay spinner until done
+                                doCancelOffer(openOffer);
+                                if (resultHandler != null) resultHandler.handleResult();
+                            });
+                        },
+                        errorMessageHandler);
+            } else {
+                ThreadUtils.submitToPool(() -> {
+                    doCancelOffer(openOffer);
+                    if (resultHandler != null) resultHandler.handleResult();
+                });
             }
         } catch (Throwable t) {
             log.warn("Error canceling open offer " + openOffer.getId() + ": " + t.getMessage(), t);
@@ -674,20 +698,22 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
     private void removeOpenOffersOnSpent(String keyImage) {
 
-        // collect spent offers under the list lock, then cancel outside the lock
+        // collect spent offer ids under the list lock, then cancel outside the lock
         // which must not be held while acquiring the wallet lock
-        List<OpenOffer> spentOffers = new ArrayList<OpenOffer>();
+        List<String> spentOfferIds = new ArrayList<String>();
         synchronized (openOffers.getList()) {
             for (OpenOffer openOffer : openOffers.getList()) {
                 if (openOffer.getState() == OpenOffer.State.CANCELED || openOffer.getState() == OpenOffer.State.RESERVED) continue;
                 if (openOffer.getOffer().getOfferPayload().getReserveTxKeyImages() != null && openOffer.getOffer().getOfferPayload().getReserveTxKeyImages().contains(keyImage)) {
-                    spentOffers.add(openOffer);
+                    spentOfferIds.add(openOffer.getId());
                 }
             }
         }
-        for (OpenOffer openOffer : spentOffers) {
-            log.warn("Canceling open offer because reserved funds have been spent unexpectedly, offerId={}, state={}", openOffer.getId(), openOffer.getState());
-            removeOpenOfferAux(openOffer, true, null, null);
+        for (String offerId : spentOfferIds) {
+            getOpenOffer(offerId).ifPresent(openOffer -> { // re-resolve in case replaced by editing
+                log.warn("Canceling open offer because reserved funds have been spent unexpectedly, offerId={}, state={}", openOffer.getId(), openOffer.getState());
+                removeOpenOfferAux(openOffer, OnReserved.SKIP, null, null);
+            });
         }
     }
 
@@ -696,6 +722,8 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                                   ErrorMessageHandler errorMessageHandler) {
         if (openOffer.isPending()) {
             resultHandler.handleResult(); // ignore if pending
+        } else if (openOffer.isReserved() || openOffer.isCanceled()) {
+            errorMessageHandler.handleErrorMessage("The offer with ID " + openOffer.getId() + " is reserved for a trade or removed, so it cannot be activated.");
         } else if (offersToBeEdited.containsKey(openOffer.getId())) {
             errorMessageHandler.handleErrorMessage(Res.get("offerbook.cannotActivateEditedOffer.warning"));
         } else if (hasConflictingClone(openOffer)) {
@@ -711,7 +739,9 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 log.info("Activating open offer: {}", openOffer.getId());
                 offerBookService.activateOffer(offer,
                         () -> {
-                            openOffer.setState(OpenOffer.State.AVAILABLE);
+                            synchronized (openOffers.getList()) { // skip if reserved or canceled while activating off thread
+                                if (openOffer.isDeactivated()) openOffer.setState(OpenOffer.State.AVAILABLE);
+                            }
                             applyTriggerState(openOffer);
                             requestPersistence();
                             log.debug("activateOpenOffer, offerId={}", offer.getId());
@@ -726,9 +756,16 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     }
 
     private void applyTriggerState(OpenOffer openOffer) {
-        if (openOffer.getState() != OpenOffer.State.AVAILABLE) return;
-        if (TriggerPriceService.isTriggered(priceFeedService.getMarketPrice(openOffer.getOffer().getCounterCurrencyCode()), openOffer)) {
-            openOffer.deactivate(true);
+        applyTriggerState(openOffer, priceFeedService.getMarketPrice(openOffer.getOffer().getCounterCurrencyCode()));
+    }
+
+    // caller fetches the market price, since the list lock cannot be held while acquiring the price cache
+    private void applyTriggerState(OpenOffer openOffer, MarketPrice marketPrice) {
+        synchronized (openOffers.getList()) { // atomic with reservation so deactivation cannot overwrite RESERVED
+            if (openOffer.getState() != OpenOffer.State.AVAILABLE) return;
+            if (TriggerPriceService.isTriggered(marketPrice, openOffer)) {
+                openOffer.deactivate(true);
+            }
         }
     }
 
@@ -741,7 +778,9 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
             log.info("Deactivating open offer: {}", openOffer.getId());
             offerBookService.deactivateOffer(offer.getOfferPayload(),
                     () -> {
-                        openOffer.deactivate(deactivatedByTrigger);
+                        synchronized (openOffers.getList()) { // skip if reserved or canceled while deactivating off thread
+                            if (openOffer.isAvailable()) openOffer.deactivate(deactivatedByTrigger);
+                        }
                         requestPersistence();
                         log.debug("deactivateOpenOffer, offerId={}", offer.getId());
                         resultHandler.handleResult();
@@ -760,14 +799,19 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     public void editOpenOfferStart(OpenOffer openOffer,
                                    ResultHandler resultHandler,
                                    ErrorMessageHandler errorMessageHandler) {
-        if (offersToBeEdited.containsKey(openOffer.getId())) {
-            log.warn("editOpenOfferStart called for offer " + openOffer.getId() + " which is already in edit mode.");
-            resultHandler.handleResult();
-            return;
+        synchronized (openOffers.getList()) { // atomic with reservation so a reserved offer cannot enter edit mode
+            if (offersToBeEdited.containsKey(openOffer.getId())) {
+                log.warn("editOpenOfferStart called for offer " + openOffer.getId() + " which is already in edit mode.");
+                resultHandler.handleResult();
+                return;
+            }
+            if (openOffer.isReserved() || openOffer.isCanceled()) {
+                errorMessageHandler.handleErrorMessage("The offer with ID " + openOffer.getId() + " is reserved for a trade or removed, so it cannot be edited.");
+                return;
+            }
+            log.info("Editing open offer: {}", openOffer.getId());
+            offersToBeEdited.put(openOffer.getId(), openOffer);
         }
-
-        log.info("Editing open offer: {}", openOffer.getId());
-        offersToBeEdited.put(openOffer.getId(), openOffer);
 
         if (openOffer.isAvailable()) {
             try {
@@ -807,30 +851,40 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
                 // replace original offer with edited offer
                 OpenOffer editedOpenOffer;
-                synchronized (openOffers.getList()) {
+                MarketPrice marketPrice = priceFeedService.getMarketPrice(editedOffer.getCounterCurrencyCode()); // fetched before the list lock which cannot be held while acquiring the price cache
+                synchronized (xmrWalletService.getWalletLock()) { // wallet lock so a split output tx cannot be assigned to the original offer concurrently
+                    synchronized (openOffers.getList()) {
 
-                    // add edited open offer
-                    editedOpenOffer = new OpenOffer(editedOffer, triggerPrice, openOffer);
-                    if (originalState == OpenOffer.State.DEACTIVATED && openOffer.isDeactivatedByTrigger()) {
-                        if (hasConflictingClone(editedOpenOffer)) {
-                            editedOpenOffer.setState(OpenOffer.State.DEACTIVATED);
-                        } else {
-                            editedOpenOffer.setState(OpenOffer.State.AVAILABLE);
+                        // reject replacing an offer which was reserved for a trade or canceled while being edited
+                        if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.getState() == OpenOffer.State.RESERVED || openOffer.getState() == OpenOffer.State.CANCELED) {
+                            offersToBeEdited.remove(openOffer.getId());
+                            errorMessageHandler.handleErrorMessage("The offer with ID " + openOffer.getId() + " was reserved for a trade or removed while being edited, so it cannot be edited.");
+                            return;
                         }
-                    } else {
-                        if (originalState == OpenOffer.State.AVAILABLE && hasConflictingClone(editedOpenOffer)) {
-                            editedOpenOffer.setState(OpenOffer.State.DEACTIVATED);
+
+                        // add edited open offer
+                        editedOpenOffer = new OpenOffer(editedOffer, triggerPrice, openOffer);
+                        if (originalState == OpenOffer.State.DEACTIVATED && openOffer.isDeactivatedByTrigger()) {
+                            if (hasConflictingClone(editedOpenOffer)) {
+                                editedOpenOffer.setState(OpenOffer.State.DEACTIVATED);
+                            } else {
+                                editedOpenOffer.setState(OpenOffer.State.AVAILABLE);
+                            }
                         } else {
-                            editedOpenOffer.setState(originalState);
+                            if (originalState == OpenOffer.State.AVAILABLE && hasConflictingClone(editedOpenOffer)) {
+                                editedOpenOffer.setState(OpenOffer.State.DEACTIVATED);
+                            } else {
+                                editedOpenOffer.setState(originalState);
+                            }
                         }
+                        applyTriggerState(editedOpenOffer, marketPrice); // apply trigger state before adding so it's not immediately removed
+                        doAddOpenOffer(editedOpenOffer);
+
+                        // remove original open offer
+                        openOffer.getOffer().setState(Offer.State.REMOVED);
+                        openOffer.setState(OpenOffer.State.CANCELED);
+                        doRemoveOpenOffer(openOffer);
                     }
-                    applyTriggerState(editedOpenOffer); // apply trigger state before adding so it's not immediately removed
-                    doAddOpenOffer(editedOpenOffer);
-
-                    // remove original open offer
-                    openOffer.getOffer().setState(Offer.State.REMOVED);
-                    openOffer.setState(OpenOffer.State.CANCELED);
-                    doRemoveOpenOffer(openOffer);
                 }
 
                 // check for valid arbitrator signature after editing
@@ -893,10 +947,14 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     // cancel open offer which thaws its key images
     private void doCancelOffer(@NotNull OpenOffer openOffer, boolean resetAddressEntries, boolean thawOutputs) {
         Offer offer = openOffer.getOffer();
+        boolean hasClonedOffer;
+        synchronized (openOffers.getList()) { // claim by removing from the list, so concurrent cancels clean up exactly once
+            if (getOpenOffer(offer.getId()).orElse(null) != openOffer) return;
+            hasClonedOffer = hasClonedOffer(offer.getId()); // record before removing open offer
+            doRemoveOpenOffer(openOffer);
+        }
         offer.setState(Offer.State.REMOVED);
         openOffer.setState(OpenOffer.State.CANCELED);
-        boolean hasClonedOffer = hasClonedOffer(offer.getId()); // record before removing open offer
-        doRemoveOpenOffer(openOffer); 
         if (!hasClonedOffer) closedTradableManager.add(openOffer); // do not add clones to closed trades TODO: don't add canceled offers to closed tradables?
         if (resetAddressEntries) xmrWalletService.resetAddressEntriesForOpenOffer(offer.getId());
         requestPersistence();
@@ -928,9 +986,23 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     // returns false unless the offer is still open and available, atomic with the state of other open offers
     public boolean reserveOpenOffer(OpenOffer openOffer) {
         synchronized (openOffers.getList()) {
-            if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.getState() != OpenOffer.State.AVAILABLE) {
+            if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.getState() != OpenOffer.State.AVAILABLE || offersToBeEdited.containsKey(openOffer.getId())) {
                 log.warn("Cannot reserve open offer {} because it is not available, state={}", openOffer.getId(), openOffer.getState());
                 return false;
+            }
+
+            // reject if the shared reserve funds are used by another trade, since restored offer states can lag open trades on startup
+            if (openOffer.getGroupId() != null) {
+                for (OpenOffer groupOffer : getOpenOfferGroup(openOffer.getGroupId())) {
+                    if (!groupOffer.getId().equals(openOffer.getId()) && groupOffer.getState() == OpenOffer.State.RESERVED) {
+                        log.warn("Cannot reserve open offer {} because cloned offer {} is reserved for another trade", openOffer.getId(), groupOffer.getId());
+                        return false;
+                    }
+                    if (HavenoUtils.tradeManager != null && (HavenoUtils.tradeManager.getOpenTrade(groupOffer.getId()).isPresent() || HavenoUtils.tradeManager.hasFailedScheduledTrade(groupOffer.getId()))) {
+                        log.warn("Cannot reserve open offer {} because offer {} has a trade in process", openOffer.getId(), groupOffer.getId());
+                        return false;
+                    }
+                }
             }
             openOffer.setState(OpenOffer.State.RESERVED);
         }
@@ -938,12 +1010,25 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         return true;
     }
 
-    public void unreserveOpenOffer(OpenOffer openOffer) {
-        if (!openOffer.isReserved()) { // TODO: this avoids a race condition with cancelOpenOffer (e.g. on 2nd arbitrator NACK) and onProtocolInitializationError after trade initialization fails, leaving a historical tradable in state AVAILABLE
-            log.warn("Not unreserving open offer {} because it is not reserved, state={}", openOffer.getId(), openOffer.getState());
-            return;
+    // restore an offer's reserved state for a trade in process, since reserved state resets when read from disk
+    public void restoreReservedState(String offerId) {
+        synchronized (openOffers.getList()) { // atomic with reservation and cancellation
+            getOpenOffer(offerId).ifPresent(openOffer -> {
+                if (openOffer.getState() == OpenOffer.State.RESERVED || openOffer.getState() == OpenOffer.State.CANCELED) return;
+                log.warn("Setting open offer {} to reserved because it has a trade in process, state={}", openOffer.getId(), openOffer.getState());
+                openOffer.setState(OpenOffer.State.RESERVED);
+            });
         }
-        openOffer.setState(OpenOffer.State.AVAILABLE);
+    }
+
+    public void unreserveOpenOffer(OpenOffer openOffer) {
+        synchronized (openOffers.getList()) { // atomic with cancellation, e.g. offer removed on 2nd arbitrator NACK before trade cleanup unreserves
+            if (!openOffer.isReserved()) {
+                log.warn("Not unreserving open offer {} because it is not reserved, state={}", openOffer.getId(), openOffer.getState());
+                return;
+            }
+            openOffer.setState(OpenOffer.State.AVAILABLE);
+        }
         requestPersistence();
     }
 
@@ -2253,6 +2338,18 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     // Update persisted offer if a new capability is required after a software update
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    // set the offer to canceled atomically with its reserved state, so it cannot be reserved concurrently
+    private boolean cancelUnreservedOpenOffer(OpenOffer openOffer) {
+        synchronized (openOffers.getList()) {
+            if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.getState() == OpenOffer.State.RESERVED || openOffer.getState() == OpenOffer.State.CANCELED) {
+                log.warn("Skipping cancellation of open offer {} because it is reserved for a trade or already canceled, state={}", openOffer.getId(), openOffer.getState());
+                return false;
+            }
+            openOffer.setState(OpenOffer.State.CANCELED);
+            return true;
+        }
+    }
+
     private void maybeUpdatePersistedOffers() {
 
         // update open offers
@@ -2293,6 +2390,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                     // keep validly signed offer grandfathered when only its version is too low
                     if (!needsRewrite && isSignedStateValid(originalOpenOffer)) return;
 
+                    if (!cancelUnreservedOpenOffer(originalOpenOffer)) return; // skip if reserved for a trade in process
                     log.warn("Canceling outdated offer {} because its fees or security deposits changed and it cannot be re-signed; the maker must recreate it", originalOffer.getId());
                     originalOffer.setErrorMessage("Offer was canceled because trade fees or security deposits changed and it could not be re-signed. Please recreate the offer.");
                     doCancelOffer(originalOpenOffer);
@@ -2380,8 +2478,9 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                         originalOfferPayload.getExtraInfo());
 
                 // cancel old offer
-                log.info("Canceling outdated offer id={}", originalOffer.getId());
                 boolean wasDeactivated = originalOpenOffer.isDeactivated();
+                if (!cancelUnreservedOpenOffer(originalOpenOffer)) return; // skip if reserved for a trade in process
+                log.info("Canceling outdated offer id={}", originalOffer.getId());
                 doCancelOffer(originalOpenOffer, false, !preserveFundingTx);
 
                 // create new offer
@@ -2516,6 +2615,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     private boolean preventedFromPublishing(OpenOffer openOffer, boolean checkSignature) {
         if (!Boolean.TRUE.equals(xmrConnectionService.isConnected())) return true;
         return openOffer.isDeactivated() ||
+                openOffer.isReserved() ||
                 openOffer.isCanceled() ||
                 (checkSignature && openOffer.getOffer().getOfferPayload().getArbitratorSigner() == null) ||
                 hasConflictingClone(openOffer);

--- a/core/src/main/java/haveno/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/haveno/core/offer/OpenOfferManager.java
@@ -74,6 +74,7 @@ import haveno.core.support.dispute.mediation.mediator.MediatorManager;
 import haveno.core.trade.ClosedTradableManager;
 import haveno.core.trade.HavenoUtils;
 import haveno.core.trade.TradableList;
+import haveno.core.trade.Trade;
 import haveno.core.trade.handlers.TransactionResultHandler;
 import haveno.core.trade.protocol.TradeProtocol;
 import haveno.core.trade.statistics.TradeStatisticsManager;
@@ -236,7 +237,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
         // read open offers
         persistenceManager.readPersisted(persisted -> {
-            openOffers.setAll(persisted.getList());
+            openOffers.setAll(persisted.getList().stream().filter(openOffer -> !openOffer.isCanceled()).collect(Collectors.toList())); // drop offers canceled mid-removal, so their outputs are not treated as reserved
             openOffers.forEach(openOffer -> openOffer.getOffer().setPriceFeedService(priceFeedService));
 
             // sort open offers by oldest first
@@ -347,17 +348,19 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     }
 
     private void removeOpenOffers(List<OpenOffer> openOffers, @Nullable Runnable completeHandler) {
+
+        // copy list, then remove offers outside the list lock which must not be held while acquiring the wallet lock
+        List<OpenOffer> openOffersList;
         synchronized (openOffers) {
-            int size = openOffers.size();
-            // Copy list as we remove in the loop
-            List<OpenOffer> openOffersList = new ArrayList<>(openOffers);
-            openOffersList.forEach(openOffer -> removeOpenOffer(openOffer, () -> {
-                    }, errorMessage -> {
-                        log.warn("Error removing open offer: " + errorMessage);
-                    }));
-            if (completeHandler != null)
-                UserThread.runAfter(completeHandler, size * 200 + 500, TimeUnit.MILLISECONDS);
+            openOffersList = new ArrayList<>(openOffers);
         }
+
+        openOffersList.forEach(openOffer -> removeOpenOfferAux(openOffer, true, () -> {
+                }, errorMessage -> {
+                    log.warn("Error removing open offer: " + errorMessage);
+                }));
+        if (completeHandler != null)
+            UserThread.runAfter(completeHandler, openOffersList.size() * 200 + 500, TimeUnit.MILLISECONDS);
     }
 
 
@@ -618,11 +621,31 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     private void removeOpenOfferAux(OpenOffer openOffer,
                                 ResultHandler resultHandler,
                                 ErrorMessageHandler errorMessageHandler) {
+        removeOpenOfferAux(openOffer, false, resultHandler, errorMessageHandler);
+    }
+
+    // claimIfUnreserved skips cancellation atomically if the offer is concurrently reserved for a trade
+    private void removeOpenOfferAux(OpenOffer openOffer,
+                                boolean claimIfUnreserved,
+                                ResultHandler resultHandler,
+                                ErrorMessageHandler errorMessageHandler) {
         log.info("Canceling and removing open offer: {}", openOffer.getId());
         try {
             if (!offersToBeEdited.containsKey(openOffer.getId())) {
-                if (isOnOfferBook(openOffer)) {
+
+                // cancel state atomically with reservation so cancellation cannot override a concurrent reservation
+                boolean wasOnOfferBook;
+                synchronized (openOffers.getList()) {
+                    if (claimIfUnreserved && (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.getState() == OpenOffer.State.RESERVED || openOffer.getState() == OpenOffer.State.CANCELED)) {
+                        log.warn("Skipping cancellation of open offer {} because it is reserved for a trade or no longer open, state={}", openOffer.getId(), openOffer.getState());
+                        if (resultHandler != null) resultHandler.handleResult();
+                        return;
+                    }
+                    wasOnOfferBook = isOnOfferBook(openOffer); // record before canceling state
                     openOffer.setState(OpenOffer.State.CANCELED);
+                }
+
+                if (wasOnOfferBook) {
                     offerBookService.removeOffer(openOffer.getOffer().getOfferPayload(),
                             () -> {
                                 ThreadUtils.submitToPool(() -> { // TODO: this runs off thread and then shows popup when done. should show overlay spinner until done
@@ -632,7 +655,6 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                             },
                             errorMessageHandler);
                 } else {
-                    openOffer.setState(OpenOffer.State.CANCELED);
                     ThreadUtils.submitToPool(() -> {
                         doCancelOffer(openOffer);
                         if (resultHandler != null) resultHandler.handleResult();
@@ -651,13 +673,21 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     }
 
     private void removeOpenOffersOnSpent(String keyImage) {
+
+        // collect spent offers under the list lock, then cancel outside the lock
+        // which must not be held while acquiring the wallet lock
+        List<OpenOffer> spentOffers = new ArrayList<OpenOffer>();
         synchronized (openOffers.getList()) {
-            for (OpenOffer openOffer : new ArrayList<>(openOffers.getList())) {
-                if (openOffer.getState() != OpenOffer.State.CANCELED && openOffer.getState() != OpenOffer.State.RESERVED && openOffer.getOffer().getOfferPayload().getReserveTxKeyImages() != null && openOffer.getOffer().getOfferPayload().getReserveTxKeyImages().contains(keyImage)) {
-                    log.warn("Canceling open offer because reserved funds have been spent unexpectedly, offerId={}, state={}", openOffer.getId(), openOffer.getState());
-                    removeOpenOfferAux(openOffer, null, null);
+            for (OpenOffer openOffer : openOffers.getList()) {
+                if (openOffer.getState() == OpenOffer.State.CANCELED || openOffer.getState() == OpenOffer.State.RESERVED) continue;
+                if (openOffer.getOffer().getOfferPayload().getReserveTxKeyImages() != null && openOffer.getOffer().getOfferPayload().getReserveTxKeyImages().contains(keyImage)) {
+                    spentOffers.add(openOffer);
                 }
             }
+        }
+        for (OpenOffer openOffer : spentOffers) {
+            log.warn("Canceling open offer because reserved funds have been spent unexpectedly, offerId={}, state={}", openOffer.getId(), openOffer.getState());
+            removeOpenOfferAux(openOffer, true, null, null);
         }
     }
 
@@ -870,7 +900,10 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         if (!hasClonedOffer) closedTradableManager.add(openOffer); // do not add clones to closed trades TODO: don't add canceled offers to closed tradables?
         if (resetAddressEntries) xmrWalletService.resetAddressEntriesForOpenOffer(offer.getId());
         requestPersistence();
-        if (thawOutputs && !hasClonedOffer) xmrWalletService.thawOutputs(offer.getOfferPayload().getReserveTxKeyImages());
+        if (thawOutputs) {
+            if (!hasClonedOffer) xmrWalletService.thawOutputs(offer.getOfferPayload().getReserveTxKeyImages());
+            thawUnreservedSplitOutputs(openOffer);
+        }
     }
 
     // close open offer group after key images spent
@@ -892,9 +925,17 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         requestPersistence();
     }
 
-    public void reserveOpenOffer(OpenOffer openOffer) {
-        openOffer.setState(OpenOffer.State.RESERVED);
+    // returns false unless the offer is still open and available, atomic with the state of other open offers
+    public boolean reserveOpenOffer(OpenOffer openOffer) {
+        synchronized (openOffers.getList()) {
+            if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.getState() != OpenOffer.State.AVAILABLE) {
+                log.warn("Cannot reserve open offer {} because it is not available, state={}", openOffer.getId(), openOffer.getState());
+                return false;
+            }
+            openOffer.setState(OpenOffer.State.RESERVED);
+        }
         requestPersistence();
+        return true;
     }
 
     public void unreserveOpenOffer(OpenOffer openOffer) {
@@ -1247,6 +1288,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 if (openOffer.getScheduledTxHashes() != null) {
                     boolean scheduledTxsAvailable = true;
                     for (MoneroTxWallet tx : xmrWalletService.getTxs(openOffer.getScheduledTxHashes())) {
+                        if (tx.getHash().equals(openOffer.getSplitOutputTxHash())) continue; // split output tx availability is checked separately
                         if (!tx.isLocked() && !hasSpendableAmount(tx)) {
                             scheduledTxsAvailable = false;
                             break;
@@ -1265,10 +1307,24 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 // handle split output offer
                 if (openOffer.isReserveExactAmount()) {
 
-                    // find tx with exact input amount
-                    MoneroTxWallet splitOutputTx = getSplitOutputFundingTx(openOffers, openOffer);
-                    if (splitOutputTx != null && openOffer.getSplitOutputTxHash() == null) {
-                        setSplitOutputTx(openOffer, splitOutputTx);
+                    // find tx with exact input amount and freeze it, with wallet lock so other txs cannot spend it concurrently
+                    MoneroTxWallet splitOutputTx;
+                    boolean offerCanceled;
+                    synchronized (xmrWalletService.getWalletLock()) {
+
+                        // re-check offer is not canceled before freezing, since cancellation thaws with the wallet lock
+                        synchronized (this.openOffers.getList()) {
+                            offerCanceled = getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.isCanceled();
+                        }
+                        splitOutputTx = offerCanceled ? null : getSplitOutputFundingTx(openOffers, openOffer);
+                        if (splitOutputTx != null && openOffer.getSplitOutputTxHash() == null) {
+                            setSplitOutputTx(openOffer, splitOutputTx);
+                            xmrWalletService.freezeOutputs(xmrWalletService.getSplitOutputKeyImages(openOffer));
+                        }
+                    }
+                    if (offerCanceled) {
+                        resultHandler.handleResult(null); // canceled while processing
+                        return;
                     }
 
                     // if wallet has exact available balance, try to sign and post directly
@@ -1340,11 +1396,19 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
             // check if split output tx is available for offer
             if (splitOutputTx != null) {
+
+                // freeze exact outputs when seen so other txs cannot spend them
+                List<MoneroOutputWallet> splitOutputs = xmrWalletService.getSplitOutputs(openOffer);
+                xmrWalletService.freezeOutputs(splitOutputs.stream()
+                        .filter(output -> !output.isFrozen() && !output.isSpent())
+                        .map(output -> output.getKeyImage().getHex())
+                        .collect(Collectors.toList()));
+
                 if (splitOutputTx.isLocked()) return splitOutputTx;
                 else {
-                    boolean isAvailable = true;
-                    for (MoneroOutputWallet output : splitOutputTx.getOutputsWallet()) {
-                        if (output.isSpent() || output.isFrozen()) {
+                    boolean isAvailable = !splitOutputs.isEmpty();
+                    for (MoneroOutputWallet output : splitOutputs) {
+                        if (output.isSpent() || isReservedByOtherOfferOrTrade(openOffer, output.getKeyImage().getHex())) {
                             isAvailable = false;
                             break;
                         }
@@ -1355,6 +1419,10 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
             } else {
                 log.warn("Split output tx no longer exists for offerId={}, txId={}", openOffer.getId(), openOffer.getSplitOutputTxHash());
             }
+
+            // thaw unavailable split output tx and clear its metadata so a replacement can be assigned
+            thawUnreservedSplitOutputs(openOffer);
+            setSplitOutputTx(openOffer, null);
         }
 
         // get split output tx to offer's preferred subaddress
@@ -1378,16 +1446,41 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         return false;
     }
 
+    private boolean isReservedByOtherOfferOrTrade(OpenOffer openOffer, String keyImage) {
+        for (OpenOffer otherOffer : getOpenOffers()) {
+            if (otherOffer.getId().equals(openOffer.getId())) continue;
+            List<String> reservedKeyImages = otherOffer.getOffer().getOfferPayload().getReserveTxKeyImages();
+            if (reservedKeyImages != null && reservedKeyImages.contains(keyImage)) return true;
+        }
+        for (Trade trade : HavenoUtils.tradeManager.getOpenTrades()) {
+            List<String> reservedKeyImages = trade.getSelf().getReserveTxKeyImages();
+            if (reservedKeyImages != null && reservedKeyImages.contains(keyImage)) return true;
+        }
+        return false;
+    }
+
+    // thaw an offer's split outputs which are not reserved by another offer or trade
+    private void thawUnreservedSplitOutputs(OpenOffer openOffer) {
+        synchronized (xmrWalletService.getWalletLock()) { // wallet lock so cancellation cannot miss outputs being assigned and frozen concurrently
+            List<String> keyImages = xmrWalletService.getSplitOutputKeyImages(openOffer);
+            keyImages.removeIf(keyImage -> isReservedByOtherOfferOrTrade(openOffer, keyImage));
+            xmrWalletService.thawOutputs(keyImages);
+        }
+    }
+
     private List<MoneroTxWallet> getSplitOutputFundingTxs(BigInteger reserveAmount, Integer preferredSubaddressIndex) {
         List<MoneroTxWallet> splitOutputTxs = xmrWalletService.getTxs(new MoneroTxQuery().setIsFailed(false)); // TODO: not using setIsIncoming(true) because split output txs sent to self have false; fix in monero-java?
         Set<MoneroTxWallet> removeTxs = new HashSet<MoneroTxWallet>();
         for (MoneroTxWallet tx : splitOutputTxs) {
+            if (!hasExactOutput(tx, reserveAmount, preferredSubaddressIndex)) {
+                removeTxs.add(tx);
+                continue;
+            }
             if (tx.getOutputs() != null) { // outputs not available until first confirmation
-                for (MoneroOutputWallet output : tx.getOutputsWallet()) {
-                    if (output.isSpent() || output.isFrozen()) removeTxs.add(tx);
+                for (MoneroOutputWallet output : tx.getOutputsWallet(new MoneroOutputQuery().setAccountIndex(0).setAmount(reserveAmount))) {
+                    if (output.isSpent() || output.isFrozen()) removeTxs.add(tx); // exact outputs must be unspent and unfrozen
                 }
             }
-            if (!hasExactOutput(tx, reserveAmount, preferredSubaddressIndex)) removeTxs.add(tx);
         }
         splitOutputTxs.removeAll(removeTxs);
         return splitOutputTxs;
@@ -1553,7 +1646,15 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         for (OpenOffer openOffer : openOffers) {
             if (openOffer.getSplitOutputTxHash() == null) continue;
             if (!openOffer.getSplitOutputTxHash().equals(tx.getHash())) continue;
-            return openOffer.getOffer().getAmountNeeded();
+            BigInteger splitAmount = openOffer.getOffer().getAmountNeeded();
+            if (!tx.isConfirmed() || tx.getOutputs() == null) return splitAmount;
+
+            // count only unfrozen unspent exact outputs, since others are already excluded from the spendable amount
+            BigInteger unfrozenSplitAmount = BigInteger.ZERO;
+            for (MoneroOutputWallet output : tx.getOutputsWallet(new MoneroOutputQuery().setAccountIndex(0).setAmount(splitAmount))) {
+                if (!output.isSpent() && !output.isFrozen()) unfrozenSplitAmount = unfrozenSplitAmount.add(output.getAmount());
+            }
+            return unfrozenSplitAmount;
         }
         return BigInteger.ZERO;
     }
@@ -2293,6 +2394,10 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                     updatedOpenOffer.setReserveTxHash(originalOpenOffer.getReserveTxHash());
                     updatedOpenOffer.setReserveTxHex(originalOpenOffer.getReserveTxHex());
                     updatedOpenOffer.setReserveTxKey(originalOpenOffer.getReserveTxKey());
+                    updatedOpenOffer.setSplitOutputTxHash(originalOpenOffer.getSplitOutputTxHash());
+                    updatedOpenOffer.setSplitOutputTxFee(originalOpenOffer.getSplitOutputTxFee());
+                    updatedOpenOffer.setScheduledTxHashes(originalOpenOffer.getScheduledTxHashes());
+                    updatedOpenOffer.setScheduledAmount(originalOpenOffer.getScheduledAmount());
                 }
                 if (wasDeactivated) {
                     updatedOpenOffer.deactivate(false); 

--- a/core/src/main/java/haveno/core/offer/placeoffer/tasks/MakerReserveOfferFunds.java
+++ b/core/src/main/java/haveno/core/offer/placeoffer/tasks/MakerReserveOfferFunds.java
@@ -96,6 +96,10 @@ public class MakerReserveOfferFunds extends Task<PlaceOfferModel> {
                 // attempt creating reserve tx
                 MoneroTxWallet reserveTx = null;
                 try {
+
+                    // thaw offer's split outputs for reserve tx to spend, within try so a thaw error re-freezes
+                    model.getXmrWalletService().thawOutputs(model.getXmrWalletService().getSplitOutputKeyImages(openOffer));
+
                     synchronized (HavenoUtils.getWalletFunctionLock()) {
                         for (int i = 0; i < TradeProtocol.MAX_ATTEMPTS; i++) {
                             MoneroRpcConnection sourceConnection = model.getXmrWalletService().getXmrConnectionService().getConnection();
@@ -125,6 +129,7 @@ public class MakerReserveOfferFunds extends Task<PlaceOfferModel> {
                     setReserveTx(null);
                     model.getXmrWalletService().resetAddressEntriesForOpenOffer(offer.getId());
                     if (reserveTx != null) model.getXmrWalletService().thawOutputs(HavenoUtils.getInputKeyImages(reserveTx));
+                    if (isPending()) model.getXmrWalletService().freezeOutputs(model.getXmrWalletService().getSplitOutputKeyImages(openOffer)); // re-freeze split outputs while offer pending
                     throw e;
                 }
 

--- a/core/src/main/java/haveno/core/provider/price/PriceFeedService.java
+++ b/core/src/main/java/haveno/core/provider/price/PriceFeedService.java
@@ -360,8 +360,8 @@ public class PriceFeedService {
                             0,
                             false));
                 }
-                updateCounter.set(updateCounter.get() + 1);
             }
+            updateCounter.set(updateCounter.get() + 1); // notify listeners without holding the cache lock
         });
     }
 

--- a/core/src/main/java/haveno/core/trade/TradeManager.java
+++ b/core/src/main/java/haveno/core/trade/TradeManager.java
@@ -305,6 +305,16 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     public void onAllServicesInitialized() {
+
+        // restore reserved state of offers with open trades or failed trades pending cleanup, since reserved state resets when read from disk
+        for (Trade trade : getOpenTrades()) {
+            openOfferManager.restoreReservedState(trade.getId());
+        }
+        for (Trade trade : failedTradesManager.getObservableList()) {
+            // skip stale schedules whose cleanup finished unpersisted before shutdown, indicated by the wallet deleted
+            if (trade.isProtocolErrorHandlingScheduled() && trade.walletExists()) openOfferManager.restoreReservedState(trade.getId());
+        }
+
         if (p2PService.isBootstrapped()) {
             initTrades();
         } else {

--- a/core/src/main/java/haveno/core/trade/TradeManager.java
+++ b/core/src/main/java/haveno/core/trade/TradeManager.java
@@ -720,12 +720,16 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                 return;
             }
   
-            // reserve open offer
-            openOfferManager.reserveOpenOffer(openOffer);
-
             // verify maker and taker pubKeyRings are different
             if (offer.getPubKeyRing().equals(request.getTakerPubKeyRing())) {
                 log.warn("Ignoring InitTradeRequest to maker because maker and taker pubKeyRings are the same, tradeId={}, sender={}", request.getOfferId(), sender);
+                return;
+            }
+
+            // reserve open offer
+            if (!openOfferManager.reserveOpenOffer(openOffer)) {
+                log.warn("Rejecting InitTradeRequest to maker because offer could not be reserved, offerId={}, sender={}", request.getOfferId(), sender);
+                sendAckMessage(sender, request.getTakerPubKeyRing(), request, false, "The offer with ID " + request.getOfferId() + " is already taken or unavailable", null);
                 return;
             }
 
@@ -767,7 +771,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
             trade.getSelf().setReserveTxKeyImages(offer.getOfferPayload().getReserveTxKeyImages());
             initTradeAndProtocol(trade, createTradeProtocol(trade));
             addTrade(trade);
-  
+
             // process with protocol
             ((MakerProtocol) getTradeProtocol(trade)).handleInitTradeRequest(request, sender, errorMessage -> {
                 log.warn("Maker error during trade initialization: " + errorMessage);

--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -1159,7 +1159,7 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
         String warningMessage = "Your offer (" + trade.getOffer().getShortId() + ") has been removed because there was a problem taking the trade.\n\nError message: " + ackMessage.getErrorMessage();
         OpenOffer openOffer = HavenoUtils.openOfferManager.getOpenOffer(trade.getId()).orElse(null);
         if (openOffer != null) {
-            HavenoUtils.openOfferManager.removeOpenOffer(openOffer, null, null);
+            HavenoUtils.openOfferManager.forceRemoveOpenOffer(openOffer); // offer is reserved for the failing trade
             HavenoUtils.setTopError(warningMessage);
         }
         log.warn(warningMessage);

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
@@ -652,15 +652,15 @@ public class XmrWalletService extends XmrWalletBase {
     public void fixReservedOutputs() {
         synchronized (walletLock) {
 
-            // collect reserved outputs
+            // collect reserved outputs, read with wallet lock held so freeze and thaw state cannot change concurrently
             Set<String> reservedKeyImages = new HashSet<String>();
             for (Trade trade : HavenoUtils.tradeManager.getOpenTrades()) {
                 if (trade.getSelf().getReserveTxKeyImages() == null) continue;
                 reservedKeyImages.addAll(trade.getSelf().getReserveTxKeyImages());
             }
             for (OpenOffer openOffer : HavenoUtils.tradeManager.getOpenOfferManager().getOpenOffers()) {
-                if (openOffer.getOffer().getOfferPayload().getReserveTxKeyImages() == null) continue;
-                reservedKeyImages.addAll(openOffer.getOffer().getOfferPayload().getReserveTxKeyImages());
+                if (openOffer.getOffer().getOfferPayload().getReserveTxKeyImages() != null) reservedKeyImages.addAll(openOffer.getOffer().getOfferPayload().getReserveTxKeyImages());
+                if (openOffer.getReserveTxHash() == null) reservedKeyImages.addAll(getSplitOutputKeyImages(openOffer)); // split outputs are frozen until the reserve tx is created
             }
 
             freezeReservedOutputs(reservedKeyImages);
@@ -760,6 +760,24 @@ public class XmrWalletService extends XmrWalletBase {
             cacheWalletInfo();
             saveWallet();
         }
+    }
+
+    /**
+     * Get the exact amount outputs of an offer's split output tx.
+     *
+     * @param openOffer the offer funded by a split output tx
+     * @return the exact amount outputs, empty if no split output tx or outputs unseen
+     */
+    public List<MoneroOutputWallet> getSplitOutputs(OpenOffer openOffer) {
+        if (openOffer.getSplitOutputTxHash() == null) return new ArrayList<MoneroOutputWallet>();
+        return getOutputs(new MoneroOutputQuery()
+                .setAccountIndex(0)
+                .setAmount(openOffer.getOffer().getAmountNeeded())
+                .setTxQuery(new MoneroTxQuery().setHash(openOffer.getSplitOutputTxHash())));
+    }
+
+    public List<String> getSplitOutputKeyImages(OpenOffer openOffer) {
+        return getSplitOutputs(openOffer).stream().map(output -> output.getKeyImage().getHex()).collect(Collectors.toList());
     }
 
     private void cacheNonPoolTxs() {

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -2649,6 +2649,8 @@ seed.restore.success=Wallet restored successfully with the new seed words.\n\nYo
 seed.restore.error=An error occurred when restoring the wallets with seed words.{0}
 seed.restore.openOffers.warn=You have open offers which will be removed if you restore from seed words.\n\
   Are you sure that you want to continue?
+seed.restore.openOffers.remaining=Your wallet was not restored because some open offers could not be removed. An offer may be reserved for a trade in progress.\n\n\
+  Please try again after your trades are completed.
 
 
 ####################################################################

--- a/core/src/test/java/haveno/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/haveno/core/offer/OpenOfferManagerTest.java
@@ -8,7 +8,10 @@ import haveno.common.handlers.ResultHandler;
 import haveno.common.persistence.PersistenceManager;
 import haveno.core.api.CoreContext;
 import haveno.core.api.XmrConnectionService;
+import haveno.core.trade.HavenoUtils;
 import haveno.core.trade.TradableList;
+import haveno.core.trade.Trade;
+import haveno.core.trade.TradeManager;
 import haveno.network.p2p.NetworkNotReadyException;
 import haveno.network.p2p.P2PService;
 import haveno.network.p2p.peers.PeerManager;
@@ -17,9 +20,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.natpryce.makeiteasy.MakeItEasy.make;
+import static com.natpryce.makeiteasy.MakeItEasy.with;
 import static haveno.core.offer.OfferMaker.btcUsdOffer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -320,6 +325,230 @@ public class OpenOfferManagerTest {
 
         // removal skips the reserved offer instead of canceling it
         manager.removeAllOpenOffers(null);
+        assertEquals(OpenOffer.State.RESERVED, openOffer.getState());
+        assertTrue(manager.getObservableList().contains(openOffer));
+        verify(offerBookService, never()).removeOffer(any(OfferPayload.class), any(), any());
+    }
+
+    @Test
+    public void testReserveOpenOfferRejectsReservedClone() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+
+        final OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer), 0, false, "group");
+        final OpenOffer clonedOffer = new OpenOffer(make(btcUsdOffer.but(with(OfferMaker.id, "5678"))), 0, false, "group");
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+        clonedOffer.setState(OpenOffer.State.AVAILABLE);
+        manager.getObservableList().add(openOffer);
+        manager.getObservableList().add(clonedOffer);
+
+        // cannot reserve an offer while a clone sharing its funds is reserved
+        assertTrue(manager.reserveOpenOffer(openOffer));
+        assertFalse(manager.reserveOpenOffer(clonedOffer));
+        assertEquals(OpenOffer.State.AVAILABLE, clonedOffer.getState());
+    }
+
+    @Test
+    public void testReserveOpenOfferRejectsCloneWithOpenTrade() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+
+        final OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer), 0, false, "group");
+        final OpenOffer clonedOffer = new OpenOffer(make(btcUsdOffer.but(with(OfferMaker.id, "5678"))), 0, false, "group");
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+        clonedOffer.setState(OpenOffer.State.AVAILABLE);
+        manager.getObservableList().add(openOffer);
+        manager.getObservableList().add(clonedOffer);
+
+        // cannot reserve an offer while a clone sharing its funds has an open trade, even if not marked reserved yet
+        TradeManager tradeManager = mock(TradeManager.class);
+        try {
+            HavenoUtils.tradeManager = tradeManager;
+            when(tradeManager.getOpenTrade(clonedOffer.getId())).thenReturn(Optional.of(mock(Trade.class)));
+            assertFalse(manager.reserveOpenOffer(openOffer));
+            assertEquals(OpenOffer.State.AVAILABLE, openOffer.getState());
+        } finally {
+            HavenoUtils.tradeManager = null;
+        }
+    }
+
+    @Test
+    public void testReserveOpenOfferRejectsOfferBeingEdited() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+
+        final OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
+
+        doAnswer(invocation -> {
+            ((ResultHandler) invocation.getArgument(1)).handleResult();
+            return null;
+        }).when(offerBookService).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+        manager.getObservableList().add(openOffer);
+        manager.editOpenOfferStart(openOffer, () -> {
+        }, errorMessage -> {
+        });
+
+        // cannot reserve an offer being edited, even if available while the edit publishes
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+        assertFalse(manager.reserveOpenOffer(openOffer));
+        assertEquals(OpenOffer.State.AVAILABLE, openOffer.getState());
+    }
+
+    @Test
+    public void testEditOpenOfferStartRejectsReservedOffer() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+
+        final OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+        manager.getObservableList().add(openOffer);
+        assertTrue(manager.reserveOpenOffer(openOffer));
+
+        // editing is rejected with an error while the offer is reserved
+        AtomicBoolean errorHandled = new AtomicBoolean(false);
+        manager.editOpenOfferStart(openOffer, () -> {
+        }, errorMessage -> errorHandled.set(true));
+        assertTrue(errorHandled.get());
+        assertEquals(OpenOffer.State.RESERVED, openOffer.getState());
+        verify(offerBookService, never()).deactivateOffer(any(OfferPayload.class), any(), any());
+    }
+
+    @Test
+    public void testRemoveOpenOfferRejectsReservedOffer() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+
+        final OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+        manager.getObservableList().add(openOffer);
+        assertTrue(manager.reserveOpenOffer(openOffer));
+
+        // cancellation is rejected with an error while the offer is reserved
+        AtomicBoolean errorHandled = new AtomicBoolean(false);
+        manager.removeOpenOffer(openOffer, () -> {
+        }, errorMessage -> errorHandled.set(true));
+        assertTrue(errorHandled.get());
         assertEquals(OpenOffer.State.RESERVED, openOffer.getState());
         assertTrue(manager.getObservableList().contains(openOffer));
         verify(offerBookService, never()).removeOffer(any(OfferPayload.class), any(), any());

--- a/core/src/test/java/haveno/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/haveno/core/offer/OpenOfferManagerTest.java
@@ -21,11 +21,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.natpryce.makeiteasy.MakeItEasy.make;
 import static haveno.core.offer.OfferMaker.btcUsdOffer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -235,6 +238,91 @@ public class OpenOfferManagerTest {
         manager.editOpenOfferStart(openOffer, () -> secondEditSuccessful.set(true), null);
         assertTrue(secondEditSuccessful.get());
         verify(offerBookService, times(2)).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+    }
+
+    @Test
+    public void testReserveOpenOfferRequiresAvailableOpenOffer() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+
+        final OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+
+        // cannot reserve an offer which is not in the open offers list
+        assertFalse(manager.reserveOpenOffer(openOffer));
+
+        // reserve an available open offer
+        manager.getObservableList().add(openOffer);
+        assertTrue(manager.reserveOpenOffer(openOffer));
+        assertEquals(OpenOffer.State.RESERVED, openOffer.getState());
+
+        // cannot reserve an already reserved offer
+        assertFalse(manager.reserveOpenOffer(openOffer));
+    }
+
+    @Test
+    public void testRemoveAllOpenOffersSkipsReservedOffer() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+
+        final OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+        openOffer.setState(OpenOffer.State.AVAILABLE);
+        manager.getObservableList().add(openOffer);
+        assertTrue(manager.reserveOpenOffer(openOffer));
+
+        // removal skips the reserved offer instead of canceling it
+        manager.removeAllOpenOffers(null);
+        assertEquals(OpenOffer.State.RESERVED, openOffer.getState());
+        assertTrue(manager.getObservableList().contains(openOffer));
+        verify(offerBookService, never()).removeOffer(any(OfferPayload.class), any(), any());
     }
 
 }

--- a/desktop/src/main/java/haveno/desktop/main/SharedPresentation.java
+++ b/desktop/src/main/java/haveno/desktop/main/SharedPresentation.java
@@ -48,8 +48,11 @@ public class SharedPresentation {
                 } else if (!openOfferManager.getObservableList().isEmpty()) {
                     new Popup().warning(Res.get("seed.restore.openOffers.warn"))
                             .actionButtonText(Res.get("shared.yes"))
-                            .onAction(() -> openOfferManager.removeAllOpenOffers(() ->
-                                    doRestoreSeedWords(xmrWalletService, seedWords, restoreHeight, restoreDate)))
+                            .onAction(() -> openOfferManager.removeAllOpenOffers(() -> {
+                                    // offers reserved for a trade are skipped, so do not replace the wallet while any remain
+                                    if (openOfferManager.getObservableList().isEmpty()) doRestoreSeedWords(xmrWalletService, seedWords, restoreHeight, restoreDate);
+                                    else new Popup().warning(Res.get("seed.restore.openOffers.remaining")).show();
+                            }))
                             .show();
                 } else {
                     doRestoreSeedWords(xmrWalletService, seedWords, restoreHeight, restoreDate);


### PR DESCRIPTION
Freeze the exact outputs of split output txs when seen so other txs cannot spend them, and thaw them to create the reserve tx or on cancel.