### PR TITLE
core: preserve offer reserve inputs during trade initialization

### DIFF
--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -4478,6 +4478,15 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
 
             // freeze outputs until spent
             xmrWalletService.freezeOutputs(getSelf().getReserveTxKeyImages());
+
+            // Release unused offer inputs; failed-trade restoration reconciles after restoring ownership.
+            if (this instanceof MakerTrade && processModel.getTradeManager().hasOpenTrade(this)) {
+                try {
+                    xmrWalletService.fixReservedOutputs();
+                } catch (Exception e) {
+                    log.warn("Error updating reserved outputs after publishing deposits for trade {}", getId(), e);
+                }
+            }
             
             // backup trade wallet after creation
             maybeBackupWallet();

--- a/core/src/main/java/haveno/core/trade/TradeManager.java
+++ b/core/src/main/java/haveno/core/trade/TradeManager.java
@@ -1080,6 +1080,15 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
         removeFailedTrade(trade);
         if (!trade.isMaker()) xmrWalletService.swapPayoutAddressEntryToAvailable(trade.getId()); // TODO The address entry should have been removed already. Check and if its the case remove that.
         requestPersistence();
+        ThreadUtils.submitToPool(() -> {
+            if (isShutDownStarted) return;
+            try {
+                // Release inputs no longer owned by an open offer or trade.
+                xmrWalletService.fixReservedOutputs();
+            } catch (Exception e) {
+                log.warn("Error updating reserved outputs after removing trade {}", trade.getId(), e);
+            }
+        });
     }
 
     public void removeTrade(Trade trade) {

--- a/core/src/main/java/haveno/core/trade/protocol/tasks/MakerRecreateReserveTx.java
+++ b/core/src/main/java/haveno/core/trade/protocol/tasks/MakerRecreateReserveTx.java
@@ -126,6 +126,9 @@ public class MakerRecreateReserveTx extends TradeTask {
                 trade.getSelf().setReserveTxHex(reserveTx.getFullHex());
                 trade.getSelf().setReserveTxKey(reserveTx.getKey());
                 trade.getSelf().setReserveTxKeyImages(HavenoUtils.getInputKeyImages(reserveTx));
+
+                // The offer still owns its original inputs if the replacement selected different ones.
+                model.getXmrWalletService().freezeOutputs(offer.getOfferPayload().getReserveTxKeyImages());
             }
 
             // save process state

--- a/core/src/main/java/haveno/core/trade/protocol/tasks/MaybeSendSignContractRequest.java
+++ b/core/src/main/java/haveno/core/trade/protocol/tasks/MaybeSendSignContractRequest.java
@@ -138,6 +138,12 @@ public class MaybeSendSignContractRequest extends TradeTask {
                     }
                 }
 
+                // Record ownership before reconciliation can inspect the freshly frozen inputs.
+                if (depositTx != null) trade.getSelf().setReserveTxKeyImages(HavenoUtils.getInputKeyImages(depositTx));
+
+                // Keep the offer's reserve frozen if deposit creation selected different inputs.
+                if (trade instanceof MakerTrade) trade.getXmrWalletService().freezeOutputs(trade.getOffer().getOfferPayload().getReserveTxKeyImages());
+
                 // reset protocol timeout
                 trade.addInitProgressStep();
             }
@@ -156,7 +162,6 @@ public class MaybeSendSignContractRequest extends TradeTask {
                 trade.getSelf().setDepositTxFee(depositTx.getFee());
                 trade.getSelf().setDepositTxHex(depositTx.getFullHex());
                 trade.getSelf().setDepositTxKey(depositTx.getKey());
-                trade.getSelf().setReserveTxKeyImages(HavenoUtils.getInputKeyImages(depositTx));
             }
 
             // maker signs deposit hash nonce to avoid challenge protocol


### PR DESCRIPTION
Keep original offer inputs frozen when trade transactions select others.
    Release unused inputs after deposit publication or trade removal.