### PR TITLE
core: reject trades with payments indistinguishable from an open trade's

### DIFF
--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -55,6 +55,7 @@ import haveno.core.offer.Offer;
 import haveno.core.offer.OfferDirection;
 import haveno.core.offer.OpenOffer;
 import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.payload.PaymentMethod;
 import haveno.core.proto.CoreProtoResolver;
 import haveno.core.proto.network.CoreNetworkProtoResolver;
 import haveno.core.support.dispute.Dispute;
@@ -2695,6 +2696,40 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
 
     private static PublicKey signaturePubKeyOrNull(PubKeyRing pubKeyRing) {
         return pubKeyRing == null ? null : pubKeyRing.getSignaturePubKey();
+    }
+
+    // true if the other trade's payment could not be told apart from this one's in a dispute
+    public boolean hasIndistinguishablePayment(Trade other) {
+        if (other == this || getOffer() == null || other.getOffer() == null) return false;
+        if (!hasSameSignaturePubKey(getBuyer(), other.getBuyer()) || !hasSameSignaturePubKey(getSeller(), other.getSeller())) return false;
+        if (!getPaymentRailId(getOffer().getPaymentMethodId()).equals(getPaymentRailId(other.getOffer().getPaymentMethodId()))) return false;
+        Volume volume = getVolume();
+        Volume otherVolume = other.getVolume();
+        return volume != null && otherVolume != null && volume.compareTo(otherVolume) == 0;
+    }
+
+    // instant variants are paid over the same rail as their base method
+    private static String getPaymentRailId(String paymentMethodId) {
+        if (PaymentMethod.BLOCK_CHAINS_INSTANT_ID.equals(paymentMethodId)) return PaymentMethod.BLOCK_CHAINS_ID;
+        if (PaymentMethod.SEPA_INSTANT_ID.equals(paymentMethodId)) return PaymentMethod.SEPA_ID;
+        return paymentMethodId;
+    }
+
+    private static boolean hasSameSignaturePubKey(TradePeer peer, TradePeer other) {
+        PublicKey pubKey = signaturePubKeyOrNull(peer.getPubKeyRing());
+        return pubKey != null && pubKey.equals(signaturePubKeyOrNull(other.getPubKeyRing()));
+    }
+
+    // latest date a payment could be claimed for this trade: unbounded while unsettled, else its payout approximated
+    // by the end of the trade period or the last dispute closing, whichever is later
+    public Date getPaymentClaimableUntil() {
+        if (!isPayoutPublished()) return new Date(Long.MAX_VALUE);
+        long until = (startTime > 0 ? startTime : getTakeOfferDate().getTime()) + getMaxTradePeriod();
+        for (Dispute dispute : getDisputes()) {
+            DisputeResult disputeResult = dispute.disputeResultProperty().get();
+            if (disputeResult != null) until = Math.max(until, disputeResult.getCloseDate().getTime());
+        }
+        return new Date(until);
     }
 
     public TradePeer getVerifiedTradePeer(DecryptedMessageWithPubKey message) {

--- a/core/src/main/java/haveno/core/trade/TradeManager.java
+++ b/core/src/main/java/haveno/core/trade/TradeManager.java
@@ -40,7 +40,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import haveno.common.ClockWatcher;
 import haveno.common.ThreadUtils;
-import haveno.common.UserThread;
 import haveno.common.crypto.KeyRing;
 import haveno.common.crypto.PubKeyRing;
 import haveno.common.handlers.ErrorMessageHandler;
@@ -693,6 +692,12 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         // handle request as maker
         if (request.getMakerNodeAddress().equals(p2PService.getNetworkNode().getNodeAddress())) {
 
+            // verify request is signed by the taker's pub key ring
+            if (!request.getTakerPubKeyRing().getSignaturePubKey().equals(decryptedMessageWithPubKey.getSignaturePubKey())) {
+                log.warn("Ignoring InitTradeRequest to maker because signature pub key does not match taker pub key, tradeId={}, sender={}", request.getOfferId(), sender);
+                return;
+            }
+
             // get open offer
             Optional<OpenOffer> openOfferOptional = openOfferManager.getOpenOffer(request.getOfferId());
 
@@ -992,7 +997,10 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                         trade.getSelf().setPubKeyRing(keyRing.getPubKeyRing());
                         trade.getSelf().setPaymentAccountId(paymentAccountId);
                         trade.getSelf().setPaymentMethodId(user.getPaymentAccount(paymentAccountId).getPaymentAccountPayload().getPaymentMethodId());
-                
+
+                        // reject a trade whose payment could not be told apart from an unsettled trade's
+                        verifyPaymentDistinguishable(trade);
+
                         // initialize trade protocol
                         TradeProtocol tradeProtocol = createTradeProtocol(trade);
                         addTrade(trade);
@@ -1256,6 +1264,27 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         }
     }
 
