### PR TITLE
p2p: purge and blocklist peers detected on a wrong P2P network

### DIFF
--- a/p2p/src/main/java/haveno/network/p2p/network/Connection.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/Connection.java
@@ -93,6 +93,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -186,6 +187,8 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
     @Getter
     private RuleViolation ruleViolation;
+    // ensures the peer failure counter is adjusted at most once, as onDisconnect can fire more than once
+    private final AtomicBoolean peerFaultAccounted = new AtomicBoolean();
     private final ConcurrentHashMap<RuleViolation, Integer> ruleViolations = new ConcurrentHashMap<>();
 
     private final Capabilities capabilities = new Capabilities();
@@ -791,6 +794,11 @@ public class Connection implements HasCapabilities, Runnable, MessageListener {
 
     public boolean reportInvalidRequest(RuleViolation ruleViolation, String errorMessage) {
         return Connection.reportInvalidRequest(this, ruleViolation, errorMessage);
+    }
+
+    // true the first time only, so the peer failure counter is adjusted once per connection
+    public boolean tryAccountPeerFault() {
+        return peerFaultAccounted.compareAndSet(false, true);
     }
 
     private static synchronized boolean reportInvalidRequest(Connection connection, RuleViolation ruleViolation, String errorMessage) {

--- a/p2p/src/main/java/haveno/network/p2p/network/Statistic.java
+++ b/p2p/src/main/java/haveno/network/p2p/network/Statistic.java
@@ -243,6 +243,10 @@ public class Statistic {
         return sentBytesProperty;
     }
 
+    public long getReceivedBytes() {
+        return receivedBytes.get();
+    }
+
     public long getReceivedBytesProperty() {
         return receivedBytesProperty.get();
     }

--- a/p2p/src/main/java/haveno/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/PeerManager.java
@@ -35,6 +35,7 @@ import haveno.network.p2p.network.Connection;
 import haveno.network.p2p.network.ConnectionListener;
 import haveno.network.p2p.network.InboundConnection;
 import haveno.network.p2p.network.NetworkNode;
+import haveno.network.p2p.network.OutboundConnection;
 import haveno.network.p2p.network.PeerType;
 import haveno.network.p2p.network.RuleViolation;
 import haveno.network.p2p.peers.peerexchange.Peer;
@@ -44,9 +45,12 @@ import haveno.network.utils.EventThrottler;
 import haveno.network.utils.EventThrottler.ThrottleResult;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -118,6 +122,9 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
     private final Set<Peer> reportedPeers = new HashSet<>();
     // Most recent peers with activity date of last 30 min.
     private final Set<Peer> latestLivePeers = new HashSet<>();
+    // Peers detected on a different P2P network; never dialed or re-added, bounded with eldest-first eviction
+    private static final int MAX_WRONG_NETWORK_PEERS = 2000;
+    private final Set<NodeAddress> wrongNetworkPeers = Collections.synchronizedSet(new LinkedHashSet<>());
 
     private Timer checkMaxConnectionsTimer;
     private boolean stopped;
@@ -231,9 +238,6 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
                 listeners.forEach(Listener::onNewConnectionAfterAllConnectionsLost);
             }
         }
-        connection.getPeersNodeAddressOptional()
-                .flatMap(this::findPeer)
-                .ifPresent(Peer::onConnection);
     }
 
     @Override
@@ -241,6 +245,19 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
         log.debug("onDisconnect called: nodeAddress={}, closeConnectionReason={}",
                 connection.getPeersNodeAddressOptional(), closeConnectionReason);
         handleConnectionFault(connection);
+
+        // score the persisted peer once per outbound dial: received bytes prove it usable, an unintended
+        // zero-byte close accrues a failure so unusable peers purge; inbound addresses are unverified
+        if (connection instanceof OutboundConnection && connection.tryAccountPeerFault()) {
+            connection.getPeersNodeAddressOptional().flatMap(this::findPersistedPeer).ifPresent(peer -> {
+                if (connection.getStatistic().getReceivedBytes() > 0) {
+                    peer.onConnection();
+                } else if (!closeConnectionReason.isIntended) {
+                    peer.onDisconnect();
+                    if (peer.tooManyFailedConnectionAttempts()) removePersistedPeer(peer.getNodeAddress());
+                }
+            });
+        }
 
         boolean previousLostAllConnections = lostAllConnections;
         lostAllConnections = networkNode.getAllConnections().isEmpty();
