### PR TITLE
desktop: add setting to enable native Monero wallet library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,6 @@ arbitrator-desktop-local:
 		--appName=haveno-XMR_LOCAL_arbitrator \
 		--apiPassword=apitest \
 		--apiPort=9998 \
-		--useNativeXmrWallet=false \
 	    --xmrNode=http://127.0.0.1:48081 \
 
 arbitrator2-daemon-local:
@@ -278,7 +277,6 @@ arbitrator2-desktop-local:
 		--appName=haveno-XMR_LOCAL_arbitrator2 \
 		--apiPassword=apitest \
 		--apiPort=10001 \
-		--useNativeXmrWallet=false \
 	    --xmrNode=http://127.0.0.1:48081 \
 
 user1-daemon-local:
@@ -305,7 +303,6 @@ user1-desktop-local:
 		--apiPort=9999 \
 		--walletRpcBindPort=38091 \
 		--logLevel=info \
-		--useNativeXmrWallet=false \
 
 user2-desktop-local:
 	./haveno-desktop$(APP_EXT) \
@@ -317,7 +314,6 @@ user2-desktop-local:
 		--apiPassword=apitest \
 		--apiPort=10000 \
 		--walletRpcBindPort=38092 \
-		--useNativeXmrWallet=false \
 
 user2-daemon-local:
 	./haveno-daemon$(APP_EXT) \
@@ -342,7 +338,6 @@ user3-desktop-local:
 		--apiPassword=apitest \
 		--apiPort=10002 \
 		--walletRpcBindPort=38093 \
-		--useNativeXmrWallet=false \
 
 user3-daemon-local:
 	./haveno-daemon$(APP_EXT) \
@@ -417,7 +412,6 @@ arbitrator-desktop-stagenet:
 		--apiPassword=apitest \
 		--apiPort=3200 \
 		--xmrNode=http://127.0.0.1:38081 \
-		--useNativeXmrWallet=false \
 
 user1-daemon-stagenet:
 	./haveno-daemon$(APP_EXT) \
@@ -440,7 +434,6 @@ user1-desktop-stagenet:
 		--appName=haveno-XMR_STAGENET_user1 \
 		--apiPassword=apitest \
 		--apiPort=3201 \
-		--useNativeXmrWallet=false \
 
 user2-daemon-stagenet:
 	./haveno-daemon$(APP_EXT) \
@@ -463,7 +456,6 @@ user2-desktop-stagenet:
 		--appName=haveno-XMR_STAGENET_user2 \
 		--apiPassword=apitest \
 		--apiPort=3202 \
-		--useNativeXmrWallet=false \
 
 user3-desktop-stagenet:
 	./haveno-desktop$(APP_EXT) \
@@ -474,7 +466,6 @@ user3-desktop-stagenet:
 		--appName=haveno-XMR_STAGENET_user3 \
 		--apiPassword=apitest \
 		--apiPort=3203 \
-		--useNativeXmrWallet=false \
 
 haveno-desktop-stagenet:
 	./haveno-desktop$(APP_EXT) \
@@ -485,7 +476,6 @@ haveno-desktop-stagenet:
 		--appName=Haveno \
 		--apiPassword=apitest \
 		--apiPort=3204 \
-		--useNativeXmrWallet=false \
 
 haveno-daemon-stagenet:
 	./haveno-daemon$(APP_EXT) \
@@ -555,7 +545,6 @@ arbitrator-desktop-mainnet:
 		--apiPassword=apitest \
 		--apiPort=1200 \
 		--xmrNode=http://127.0.0.1:18081 \
-		--useNativeXmrWallet=false \
 
 arbitrator2-daemon-mainnet:
 	./haveno-daemon$(APP_EXT) \
@@ -580,7 +569,6 @@ arbitrator2-desktop-mainnet:
 		--apiPassword=apitest \
 		--apiPort=1205 \
 		--xmrNode=http://127.0.0.1:18081 \