+    // reject a trade whose payment could not be told apart from an unsettled trade's in a dispute
+    public void verifyPaymentDistinguishable(Trade trade) {
+        Stream<Trade> unsettledTrades = Stream.concat(
+                getOpenTrades().stream(),
+                Stream.concat(getClosedTrades().stream(), failedTradesManager.getTrades().stream()).filter(other -> other.isDepositsPublished() || (other.isProtocolErrorHandlingScheduled() && other.walletExists())))
+                .filter(other -> !other.isPayoutPublished());
+        unsettledTrades.filter(other -> other.hasIndistinguishablePayment(trade))
+                .findFirst()
+                .ifPresent(other -> {
+                    throw new RuntimeException("Trade " + other.getShortId() + " with the same peer, payment method, and amount is not settled yet, so the payments could not be told apart in a dispute. Please wait for it to complete before trading again on the same terms.");
+                });
+    }
+
+    // trades whose payment could not be told apart from the given trade's while a payment could be claimed for both
+    public List<Trade> getTradesWithIndistinguishablePayment(Trade trade) {
+        return Stream.concat(getOpenTrades().stream(), Stream.concat(getClosedTrades().stream(), failedTradesManager.getTrades().stream()))
+                .filter(other -> other.isDepositsPublished() && other.hasIndistinguishablePayment(trade))
+                .filter(other -> !other.getDate().after(trade.getPaymentClaimableUntil()) && !trade.getDate().after(other.getPaymentClaimableUntil()))
+                .collect(Collectors.toList());
+    }
+
     private void checkForLockedUpFunds() {
         try {
             getSetOfFailedOrClosedTradeIdsFromLockedInFunds();
@@ -1326,15 +1355,7 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         }
 
         initTrade(trade);
-
-        UserThread.execute(() -> {
-            synchronized (tradableList.getList()) {
-                if (!tradableList.contains(trade)) {
-                    tradableList.add(trade);
-                }
-            }
-        });
-
+        addTrade(trade);
         return true;
     }
 

--- a/core/src/main/java/haveno/core/trade/failed/FailedTradesManager.java
+++ b/core/src/main/java/haveno/core/trade/failed/FailedTradesManager.java
@@ -34,6 +34,7 @@ import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -131,25 +132,21 @@ public class FailedTradesManager implements PersistedDataHost {
         }
     }
 