@@ -290,19 +307,17 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
     }
 
     public void handleConnectionFault(NodeAddress nodeAddress, @Nullable Connection connection) {
-        boolean doRemovePersistedPeer = false;
-        // with no connections at all the fault reflects our own connectivity (e.g. OS standby),
-        // not the peer's, so we do not penalize the peer
-        boolean isOffline = networkNode.getAllConnections().isEmpty();
+        // inbound faults are no evidence against the peer, whose address is an unverified claim
+        if (connection instanceof InboundConnection) return;
+        // the peer failure counter is adjusted only at onDisconnect by outbound connection outcomes
+        boolean isOffline = connection == null && networkNode.getAllConnections().isEmpty();
         if (!isOffline) removeReportedPeer(nodeAddress);
-        Optional<Peer> persistedPeerOptional = findPersistedPeer(nodeAddress);
-        if (persistedPeerOptional.isPresent() && !isOffline) {
-            Peer persistedPeer = persistedPeerOptional.get();
-            persistedPeer.onDisconnect();
-            doRemovePersistedPeer = persistedPeer.tooManyFailedConnectionAttempts();
-        }
         boolean ruleViolation = connection != null && connection.getRuleViolation() != null;
-        doRemovePersistedPeer = doRemovePersistedPeer || ruleViolation;
+        boolean doRemovePersistedPeer = ruleViolation ||
+                findPersistedPeer(nodeAddress).map(Peer::tooManyFailedConnectionAttempts).orElse(false);
+
+        // never dial or re-add peers detected on a different P2P network
+        if (connection != null && connection.getRuleViolation() == RuleViolation.WRONG_NETWORK_ID) blocklistWrongNetworkPeer(nodeAddress);
 
         if (doRemovePersistedPeer)
             removePersistedPeer(nodeAddress);
@@ -320,6 +335,22 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
                 synchronized (reportedPeers) {
                     reportedPeers.removeIf(peer -> peer.getNodeAddress().equals(optionalNodeAddress.get()));
                 }
+            }
+        }
+    }
+
+    public boolean isWrongNetworkPeer(NodeAddress nodeAddress) {
+        return wrongNetworkPeers.contains(nodeAddress);
+    }
+
+    private void blocklistWrongNetworkPeer(NodeAddress nodeAddress) {
+        synchronized (wrongNetworkPeers) {
+            wrongNetworkPeers.remove(nodeAddress); // re-insert so eviction order tracks the latest detection
+            wrongNetworkPeers.add(nodeAddress);
+            if (wrongNetworkPeers.size() > MAX_WRONG_NETWORK_PEERS) {
+                Iterator<NodeAddress> it = wrongNetworkPeers.iterator();
+                it.next();
+                it.remove();
             }
         }
     }
@@ -395,29 +426,29 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
                                    Capabilities capabilities) {
         applyCapabilities(connection, capabilities);
 
+        // an oversized list is a rule violation which shuts down the connection on the 2nd offense;
+        // check the raw count before filtering, so filtered-out entries cannot mask an oversized list
+        if (reportedPeersToAdd.size() > (MAX_REPORTED_PEERS + maxConnectionsAbsolute + 10)) {
+            connection.reportInvalidRequest(RuleViolation.TOO_MANY_REPORTED_PEERS_SENT, "Too many reported peers sent");
+            return;
+        }
+
         Set<Peer> peers = reportedPeersToAdd.stream()
                 .filter(peer -> !isSelf(peer.getNodeAddress()))
+                .filter(peer -> !wrongNetworkPeers.contains(peer.getNodeAddress()))
                 .collect(Collectors.toSet());
 
         printNewReportedPeers(peers);
 
-        // We check if the reported msg is not violating our rules
-        if (peers.size() <= (MAX_REPORTED_PEERS + maxConnectionsAbsolute + 10)) {
-            synchronized (reportedPeers) {
-                reportedPeers.addAll(peers);
-                purgeReportedPeersIfExceeds();
+        synchronized (reportedPeers) {
+            reportedPeers.addAll(peers);
+            purgeReportedPeersIfExceeds();
 
-                peerList.addAll(peers);
-                purgePersistedPeersIfExceeds();
-                requestPersistence();
+            peerList.addAll(peers);
+            purgePersistedPeersIfExceeds();
+            requestPersistence();
 
-                printReportedPeers();
-            }
-        } else {
-            // If a node is trying to send too many list we treat it as rule violation.
-            // Reported list include the connected list. We use the max value and give some extra headroom.
-            // Will trigger a shutdown after 2nd time sending too much
-            connection.reportInvalidRequest(RuleViolation.TOO_MANY_REPORTED_PEERS_SENT, "Too many reported peers sent");
+            printReportedPeers();
         }
     }
 

--- a/p2p/src/main/java/haveno/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/getdata/RequestDataManager.java
@@ -568,7 +568,8 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
     private List<NodeAddress> getFilteredList(Collection<NodeAddress> collection, List<NodeAddress> list) {
         return collection.stream()
                 .filter(e -> !list.contains(e) &&
-                        !peerManager.isSelf(e))
+                        !peerManager.isSelf(e) &&
+                        !peerManager.isWrongNetworkPeer(e))
                 .collect(Collectors.toList());
     }
 

--- a/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/Peer.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/Peer.java
@@ -82,7 +82,8 @@ public final class Peer implements HasCapabilities, NetworkPayload, PersistableP
     }
 
     public void onConnection() {
-        this.failedConnectionAttempts--;
+        // floor at zero so a peer cannot bank credit to resist later purging
+        if (failedConnectionAttempts > 0) this.failedConnectionAttempts--;
     }
 
     public boolean tooManyFailedConnectionAttempts() {

--- a/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/PeerExchangeManager.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/PeerExchangeManager.java
@@ -356,7 +356,8 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
         return collection.stream()
                 .filter(e -> !list.contains(e) &&
                         !peerManager.isSelf(e) &&
-                        !peerManager.isConfirmed(e))
+                        !peerManager.isConfirmed(e) &&
+                        !peerManager.isWrongNetworkPeer(e))
                 .collect(Collectors.toList());
     }
 

--- a/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/PeerList.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/PeerList.java
@@ -68,7 +68,12 @@ public class PeerList implements PersistableEnvelope {
 
     public void addAll(Collection<Peer> collection) {
         synchronized (map) {
-            collection.forEach(peer -> this.map.put(peer.getNodeAddress().toString(), peer));
+            collection.forEach(peer -> {
+                // carry over the transient failure counter, else re-adding a known peer resets it
+                Peer existing = map.get(peer.getNodeAddress().toString());
+                if (existing != null) peer.setFailedConnectionAttempts(existing.getFailedConnectionAttempts());
+                this.map.put(peer.getNodeAddress().toString(), peer);
+            });
         }
     }
 


### PR DESCRIPTION
Stop dialing peers detected on a wrong P2P network and count silent zero-byte dials as connection failures so stale cross-network peers purge instead of churning forever.