-		--useNativeXmrWallet=false \
 
 haveno-daemon-mainnet:
 	./haveno-daemon$(APP_EXT) \
@@ -603,7 +591,6 @@ haveno-desktop-mainnet:
 		--appName=Haveno \
 		--apiPassword=apitest \
 		--apiPort=1201 \
-		--useNativeXmrWallet=false \
 		--ignoreLocalXmrNode=false \
 
 # expose the mainnet daemon API to grpc-web clients at http://localhost:8080
@@ -633,7 +620,6 @@ user1-desktop-mainnet:
 		--appName=haveno-XMR_MAINNET_user1 \
 		--apiPassword=apitest \
 		--apiPort=1202 \
-		--useNativeXmrWallet=false \
 		--ignoreLocalXmrNode=false \
 
 user2-daemon-mainnet:
@@ -658,7 +644,6 @@ user2-desktop-mainnet:
 		--appName=haveno-XMR_MAINNET_user2 \
 		--apiPassword=apitest \
 		--apiPort=1203 \
-		--useNativeXmrWallet=false \
 		--ignoreLocalXmrNode=false \
 
 user3-desktop-mainnet:
@@ -670,7 +655,6 @@ user3-desktop-mainnet:
 		--appName=haveno-XMR_MAINNET_user3 \
 		--apiPassword=apitest \
 		--apiPort=1204 \
-		--useNativeXmrWallet=false \
 		--ignoreLocalXmrNode=false \
 
 buyer-wallet-mainnet:

