### PR TITLE
core: guarantee monero-wallet-rpc termination when closing wallets

### DIFF
--- a/core/src/main/java/haveno/core/xmr/setup/MoneroWalletRpcManager.java
+++ b/core/src/main/java/haveno/core/xmr/setup/MoneroWalletRpcManager.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Manages monero-wallet-rpc processes bound to ports.
@@ -36,6 +37,8 @@ public class MoneroWalletRpcManager {
 
     private static final String RPC_BIND_PORT_ARGUMENT = "--rpc-bind-port";
     private static int NUM_ALLOWED_ATTEMPTS = 3; // allow this many attempts to bind to an assigned port
+    private static final long STOP_PROCESS_TIMEOUT_MS = 20000; // allow time to save the wallet before forcibly destroying, within the shutdown budget
+    private static final long DESTROY_FORCIBLY_TIMEOUT_MS = 10000; // bounded wait to reap the process after forcible destroy
     private Integer startPort;
     private volatile boolean isShutDownStarted;
     private final Map<Integer, MoneroWalletRpc> registeredPorts = new HashMap<>();
@@ -153,14 +156,36 @@ public class MoneroWalletRpcManager {
      */
     public void stopInstance(MoneroWalletRpc walletRpc, String path, boolean force) {
 
-        // unregister port
-        int port = unregisterPort(walletRpc);
+        // unregister port, always proceeding to stop the process
+        Integer port = null;
+        try {
+            port = unregisterPort(walletRpc);
+        } catch (Exception e) {
+            log.warn("Error unregistering monero-wallet-rpc port, path={}: {}", path, e.getMessage());
+        }
 
-        // stop process
-        String pid = walletRpc.getProcess() == null ? null : String.valueOf(walletRpc.getProcess().pid());
+        // stop process directly, since monero-java waits for exit without a timeout
+        Process process = walletRpc.getProcess();
+        String pid = process == null ? null : String.valueOf(process.pid());
         if (force) log.info("Stopping MoneroWalletRpc path={}, port={}, pid={}, force={}", path, port, pid, force);
         else log.debug("Stopping MoneroWalletRpc path={}, port={}, pid={}, force={}", path, port, pid, force);
-        walletRpc.stopProcess(force);
+        if (process == null) return;
+        try {
+            if (force) process.destroyForcibly();
+            else if (process.supportsNormalTermination()) process.destroy(); // else await natural exit, since destroy is forcible on windows
+            if (process.waitFor(force ? DESTROY_FORCIBLY_TIMEOUT_MS : STOP_PROCESS_TIMEOUT_MS, TimeUnit.MILLISECONDS)) return;
+
+            // forcibly destroy the process if it has not exited in time
+            if (!force) {
+                log.warn("Forcibly destroying monero-wallet-rpc process which did not stop within {} ms, path={}, pid={}", STOP_PROCESS_TIMEOUT_MS, path, pid);
+                process.destroyForcibly();
+                if (process.waitFor(DESTROY_FORCIBLY_TIMEOUT_MS, TimeUnit.MILLISECONDS)) return;
+            }
+            log.warn("monero-wallet-rpc process is still alive after forcible destroy, path={}, pid={}", path, pid);
+        } catch (InterruptedException e) {
+            process.destroyForcibly(); // escalate without waiting since the caller's budget is exhausted
+            Thread.currentThread().interrupt();
+        }
     }
 
     private int registerNextPort() throws IOException {

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
@@ -129,6 +129,7 @@ public class XmrWalletService extends XmrWalletBase {
     private static final boolean PRINT_RPC_STACK_TRACE = false;
     private static final long SHUTDOWN_TIMEOUT_MS = 60000;
     private static final long FORCE_CLOSE_TIMEOUT_MS = 15000; // bounded wait since native close can block draining a stalled network request
+    private static final long STOP_WALLET_RPC_TIMEOUT_MS = 20000; // bounded wait for wallet rpc to save and stop, within the shutdown budget
     private static final long PENDING_CLOSE_TIMEOUT_MS = 240000; // max wait to reopen, covering wallet2's 3.5 minute rpc timeout
     private static final long NUM_BLOCKS_BEHIND_TOLERANCE = 5;
     private static final long POLL_TXS_TOLERANCE_MS = 1000 * 60 * 3; // request connection switch if txs not updated within 3 minutes
@@ -509,20 +510,29 @@ public class XmrWalletService extends XmrWalletBase {
 
     public void closeWallet(MoneroWallet wallet, boolean save) {
         log.debug("Closing wallet with path={}, save={}", Utilities.redactSensitiveInfo(wallet.getPath()), save);
-        MoneroError err = null;
+        RuntimeException err = null;
         String path = wallet.getPath();
         try {
-            if (save && wallet instanceof MoneroWalletRpc) {
-                ((MoneroWalletRpc) wallet).stop(); // saves wallet and stops rpc server
+            if (wallet instanceof MoneroWalletRpc) {
+                // bound the request, which has no timeout and can block behind a stalled request
+                ThreadUtils.awaitTask(() -> {
+                    if (save) ((MoneroWalletRpc) wallet).stop(); // saves wallet and stops rpc server
+                    else wallet.close(false);
+                }, STOP_WALLET_RPC_TIMEOUT_MS);
             } else {
                 wallet.close(save);
             }
-        } catch (MoneroError e) {
+        } catch (RuntimeException e) {
             err = e;
         }
 
-        // stop wallet rpc instance if applicable
-        if (wallet instanceof MoneroWalletRpc) MONERO_WALLET_RPC_MANAGER.stopInstance((MoneroWalletRpc) wallet, path, false);
+        // stop wallet rpc instance if applicable, forcibly if the stop request was interrupted (e.g. shutdown timeout)
+        if (wallet instanceof MoneroWalletRpc) {
+            boolean interrupted = false;
+            for (Throwable t = err; t != null; t = t.getCause()) if (t instanceof InterruptedException) interrupted = true;
+            MONERO_WALLET_RPC_MANAGER.stopInstance((MoneroWalletRpc) wallet, path, interrupted);
+            if (interrupted) Thread.currentThread().interrupt(); // restore interrupt status consumed awaiting the stop request
+        }
         if (err != null) throw err;
     }
 
@@ -2202,7 +2212,10 @@ public class XmrWalletService extends XmrWalletBase {
             try {
                 if (wallet != null) {
                     log.info("Closing main wallet");
-                    closeWallet(wallet, true);
+                    // nullify rpc wallet before closing since its process is always stopped, else after so a stalled native close can be force closed
+                    MoneroWallet walletRef = wallet;
+                    if (walletRef instanceof MoneroWalletRpc) wallet = null;
+                    closeWallet(walletRef, true);
                     wallet = null;
                 }
             } catch (Exception e) {


### PR DESCRIPTION
Bound the wallet rpc stop request and graceful process stop, escalating to forcible destroy so wallet restarts cannot orphan monero-wallet-rpc (#2560).