-    public Stream<Trade> getTradesStreamWithFundsLockedIn() {
+    public List<Trade> getTrades() {
         synchronized (failedTrades.getList()) {
-            return failedTrades.stream()
-                    .filter(Trade::isFundsLockedIn);
+            return new ArrayList<>(failedTrades.getList());
         }
     }
 
-    public void unFailTrade(Trade trade) {
-        synchronized (failedTrades.getList()) {
-            if (unFailTradeCallback == null)
-                return;
+    public Stream<Trade> getTradesStreamWithFundsLockedIn() {
+        return getTrades().stream().filter(Trade::isFundsLockedIn);
+    }
 
-            if (unFailTradeCallback.apply(trade)) {
-                log.info("Unfailing trade {}", trade.getId());
-                if (failedTrades.remove(trade)) {
-                    requestPersistence();
-                }
-            }
-        }
+    // the callback adds the trade to pending trades before it is removed here, so it is always in a store
+    public void unFailTrade(Trade trade) {
+        if (unFailTradeCallback == null || !unFailTradeCallback.apply(trade)) return;
+        log.info("Unfailing trade {}", trade.getId());
+        removeTrade(trade);
     }
 
     public String checkUnFail(Trade trade) {

--- a/core/src/main/java/haveno/core/trade/protocol/tasks/ProcessInitMultisigRequest.java
+++ b/core/src/main/java/haveno/core/trade/protocol/tasks/ProcessInitMultisigRequest.java
@@ -82,6 +82,7 @@ public class ProcessInitMultisigRequest extends TradeTask {
             try {
               trade.getOffer().verifyTradePrice(request.getTradePrice(), true);
               trade.setPrice(request.getTradePrice());
+              processModel.getTradeManager().verifyPaymentDistinguishable(trade); // re-check with the final price
             } catch (TradePriceOutOfToleranceException e) {
               failed(e.getMessage());
               return;

--- a/core/src/main/java/haveno/core/trade/protocol/tasks/ProcessInitTradeRequest.java
+++ b/core/src/main/java/haveno/core/trade/protocol/tasks/ProcessInitTradeRequest.java
@@ -150,6 +150,9 @@ public class ProcessInitTradeRequest extends TradeTask {
                 throw new RuntimeException("Invalid trade type to process init trade request: " + trade.getClass().getName());
             }
 
+            // reject a trade whose payment could not be told apart from an unsettled trade's
+            if (!(trade instanceof ArbitratorTrade)) processModel.getTradeManager().verifyPaymentDistinguishable(trade);
+
             // set trading peer info
             if (trade.getMaker().getAccountId() == null) trade.getMaker().setAccountId(request.getMakerAccountId());
             else if (!trade.getMaker().getAccountId().equals(request.getMakerAccountId())) throw new RuntimeException("Maker account id is different from previous");

--- a/core/src/test/java/haveno/core/trade/IndistinguishablePaymentTest.java
+++ b/core/src/test/java/haveno/core/trade/IndistinguishablePaymentTest.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.trade;
+
+import haveno.common.crypto.KeyRing;
+import haveno.common.crypto.KeyStorage;
+import haveno.common.crypto.PubKeyRing;
+import haveno.common.file.FileUtil;
+import haveno.core.monetary.TraditionalMoney;
+import haveno.core.monetary.Volume;
+import haveno.core.offer.Offer;
+import haveno.core.trade.protocol.TradePeer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IndistinguishablePaymentTest {
+    private static final String SEPA = "SEPA";
+    private static final Volume EUR_100 = volume("EUR", "100");
+
+    private File dir;
+    private PubKeyRing buyer;
+    private PubKeyRing seller;
+    private PubKeyRing other;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        dir = File.createTempFile("temp_tests", "");
+        //noinspection ResultOfMethodCallIgnored
+        dir.delete();
+        //noinspection ResultOfMethodCallIgnored
+        dir.mkdir();
+        buyer = newPubKeyRing("buyer");
+        seller = newPubKeyRing("seller");
+        other = newPubKeyRing("other");
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        FileUtil.deleteDirectory(dir);
+    }
+
+    @Test
+    public void sameTermsAreIndistinguishable() {
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        Trade duplicate = newTrade(buyer, seller, SEPA, EUR_100);
+        assertTrue(trade.hasIndistinguishablePayment(duplicate));
+        assertTrue(duplicate.hasIndistinguishablePayment(trade));
+    }
+
+    @Test
+    public void sameInstanceIsNotAMatch() {
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        assertFalse(trade.hasIndistinguishablePayment(trade));
+    }
+
+    @Test
+    public void differentCounterpartyIsDistinguishable() {
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        assertFalse(trade.hasIndistinguishablePayment(newTrade(other, seller, SEPA, EUR_100)));
+        assertFalse(trade.hasIndistinguishablePayment(newTrade(buyer, other, SEPA, EUR_100)));
+    }
+
+    @Test
+    public void oppositeDirectionIsDistinguishable() {
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        assertFalse(trade.hasIndistinguishablePayment(newTrade(seller, buyer, SEPA, EUR_100)));
+    }
+
+    @Test
+    public void differentPaymentMethodIsDistinguishable() {
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        assertFalse(trade.hasIndistinguishablePayment(newTrade(buyer, seller, "REVOLUT", EUR_100)));
+    }
+
+    @Test
+    public void instantVariantIsIndistinguishable() {
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        assertTrue(trade.hasIndistinguishablePayment(newTrade(buyer, seller, "SEPA_INSTANT", EUR_100)));
+        Trade cryptoTrade = newTrade(buyer, seller, "BLOCK_CHAINS", EUR_100);
+        assertTrue(cryptoTrade.hasIndistinguishablePayment(newTrade(buyer, seller, "BLOCK_CHAINS_INSTANT", EUR_100)));
+    }
+
+    @Test
+    public void differentVolumeOrCurrencyIsDistinguishable() {
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        assertFalse(trade.hasIndistinguishablePayment(newTrade(buyer, seller, SEPA, volume("EUR", "100.01"))));
+        assertFalse(trade.hasIndistinguishablePayment(newTrade(buyer, seller, SEPA, volume("USD", "100"))));
+        assertFalse(trade.hasIndistinguishablePayment(newTrade(buyer, seller, SEPA, null)));
+    }
+
+    @Test
+    public void rotatedEncryptionKeyStillMatchesBySignatureKey() {
+        PubKeyRing rotated = new PubKeyRing(buyer.getSignaturePubKeyBytes(), other.getEncryptionPubKeyBytes());
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        assertTrue(trade.hasIndistinguishablePayment(newTrade(rotated, seller, SEPA, EUR_100)));
+    }
+
+    @Test
+    public void unknownPeerIsDistinguishable() {
+        Trade trade = newTrade(buyer, seller, SEPA, EUR_100);
+        assertFalse(trade.hasIndistinguishablePayment(newTrade(null, seller, SEPA, EUR_100)));
+    }
+
+    private Trade newTrade(PubKeyRing buyerPubKeyRing, PubKeyRing sellerPubKeyRing, String paymentMethodId, Volume volume) {
+        Offer offer = mock(Offer.class);
+        when(offer.getPaymentMethodId()).thenReturn(paymentMethodId);
+        Trade trade = mock(Trade.class);
+        when(trade.hasIndistinguishablePayment(any())).thenCallRealMethod();
+        when(trade.getBuyer()).thenReturn(peer(buyerPubKeyRing));
+        when(trade.getSeller()).thenReturn(peer(sellerPubKeyRing));
+        when(trade.getOffer()).thenReturn(offer);
+        when(trade.getVolume()).thenReturn(volume);
+        return trade;
+    }
+
+    private static Volume volume(String currencyCode, String amount) {
+        return new Volume(TraditionalMoney.parseTraditionalMoney(currencyCode, amount));
+    }
+
+    private static TradePeer peer(PubKeyRing pubKeyRing) {
+        TradePeer peer = new TradePeer();
+        peer.setPubKeyRing(pubKeyRing);
+        return peer;
+    }
+
+    private PubKeyRing newPubKeyRing(String name) {
+        File keyDir = new File(dir, name);
+        //noinspection ResultOfMethodCallIgnored
+        keyDir.mkdir();
+        return new KeyRing(new KeyStorage(keyDir), null, true).getPubKeyRing();
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/haveno/desktop/main/support/dispute/DisputeView.java
@@ -152,7 +152,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> implements
 
     protected final DisputeManager<? extends DisputeList<Dispute>> disputeManager;
     protected final KeyRing keyRing;
-    private final TradeManager tradeManager;
+    protected final TradeManager tradeManager;
     protected final CoinFormatter formatter;
     protected final Preferences preferences;
     protected final DisputeSummaryWindow disputeSummaryWindow;

--- a/desktop/src/main/java/haveno/desktop/main/support/dispute/agent/DisputeAgentView.java
+++ b/desktop/src/main/java/haveno/desktop/main/support/dispute/agent/DisputeAgentView.java
@@ -29,9 +29,11 @@ import haveno.core.support.dispute.DisputeManager;
 import haveno.core.support.dispute.DisputeValidation;
 import haveno.core.support.dispute.agent.MultipleHolderNameDetection;
 import haveno.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
+import haveno.core.trade.Trade;
 import haveno.core.trade.TradeManager;
 import haveno.core.user.DontShowAgainLookup;
 import haveno.core.user.Preferences;
+import haveno.core.util.VolumeUtil;
 import haveno.core.util.coin.CoinFormatter;
 import haveno.desktop.components.AutoTooltipTableColumn;
 import haveno.desktop.main.overlays.popups.Popup;
@@ -50,14 +52,20 @@ import javafx.scene.layout.HBox;
 import javafx.scene.text.Text;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import haveno.desktop.util.Accessibility;
+import haveno.desktop.util.DisplayUtils;
 import static haveno.desktop.util.FormBuilder.getIconForLabel;
 
 public abstract class DisputeAgentView extends DisputeView implements MultipleHolderNameDetection.Listener {
 
     private final MultipleHolderNameDetection multipleHolderNameDetection;
+    private final Map<String, List<Trade>> ambiguousPaymentTradesByTradeId = new HashMap<>();
+    private long ambiguousPaymentTradesTime;
     private ListChangeListener<DisputeValidation.ValidationException> validationExceptionListener;
 
     public DisputeAgentView(DisputeManager<? extends DisputeList<Dispute>> disputeManager,
@@ -273,27 +281,36 @@ public abstract class DisputeAgentView extends DisputeView implements MultipleHo
                             setGraphic(alertIconLabel);
 
                             alertIconLabel.setOnMouseClicked(e -> {
-                                List<Dispute> realNameAccountInfoList = multipleHolderNameDetection.getDisputesForTrader(dispute);
-                                String reportForDisputeOfTrader = multipleHolderNameDetection.getReportForDisputeOfTrader(realNameAccountInfoList);
                                 String key = MultipleHolderNameDetection.getAckKey(dispute);
-                                new Popup()
+                                List<Dispute> holderNameDisputes = DontShowAgainLookup.showAgain(key) ? multipleHolderNameDetection.getDisputesForTrader(dispute) : List.of();
+                                List<Trade> ambiguousPaymentTrades = getTradesWithIndistinguishablePayment(dispute);
+                                String report = "";
+                                String message = "";
+                                if (!holderNameDisputes.isEmpty()) {
+                                    report = multipleHolderNameDetection.getReportForDisputeOfTrader(holderNameDisputes);
+                                    message = getReportMessage(report, "this trader");
+                                }
+                                if (!ambiguousPaymentTrades.isEmpty()) {
+                                    String paymentReport = getIndistinguishablePaymentReport(ambiguousPaymentTrades);
+                                    report += (report.isEmpty() ? "" : "\n\n") + paymentReport;
+                                    message += (message.isEmpty() ? "" : "\n\n") + getIndistinguishablePaymentMessage(dispute, paymentReport);
+                                }
+                                String fullReport = report;
+                                Popup popup = new Popup()
                                         .width(1100)
-                                        .warning(getReportMessage(reportForDisputeOfTrader, "this trader"))
+                                        .warning(message)
                                         .actionButtonText(Res.get("shared.copyToClipboard"))
                                         .onAction(() -> {
-                                            Utilities.copyToClipboard(reportForDisputeOfTrader);
-                                            if (!DontShowAgainLookup.showAgain(key)) {
-                                                setGraphic(null);
-                                            }
+                                            Utilities.copyToClipboard(fullReport);
+                                            if (!showAlertAtDispute(dispute)) setGraphic(null);
                                         })
-                                        .dontShowAgainId(key)
-                                        .dontShowAgainText("Is not suspicious")
                                         .onClose(() -> {
-                                            if (!DontShowAgainLookup.showAgain(key)) {
-                                                setGraphic(null);
-                                            }
-                                        })
-                                        .show();
+                                            if (!showAlertAtDispute(dispute)) setGraphic(null);
+                                        });
+                                if (!holderNameDisputes.isEmpty()) {
+                                    popup.dontShowAgainId(key).dontShowAgainText("Is not suspicious");
+                                }
+                                popup.show();
                             });
                         } else {
                             setGraphic(null);
@@ -310,8 +327,40 @@ public abstract class DisputeAgentView extends DisputeView implements MultipleHo
     }
 
     private boolean showAlertAtDispute(Dispute dispute) {
-        return DontShowAgainLookup.showAgain(MultipleHolderNameDetection.getAckKey(dispute)) &&
-                !multipleHolderNameDetection.getDisputesForTrader(dispute).isEmpty();
+        return (DontShowAgainLookup.showAgain(MultipleHolderNameDetection.getAckKey(dispute)) &&
+                !multipleHolderNameDetection.getDisputesForTrader(dispute).isEmpty()) ||
+                !getTradesWithIndistinguishablePayment(dispute).isEmpty();
+    }
+
+    // memoized briefly since each lookup scans every trade and table sorts compare rows repeatedly
+    private List<Trade> getTradesWithIndistinguishablePayment(Dispute dispute) {
+        long now = System.currentTimeMillis();
+        if (now - ambiguousPaymentTradesTime > 2000) {
+            ambiguousPaymentTradesByTradeId.clear();
+            ambiguousPaymentTradesTime = now;
+        }
+        return ambiguousPaymentTradesByTradeId.computeIfAbsent(dispute.getTradeId(), tradeId -> {
+            Trade trade = tradeManager.getTrade(tradeId);
+            return trade == null ? List.of() : tradeManager.getTradesWithIndistinguishablePayment(trade);
+        });
+    }
+
+    // Text below is for arbitrators only so no need to translate it
+    private String getIndistinguishablePaymentReport(List<Trade> trades) {
+        return trades.stream()
+                .map(trade -> "    Trade ID: '" + trade.getShortId() +
+                        "'\n        Amount: '" + VolumeUtil.formatVolumeWithCode(trade.getVolume()) +
+                        "'\n        Started: '" + DisplayUtils.formatDateTime(trade.getDate()) +
+                        "'\n        Paid out: '" + (trade.isPayoutPublished() ? "yes" : "no") + "'")
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String getIndistinguishablePaymentMessage(Dispute dispute, String report) {
+        return "Trade " + dispute.getShortTradeId() + " has the same buyer, seller, payment method, and amount as the " +
+                "following trade(s), and a payment could be claimed for both at the same time, so one payment " +
+                "might be presented as evidence for more than one trade.\n\n" +
+                "Verify that each trade was paid with its own transaction, e.g. by comparing transaction dates and identifiers.\n\n" +
+                report;
     }
 
     private String getReportMessage(String report, String subString) {


### PR DESCRIPTION
Same buyer, seller, payment method, and amount as an unsettled trade is rejected at trade init, and arbitrators are alerted on such disputes.

Supersedes https://github.com/haveno-dex/haveno/pull/2559