--- a/common/src/main/java/haveno/common/config/Config.java
+++ b/common/src/main/java/haveno/common/config/Config.java
@@ -210,6 +210,7 @@ public class Config {
     public final String xmrNodePassword;
     public final String xmrNodes;
     public final boolean useNativeXmrWallet;
+    public final boolean useNativeXmrWalletOptionSetExplicitly;
     public final boolean xmrStreamIsolation;
     public final UseTorForXmr useTorForXmr;
     public final boolean useTorForXmrOptionSetExplicitly;
@@ -605,7 +606,7 @@ public class Config {
                         .defaultsTo("");
 
         ArgumentAcceptingOptionSpec<Boolean> useNativeXmrWalletOpt =
-                parser.accepts(USE_NATIVE_XMR_WALLET, "Use native wallet libraries instead of monero-wallet-rpc server")
+                parser.accepts(USE_NATIVE_XMR_WALLET, "Use the native Monero wallet library instead of monero-wallet-rpc (overrides the setting in the UI)")
                         .withRequiredArg()
                         .ofType(boolean.class)
                         .defaultsTo(false);
@@ -816,6 +817,7 @@ public class Config {
             this.xmrNodePassword = options.valueOf(xmrNodePasswordOpt);
             this.xmrNodes = options.valueOf(xmrNodesOpt);
             this.useNativeXmrWallet = options.valueOf(useNativeXmrWalletOpt);
+            this.useNativeXmrWalletOptionSetExplicitly = options.has(useNativeXmrWalletOpt);
             this.xmrStreamIsolation = options.valueOf(xmrStreamIsolationOpt);
             this.useTorForXmr = (UseTorForXmr) options.valueOf(useTorForXmrOpt);
             this.useTorForXmrOptionSetExplicitly = options.has(useTorForXmrOpt);

--- a/core/src/main/java/haveno/core/user/Preferences.java
+++ b/core/src/main/java/haveno/core/user/Preferences.java
@@ -298,6 +298,9 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
         if (config.useTorForXmrOptionSetExplicitly)
             setUseTorForXmr(config.useTorForXmr);
 
+        if (config.useNativeXmrWalletOptionSetExplicitly)
+            setUseNativeXmrWallet(config.useNativeXmrWallet);
+
         // switch to public nodes if no provided nodes available
         boolean isFixedConnection = !"".equals(config.xmrNode) && (!NetworkUtils.isLocalHost(config.xmrNode) || !config.ignoreLocalXmrNode);
         if (!isFixedConnection && getMoneroNodesOptionOrdinal() == XmrNodes.MoneroNodesOption.PROVIDED.ordinal() && xmrNodes.selectPreferredNodes(new XmrNodesSetupPreferences(this)).isEmpty()) {
@@ -552,6 +555,11 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     public void setSplitOfferOutput(boolean splitOfferOutput) {
         prefPayload.setSplitOfferOutput(splitOfferOutput);
+        requestPersistence();
+    }
+
+    public void setUseNativeXmrWallet(boolean useNativeXmrWallet) {
+        prefPayload.setUseNativeXmrWallet(useNativeXmrWallet);
         requestPersistence();
     }
 
@@ -997,6 +1005,8 @@ public final class Preferences implements PersistedDataHost, BridgeAddressProvid
 
     private interface ExcludesDelegateMethods {
         void setTacAccepted(boolean tacAccepted);
+
+        void setUseNativeXmrWallet(boolean useNativeXmrWallet);
 
         void setUseAnimations(boolean useAnimations);
 

--- a/core/src/main/java/haveno/core/user/PreferencesPayload.java
+++ b/core/src/main/java/haveno/core/user/PreferencesPayload.java
@@ -156,6 +156,7 @@ public final class PreferencesPayload implements PersistableEnvelope {
     private XmrNodeSettings xmrNodeSettings = new XmrNodeSettings();
     private boolean depositAddressesExpanded;
     private boolean tacAcceptedV190;
+    private boolean useNativeXmrWallet;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -231,7 +232,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 .setDenyApiTaker(denyApiTaker)
                 .setNotifyOnPreRelease(notifyOnPreRelease)
                 .setDepositAddressesExpanded(depositAddressesExpanded)
-                .setTacAcceptedV190(tacAcceptedV190);
+                .setTacAcceptedV190(tacAcceptedV190)
+                .setUseNativeXmrWallet(useNativeXmrWallet);
 
         Optional.ofNullable(backupDirectory).ifPresent(builder::setBackupDirectory);
         Optional.ofNullable(preferredTradeCurrency).ifPresent(e -> builder.setPreferredTradeCurrency((protobuf.TradeCurrency) e.toProtoMessage()));
@@ -358,7 +360,8 @@ public final class PreferencesPayload implements PersistableEnvelope {
                 proto.getNotifyOnPreRelease(),
                 XmrNodeSettings.fromProto(proto.getXmrNodeSettings()),
                 proto.getDepositAddressesExpanded(),
-                proto.getTacAcceptedV190()
+                proto.getTacAcceptedV190(),
+                proto.getUseNativeXmrWallet()
         );
     }
 }

--- a/core/src/main/java/haveno/core/xmr/XmrModule.java
+++ b/core/src/main/java/haveno/core/xmr/XmrModule.java
@@ -92,7 +92,6 @@ public class XmrModule extends AppModule {
         bindConstant().annotatedWith(named(Config.XMR_NODE_USERNAME)).to(config.xmrNodeUsername);
         bindConstant().annotatedWith(named(Config.XMR_NODE_PASSWORD)).to(config.xmrNodePassword);
         bindConstant().annotatedWith(named(Config.XMR_NODES)).to(config.xmrNodes);
-        bindConstant().annotatedWith(named(Config.USE_NATIVE_XMR_WALLET)).to(config.useNativeXmrWallet);
         bindConstant().annotatedWith(named(Config.USER_AGENT)).to(config.userAgent);
         bindConstant().annotatedWith(named(Config.NUM_CONNECTIONS_FOR_BTC)).to(config.numConnectionsForBtc);
         bindConstant().annotatedWith(named(Config.USE_ALL_PROVIDED_NODES)).to(config.useAllProvidedNodes);

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
@@ -156,7 +156,6 @@ public class XmrWalletService extends XmrWalletBase {
 
     private final File walletDir;
     private final int rpcBindPort;
-    private final boolean useNativeXmrWallet;
     protected final CopyOnWriteArraySet<XmrBalanceListener> balanceListeners = new CopyOnWriteArraySet<>();
     protected final CopyOnWriteArraySet<MoneroWalletListenerI> walletListeners = new CopyOnWriteArraySet<>();
 
@@ -198,8 +197,7 @@ public class XmrWalletService extends XmrWalletBase {
                      WalletsSetup walletsSetup,
                      XmrAddressEntryList xmrAddressEntryList,
                      @Named(Config.WALLET_DIR) File walletDir,
-                     @Named(Config.WALLET_RPC_BIND_PORT) int rpcBindPort,
-                     @Named(Config.USE_NATIVE_XMR_WALLET) boolean useNativeXmrWallet) {
+                     @Named(Config.WALLET_RPC_BIND_PORT) int rpcBindPort) {
         this.user = user;
         this.preferences = preferences;
         this.accountService = accountService;
@@ -207,7 +205,6 @@ public class XmrWalletService extends XmrWalletBase {
         this.xmrAddressEntryList = xmrAddressEntryList;
         this.walletDir = walletDir;
         this.rpcBindPort = rpcBindPort;
-        this.useNativeXmrWallet = useNativeXmrWallet;
         this.xmrConnectionService = xmrConnectionService; // TODO: super's is null unless set here from injection
         HavenoUtils.xmrWalletService = this;
         MONERO_WALLET_RPC_MANAGER.onStartUp(); // clear the shared manager's shutdown state, which persists across in-process restarts
@@ -368,7 +365,7 @@ public class XmrWalletService extends XmrWalletBase {
 
     /** Check whether the seed is a valid wallet seed, using an offline temporary wallet (native or RPC). */
     public boolean isSeedValid(String seed) {
-        if (useNativeXmrWallet) MoneroUtils.tryLoadNativeLibrary();
+        if (isUseNativeXmrWallet()) MoneroUtils.tryLoadNativeLibrary();
         synchronized (seedValidationLock) {
             return isNativeLibraryApplied() ? isSeedValidNative(seed) : isSeedValidRpc(seed);
         }
@@ -376,7 +373,7 @@ public class XmrWalletService extends XmrWalletBase {
 
     /** Preload the native library and wallet creation path so the first seed validation is fast. */
     public void warmUpSeedValidation() {
-        if (!useNativeXmrWallet) return; // rpc validation starts a new process per check, so nothing to warm
+        if (!isUseNativeXmrWallet()) return; // rpc validation starts a new process per check, so nothing to warm
         MoneroUtils.tryLoadNativeLibrary();
         if (!isNativeLibraryApplied()) return;
         synchronized (seedValidationLock) {
@@ -501,8 +498,12 @@ public class XmrWalletService extends XmrWalletBase {
         return walletPath.substring(walletPath.lastIndexOf(File.separator) + 1);
     }
 
+    private boolean isUseNativeXmrWallet() {
+        return preferences.isUseNativeXmrWallet();
+    }
+
     private boolean isNativeLibraryApplied() {
-        return useNativeXmrWallet && MoneroUtils.isNativeLibraryLoaded();
+        return isUseNativeXmrWallet() && MoneroUtils.isNativeLibraryLoaded();
     }
 
     public void closeWallet(MoneroWallet wallet, boolean save) {
@@ -1550,7 +1551,7 @@ public class XmrWalletService extends XmrWalletBase {
     private void initialize() {
 
         // try to load native monero library
-        if (useNativeXmrWallet && !MoneroUtils.isNativeLibraryLoaded()) {
+        if (isUseNativeXmrWallet() && !MoneroUtils.isNativeLibraryLoaded()) {
             try {
                 MoneroUtils.loadNativeLibrary();
             } catch (Exception | UnsatisfiedLinkError e) {
@@ -1558,7 +1559,7 @@ public class XmrWalletService extends XmrWalletBase {
             }
         }
         String appliedMsg = "Monero native libraries applied: " + isNativeLibraryApplied();
-        if (useNativeXmrWallet && !isNativeLibraryApplied()) log.warn(appliedMsg);
+        if (isUseNativeXmrWallet() && !isNativeLibraryApplied()) log.warn(appliedMsg);
         else log.info(appliedMsg);
 
         // listen for connection changes

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1322,6 +1322,10 @@ setting.preferences.explorer=Monero Explorer
 setting.preferences.deviation=Max. deviation from market price
 setting.preferences.avoidStandbyMode=Avoid standby mode
 setting.preferences.useSoundForNotifications=Play sounds for notifications
+setting.preferences.useNativeXmrWallet=Use native wallet (experimental)
+setting.preferences.useNativeXmrWallet.info=Run wallets inside the Haveno process using native wallet libraries, \
+  instead of running monero-wallet-rpc in the background. This is generally faster and uses less resources, \
+  but is still experimental. Requires a restart to apply.
 setting.preferences.autoConfirmXMR=XMR auto-confirm
 setting.preferences.autoConfirmEnabled=Enabled
 setting.preferences.autoConfirmRequiredConfirmations=Required confirmations

--- a/desktop/src/main/java/haveno/desktop/components/controlsfx/control/PopOver.java
+++ b/desktop/src/main/java/haveno/desktop/components/controlsfx/control/PopOver.java
@@ -583,7 +583,11 @@ public class PopOver extends PopupControl {
     }
 
     private double computeYOffset() {
-        double prefContentHeight = getContentNode().prefHeight(-1);
+        // use the laid-out skin height when shown, since the arrow is drawn on the actual bubble
+        // (content plus padding); prefHeight(-1) is the unwrapped single-line height for
+        // wrapping content, which misplaces multi-line pop overs
+        double skinHeight = getSkin() != null ? getSkin().getNode().getLayoutBounds().getHeight() : 0;
+        double prefContentHeight = skinHeight > 0 ? skinHeight : getContentNode().prefHeight(-1);
 
         switch (getArrowLocation()) {
             case LEFT_TOP:

--- a/desktop/src/main/java/haveno/desktop/main/settings/preferences/PreferencesView.java
+++ b/desktop/src/main/java/haveno/desktop/main/settings/preferences/PreferencesView.java
@@ -19,6 +19,7 @@ package haveno.desktop.main.settings.preferences;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
 import haveno.common.UserThread;
 import haveno.common.app.DevEnv;
 import haveno.common.config.Config;
@@ -47,11 +48,14 @@ import haveno.core.util.ParsingUtils;
 import haveno.core.util.validation.IntegerValidator;
 import haveno.core.util.validation.RegexValidator;
 import haveno.core.util.validation.RegexValidatorFactory;
+import haveno.desktop.app.HavenoApp;
 import haveno.desktop.common.view.ActivatableViewAndModel;
 import haveno.desktop.common.view.FxmlView;
 import haveno.desktop.components.AutoTooltipButton;
 import haveno.desktop.components.AutoTooltipLabel;
+import haveno.desktop.components.AutoTooltipSlideToggleButton;
 import haveno.desktop.components.AutocompleteComboBox;
+import haveno.desktop.components.InfoAutoTooltipLabel;
 import haveno.desktop.components.InputTextField;
 import haveno.desktop.components.PasswordTextField;
 import haveno.desktop.components.TitledGroupBg;
@@ -82,9 +86,11 @@ import javafx.collections.ObservableList;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
+import javafx.geometry.Pos;
 import javafx.geometry.VPos;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
@@ -95,6 +101,7 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
@@ -110,7 +117,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
     private AutocompleteComboBox<TradeCurrency> preferredTradeCurrencyComboBox;
 
     private ToggleButton showOwnOffersInOfferBook, useAnimations, useDarkMode, sortMarketCurrenciesNumerically,
-            avoidStandbyMode, useSoundForNotifications, useCustomFee, autoConfirmXmrToggle, hideNonAccountPaymentMethodsToggle, denyApiTakerToggle,
+            avoidStandbyMode, useSoundForNotifications, useNativeXmrWallet, useCustomFee, autoConfirmXmrToggle, hideNonAccountPaymentMethodsToggle, denyApiTakerToggle,
             notifyOnPreReleaseToggle;
     private int gridRow = 0;
     private int displayCurrenciesGridRowIndex = 0;
@@ -240,7 +247,7 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         GridPane.setValignment(optionsGridPane, VPos.TOP);
         root.add(optionsGridPane, 0, 0);
 
-        int titledGroupBgRowSpan = displayStandbyModeFeature ? 8 : 7;
+        int titledGroupBgRowSpan = displayStandbyModeFeature ? 9 : 8;
         TitledGroupBg titledGroupBg = addTitledGroupBg(optionsGridPane, gridRow, titledGroupBgRowSpan, Res.get("setting.preferences.general"));
         GridPane.setColumnSpan(titledGroupBg, 1);
 
@@ -314,6 +321,15 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
 
         useSoundForNotifications = addSlideToggleButton(optionsGridPane, ++gridRow,
                 Res.get("setting.preferences.useSoundForNotifications"));
+
+        useNativeXmrWallet = new AutoTooltipSlideToggleButton();
+        useNativeXmrWallet.setText(Res.get("setting.preferences.useNativeXmrWallet"));
+        InfoAutoTooltipLabel useNativeXmrWalletInfo = new InfoAutoTooltipLabel("", FontAwesomeIcon.INFO_CIRCLE, ContentDisplay.RIGHT,
+                Res.get("setting.preferences.useNativeXmrWallet.info"), 420);
+        HBox useNativeXmrWalletBox = new HBox(6, useNativeXmrWallet, useNativeXmrWalletInfo);
+        useNativeXmrWalletBox.setAlignment(Pos.CENTER_LEFT);
+        GridPane.setRowIndex(useNativeXmrWalletBox, ++gridRow);
+        optionsGridPane.getChildren().add(useNativeXmrWalletBox);
     }
 
     private void initializeSeparator() {
@@ -843,6 +859,20 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
 
         useSoundForNotifications.setSelected(preferences.isUseSoundForNotifications());
         useSoundForNotifications.setOnAction(e -> preferences.setUseSoundForNotifications(useSoundForNotifications.isSelected()));
+
+        useNativeXmrWallet.setSelected(preferences.isUseNativeXmrWallet());
+        useNativeXmrWallet.setOnAction(e -> {
+            boolean selected = useNativeXmrWallet.isSelected();
+            new Popup().information(Res.get("settings.net.needRestart"))
+                    .actionButtonText(Res.get("shared.applyAndShutDown"))
+                    .onAction(() -> {
+                        preferences.setUseNativeXmrWallet(selected);
+                        UserThread.runAfter(HavenoApp.getShutDownHandler(), 500, TimeUnit.MILLISECONDS);
+                    })
+                    .closeButtonText(Res.get("shared.cancel"))
+                    .onClose(() -> useNativeXmrWallet.setSelected(preferences.isUseNativeXmrWallet()))
+                    .show();
+        });
     }
 
     private void activateAutoConfirmPreferences() {
@@ -896,6 +926,8 @@ public class PreferencesView extends ActivatableViewAndModel<GridPane, Preferenc
         if (displayStandbyModeFeature) {
             avoidStandbyMode.setOnAction(null);
         }
+        useSoundForNotifications.setOnAction(null);
+        useNativeXmrWallet.setOnAction(null);
     }
 
     private void deactivateAutoConfirmPreferences() {

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1954,6 +1954,7 @@ message PreferencesPayload {
     string sell_screen_other_payment_method_id = 77;
     bool deposit_addresses_expanded = 78;
     bool tac_accepted_v190 = 79;
+    bool use_native_xmr_wallet = 80;
 }
 
 message AutoConfirmSettings {


### PR DESCRIPTION
Persist useNativeXmrWallet as a preference with a restart toggle in preferences, overridden by --useNativeXmrWallet when set explicitly.