### PR TITLE
desktop: fix trades chart bars rendering at full height on load

### DIFF
--- a/desktop/src/main/java/haveno/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/haveno/desktop/main/market/trades/TradesChartsView.java
@@ -456,6 +456,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         priceAxisY = new NumberAxis();
         priceAxisY.setForceZeroInRange(false);
         priceAxisY.setAutoRanging(true);
+        priceAxisY.setAnimated(false); // range animation renders candles at full height until settled
         priceAxisY.setTickLabelFormatter(new StringConverter<>() {
             @Override
             public String toString(Number object) {
@@ -552,6 +553,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
         axisY.setForceZeroInRange(true);
         axisY.setAutoRanging(true);
+        axisY.setAnimated(false); // range animation renders bars at full height until settled
         axisY.setLabel(Res.get("shared.volumeWithCur", currency));
         axisY.setTickLabelFormatter(new StringConverter<>() {
             @Override

--- a/desktop/src/main/java/haveno/desktop/main/market/trades/charts/price/CandleStickChart.java
+++ b/desktop/src/main/java/haveno/desktop/main/market/trades/charts/price/CandleStickChart.java
@@ -52,7 +52,6 @@ package haveno.desktop.main.market.trades.charts.price;
 import haveno.desktop.main.market.trades.charts.CandleData;
 import haveno.desktop.main.market.trades.charts.PlotAreaTooltip;
 import javafx.animation.FadeTransition;
-import javafx.event.ActionEvent;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.chart.Axis;
@@ -206,20 +205,9 @@ public class CandleStickChart extends XYChart<Number, Number> {
             seriesPath.getElements().clear();
         }
 
-        final Node node = item.getNode();
-        if (shouldAnimate()) {
-            // fade out old candle
-            FadeTransition ft = new FadeTransition(Duration.millis(500), node);
-            ft.setToValue(0);
-            ft.setOnFinished((ActionEvent actionEvent) -> {
-                getPlotChildren().remove(node);
-                removeDataItemFromDisplay(series, item);
-            });
-            ft.play();
-        } else {
-            getPlotChildren().remove(node);
-            removeDataItemFromDisplay(series, item);
-        }
+        // remove immediately; fading out would render stale candles against the new axis range
+        getPlotChildren().remove(item.getNode());
+        removeDataItemFromDisplay(series, item);
     }
 
     @Override
@@ -259,37 +247,16 @@ public class CandleStickChart extends XYChart<Number, Number> {
     @Override
     protected void seriesRemoved(XYChart.Series<Number, Number> series) {
         legendWidthInvalid = true;
-        // remove all candle nodes
+        // remove immediately; fading out would render stale candles against the new axis range
         for (XYChart.Data<Number, Number> d : series.getData()) {
-            final Node candle = d.getNode();
-            if (shouldAnimate()) {
-                FadeTransition ft = new FadeTransition(Duration.millis(500), candle);
-                ft.setToValue(0);
-                ft.setOnFinished((ActionEvent actionEvent) -> getPlotChildren().remove(candle));
-                ft.play();
-            } else {
-                getPlotChildren().remove(candle);
-            }
+            getPlotChildren().remove(d.getNode());
         }
         if (series.getNode() instanceof Path) {
             Path seriesPath = (Path) series.getNode();
-            if (shouldAnimate()) {
-                FadeTransition ft = new FadeTransition(Duration.millis(500), seriesPath);
-                ft.setToValue(0);
-                ft.setOnFinished((ActionEvent actionEvent) -> {
-                    getPlotChildren().remove(seriesPath);
-                    seriesPath.getElements().clear();
-                    removeSeriesFromDisplay(series);
-                });
-                ft.play();
-            } else {
-                getPlotChildren().remove(seriesPath);
-                seriesPath.getElements().clear();
-                removeSeriesFromDisplay(series);
-            }
-        } else {
-            removeSeriesFromDisplay(series);
+            getPlotChildren().remove(seriesPath);
+            seriesPath.getElements().clear();
         }
+        removeSeriesFromDisplay(series);
     }
 
     /**

--- a/desktop/src/main/java/haveno/desktop/main/market/trades/charts/volume/VolumeChart.java
+++ b/desktop/src/main/java/haveno/desktop/main/market/trades/charts/volume/VolumeChart.java
@@ -20,9 +20,6 @@ package haveno.desktop.main.market.trades.charts.volume;
 import haveno.desktop.main.market.trades.charts.CandleData;
 import haveno.desktop.main.market.trades.charts.PlotAreaTooltip;
 import javafx.animation.FadeTransition;
-import javafx.animation.KeyFrame;
-import javafx.animation.Timeline;
-import javafx.event.ActionEvent;
 import javafx.scene.Node;
 import javafx.scene.chart.Axis;
 import javafx.scene.chart.NumberAxis;
@@ -106,19 +103,9 @@ public class VolumeChart extends XYChart<Number, Number> {
 
     @Override
     protected void dataItemRemoved(XYChart.Data<Number, Number> item, XYChart.Series<Number, Number> series) {
-        final Node node = item.getNode();
-        if (shouldAnimate()) {
-            FadeTransition ft = new FadeTransition(Duration.millis(500), node);
-            ft.setToValue(0);
-            ft.setOnFinished((ActionEvent actionEvent) -> {
-                getPlotChildren().remove(node);
-                removeDataItemFromDisplay(series, item);
-            });
-            ft.play();
-        } else {
-            getPlotChildren().remove(node);
-            removeDataItemFromDisplay(series, item);
-        }
+        // remove immediately; fading out would render stale bars against the new axis range
+        getPlotChildren().remove(item.getNode());
+        removeDataItemFromDisplay(series, item);
     }
 
     @Override
@@ -140,22 +127,11 @@ public class VolumeChart extends XYChart<Number, Number> {
 
     @Override
     protected void seriesRemoved(XYChart.Series<Number, Number> series) {
+        // remove immediately; fading out would render stale bars against the new axis range
         for (XYChart.Data<Number, Number> d : series.getData()) {
-            final Node volumeBar = d.getNode();
-            if (shouldAnimate()) {
-                FadeTransition ft = new FadeTransition(Duration.millis(500), volumeBar);
-                ft.setToValue(0);
-                ft.setOnFinished((ActionEvent actionEvent) -> getPlotChildren().remove(volumeBar));
-                ft.play();
-            } else {
-                getPlotChildren().remove(volumeBar);
-            }
+            getPlotChildren().remove(d.getNode());
         }
-        if (shouldAnimate()) {
-            new Timeline(new KeyFrame(Duration.millis(500), event -> removeSeriesFromDisplay(series))).play();
-        } else {
-            removeSeriesFromDisplay(series);
-        }
+        removeSeriesFromDisplay(series);
     }
 
     private Node createCandle(int seriesIndex, final XYChart.Data<Number, Number> item, int itemIndex) {


### PR DESCRIPTION
Disable y-axis range animation so bars and candles are not drawn against the animating range when data first loads.