### PR TITLE
common: handle SIGINT and SIGTERM before the JVM shutdown sequence

### DIFF
--- a/common/src/main/java/haveno/common/setup/CommonSetup.java
+++ b/common/src/main/java/haveno/common/setup/CommonSetup.java
@@ -29,6 +29,7 @@ import haveno.common.util.Utilities;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.bitcoinj.store.BlockStoreException;
+import sun.misc.Signal;
 
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
@@ -41,7 +42,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 public class CommonSetup {
+    private static final int SHUTDOWN_WATCHDOG_MINUTES = 4;
     private static final AtomicBoolean exitScheduled = new AtomicBoolean();
+    private static final AtomicBoolean shutdownSignalReceived = new AtomicBoolean();
     private static volatile Thread shutdownHook;
 
     // throttle repeated exceptions per throw site so a hot loop cannot fill the logs:
@@ -160,6 +163,18 @@ public class CommonSetup {
     }
 
     protected static void setupShutdownHandler(GracefulShutDownHandler gracefulShutDownHandler) {
+        // handle INT and TERM before the JVM shutdown sequence starts, as concurrent shutdown hooks
+        // tear down JavaFX and the UserThread then silently drops the graceful shutdown task
+        for (String signalName : new String[]{"INT", "TERM"}) {
+            Signal.handle(new Signal(signalName), signal -> {
+                log.info("Received {}", signal);
+                startShutdownWatchdog();
+                UserThread.execute(() -> gracefulShutDownHandler.gracefulShutDown(() -> {
+                }));
+            });
+        }
+
+        // fallback for termination paths which bypass the signal handlers, e.g. System.exit
         // setup re-runs on in-process restart, so replace any hook of the previous executable
         removeShutdownHook();
         Thread hook = new Thread(() -> {
@@ -175,6 +190,26 @@ public class CommonSetup {
         }, "HavenoShutdownHook");
         Runtime.getRuntime().addShutdownHook(hook);
         shutdownHook = hook;
+    }
+
+    // Halts the process if a signal-initiated graceful shutdown does not complete in time,
+    // since the handled signals no longer trigger the JVM's own bounded shutdown sequence.
+    private static void startShutdownWatchdog() {
+        if (!shutdownSignalReceived.compareAndSet(false, true)) {
+            return;
+        }
+
+        Thread watchdog = new Thread(() -> {
+            try {
+                TimeUnit.MINUTES.sleep(SHUTDOWN_WATCHDOG_MINUTES);
+            } catch (InterruptedException e) {
+                return;
+            }
+            log.warn("Graceful shutdown did not complete within {} minutes, halting", SHUTDOWN_WATCHDOG_MINUTES);
+            Runtime.getRuntime().halt(1);
+        }, "HavenoShutdownWatchdog");
+        watchdog.setDaemon(true);
+        watchdog.start();
     }
 
     // Terminates the process after an application-initiated graceful shutdown. Removes the shutdown hook first,

--- a/core/src/main/java/haveno/core/app/HavenoExecutable.java
+++ b/core/src/main/java/haveno/core/app/HavenoExecutable.java
@@ -105,6 +105,7 @@ public abstract class HavenoExecutable implements GracefulShutDownHandler, Haven
     private final Object shutdownLock = new Object();
     private final List<ResultHandler> shutdownResultHandlers = new ArrayList<>();
     private boolean isShutdownComplete;
+    private boolean systemExitRequested;
     private boolean isReadOnly;
     private Thread keepRunningThread;
     private AtomicInteger keepRunningResult = new AtomicInteger(EXIT_SUCCESS);
@@ -337,7 +338,10 @@ public abstract class HavenoExecutable implements GracefulShutDownHandler, Haven
 
         // consume shutdownCompletedHandler so it runs once even when repeated requests join
         ResultHandler resultHandler;
+        boolean exitCompletedShutdown;
         synchronized (shutdownLock) {
+            systemExitRequested |= systemExit;
+            exitCompletedShutdown = isShutdownComplete && systemExit; // a completed shutdown cannot exit anymore
             Runnable completedHandler = shutdownCompletedHandler;
             shutdownCompletedHandler = null;
             resultHandler = completedHandler == null ? onShutdown : () -> {
@@ -348,12 +352,13 @@ public abstract class HavenoExecutable implements GracefulShutDownHandler, Haven
 
         // repeated requests join the shutdown in progress and get notified on completion
         if (!beginGracefulShutDown(resultHandler)) {
+            if (exitCompletedShutdown) CommonSetup.exitAfter(EXIT_SUCCESS, 100, TimeUnit.MILLISECONDS);
             return;
         }
 
         if (injector == null) {
             log.info("Shut down called before injector was created");
-            completeShutdown(EXIT_SUCCESS, systemExit);
+            completeShutdown(EXIT_SUCCESS);
             return;
         }
 
@@ -389,7 +394,7 @@ public abstract class HavenoExecutable implements GracefulShutDownHandler, Haven
                         // done shutting down
                         log.info("Graceful shutdown completed. Exiting now.");
                         module.close(injector);
-                        completeShutdown(EXIT_SUCCESS, systemExit);
+                        completeShutdown(EXIT_SUCCESS);
                     });
                 });
 
@@ -404,7 +409,7 @@ public abstract class HavenoExecutable implements GracefulShutDownHandler, Haven
             });
         } catch (Throwable t) {
             log.error("App shutdown failed with exception: {}\n", t.getMessage(), t);
-            completeShutdown(EXIT_FAILURE, systemExit);
+            completeShutdown(EXIT_FAILURE);
         }
     }
 
@@ -459,19 +464,26 @@ public abstract class HavenoExecutable implements GracefulShutDownHandler, Haven
         }
     }
 
-    private void completeShutdown(int exitCode, boolean systemExit) {
+    private void completeShutdown(int exitCode) {
         if (!isReadOnly) {
             // If user tried to downgrade we do not write the persistable data to avoid data corruption
             PersistenceManager.flushAllDataToDiskAtShutdown(() -> {
                 log.info("Graceful shutdown flushed persistence. Exiting now.");
                 notifyGracefulShutDownComplete();
-                if (systemExit)
+                if (isSystemExitRequested())
                     CommonSetup.exitAfter(exitCode, 100, TimeUnit.MILLISECONDS);
             });
         } else {
             notifyGracefulShutDownComplete();
-            if (systemExit)
+            if (isSystemExitRequested())
                 CommonSetup.exitAfter(exitCode, 100, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    // read after notifying completion so exit requests which joined the shutdown are honored
+    private boolean isSystemExitRequested() {
+        synchronized (shutdownLock) {
+            return systemExitRequested;
         }
     }
 


### PR DESCRIPTION
Restore sun.misc.Signal handlers so ctrl+c runs the graceful shutdown while JavaFX is alive, with a watchdog halting the JVM if it wedges. Joining shutdown requests propagate their system exit request.