### PR TITLE
core: reduce zelle max trade period to 1 day (mandatory update)

### DIFF
--- a/core/src/main/java/haveno/core/api/CoreOffersService.java
+++ b/core/src/main/java/haveno/core/api/CoreOffersService.java
@@ -70,7 +70,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -414,6 +416,16 @@ public class CoreOffersService {
             throw new IllegalArgumentException("Cannot edit offer with different maker fee, original maker fee: " + openOffer.getOffer().getOfferPayload().getMakerFeePct() + ", new maker fee: " + newMakerFee);
         }
 
+        // Refresh only the Zelle period marker, preserving the original offer's other metadata.
+        Map<String, String> extraDataMap = offerPayload.getExtraDataMap() == null ?
+                new HashMap<>() : new HashMap<>(offerPayload.getExtraDataMap());
+        if (newOfferPayload.getExtraDataMap() != null &&
+                "1".equals(newOfferPayload.getExtraDataMap().get(OfferPayload.ZELLE_ONE_DAY_TRADE_PERIOD))) {
+            extraDataMap.put(OfferPayload.ZELLE_ONE_DAY_TRADE_PERIOD, "1");
+        } else {
+            extraDataMap.remove(OfferPayload.ZELLE_ONE_DAY_TRADE_PERIOD);
+        }
+
         final OfferPayload editedPayload = new OfferPayload(offerPayload.getId(),
                 offerPayload.getDate(),
                 offerPayload.getOwnerNodeAddress(),
@@ -440,14 +452,14 @@ public class CoreOffersService {
                 Version.VERSION, // refresh version so outdated offers are re-signed
                 offerPayload.getBlockHeightAtOfferCreation(),
                 offerPayload.getMaxTradeLimit(),
-                offerPayload.getMaxTradePeriod(),
+                newOfferPayload.getMaxTradePeriod(),
                 offerPayload.isUseAutoClose(),
                 offerPayload.isUseReOpenAfterAutoClose(),
                 offerPayload.getLowerClosePrice(),
                 offerPayload.getUpperClosePrice(),
                 offerPayload.isPrivateOffer(),
                 offerPayload.getChallengeHash(),
-                offerPayload.getExtraDataMap(),
+                extraDataMap.isEmpty() ? null : extraDataMap,
                 offerPayload.getProtocolVersion(),
                 offerPayload.getArbitratorSigner(),
                 offerPayload.getArbitratorSignature(),

--- a/core/src/main/java/haveno/core/offer/Offer.java
+++ b/core/src/main/java/haveno/core/offer/Offer.java
@@ -575,8 +575,13 @@ public class Offer implements NetworkPayload, PersistablePayload {
         return offerPayload.getVersionNr();
     }
 
+    // Effective duration; the signed payload's raw period can be stale after legacy payment-method edits.
     public long getMaxTradePeriod() {
-        return offerPayload.getMaxTradePeriod();
+        if (PaymentMethod.ZELLE_ID.equals(getPaymentMethodId()) &&
+                (getExtraDataMap() == null || !"1".equals(getExtraDataMap().get(OfferPayload.ZELLE_ONE_DAY_TRADE_PERIOD)))) {
+            return PaymentMethod.ZELLE_LEGACY_MAX_TRADE_PERIOD;
+        }
+        return getPaymentMethod().getMaxTradePeriod();
     }
 
     public NodeAddress getOwnerNodeAddress() {

--- a/core/src/main/java/haveno/core/offer/OfferPayload.java
+++ b/core/src/main/java/haveno/core/offer/OfferPayload.java
@@ -104,6 +104,8 @@ public final class OfferPayload implements ProtectedStoragePayload, ExpirablePay
     public static final String PAYPAL_EXTRA_INFO = "payPalExtraInfo";
     public static final String CASH_AT_ATM_EXTRA_INFO = "cashAtAtmExtraInfo";
     public static final String BLIK_EXTRA_INFO = "blikExtraInfo";
+    // Legacy Zelle payload periods can be stale after payment-method edits, so mark new one-day offers explicitly.
+    public static final String ZELLE_ONE_DAY_TRADE_PERIOD = "zelleOneDayTradePeriod";
 
     // Comma separated list of ordinal of a haveno.common.app.Capability. E.g. ordinal of
     // Capability.SIGNED_ACCOUNT_AGE_WITNESS is 11 and Capability.MEDIATION is 12 so if we want to signal that maker

--- a/core/src/main/java/haveno/core/offer/OfferUtil.java
+++ b/core/src/main/java/haveno/core/offer/OfferUtil.java
@@ -55,6 +55,7 @@ import haveno.core.payment.F2FAccount;
 import haveno.core.payment.PayByMailAccount;
 import haveno.core.payment.PayPalAccount;
 import haveno.core.payment.PaymentAccount;
+import haveno.core.payment.payload.PaymentMethod;
 import haveno.core.provider.price.MarketPrice;
 import haveno.core.provider.price.PriceFeedService;
 import haveno.core.trade.HavenoUtils;
@@ -219,6 +220,10 @@ public class OfferUtil {
 
         if (paymentAccount instanceof BlikAccount) {
             extraDataMap.put(BLIK_EXTRA_INFO, ((BlikAccount) paymentAccount).getExtraInfo());
+        }
+
+        if (PaymentMethod.ZELLE_ID.equals(paymentAccount.getPaymentMethod().getId())) {
+            extraDataMap.put(OfferPayload.ZELLE_ONE_DAY_TRADE_PERIOD, "1");
         }
 
         extraDataMap.put(CAPABILITIES, Capabilities.app.toStringList());

--- a/core/src/main/java/haveno/core/offer/placeoffer/tasks/ValidateOffer.java
+++ b/core/src/main/java/haveno/core/offer/placeoffer/tasks/ValidateOffer.java
@@ -150,8 +150,8 @@ public class ValidateOffer extends Task<PlaceOfferModel> {
         checkNotNull(offer.getPubKeyRing(), "pubKeyRing is null");
         checkNotNull(offer.getMinAmount(), "MinAmount is null");
         checkNotNull(offer.getVersionNr(), "VersionNr is null");
-        checkArgument(offer.getMaxTradePeriod() > 0,
-                "maxTradePeriod must be positive. maxTradePeriod=" + offer.getMaxTradePeriod());
+        checkArgument(offer.getOfferPayload().getMaxTradePeriod() > 0,
+                "maxTradePeriod must be positive. maxTradePeriod=" + offer.getOfferPayload().getMaxTradePeriod());
         // TODO check upper and lower bounds for fiat
         // TODO check rest of new parameters
     }

--- a/core/src/main/java/haveno/core/payment/payload/PaymentMethod.java
+++ b/core/src/main/java/haveno/core/payment/payload/PaymentMethod.java
@@ -149,6 +149,8 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
                                     Config.baseCurrencyNetwork() == BaseCurrencyNetwork.XMR_STAGENET ? TimeUnit.MINUTES.toMillis(30) :
                                     TimeUnit.DAYS.toMillis(1);
 
+    public static final long ZELLE_LEGACY_MAX_TRADE_PERIOD = 4 * DAY;
+
     // These values are not used except to derive the associated risk factor.
     private static final BigInteger DEFAULT_TRADE_LIMIT_CRYPTO = HavenoUtils.xmrToAtomicUnits(200);
     private static final BigInteger DEFAULT_TRADE_LIMIT_VERY_LOW_RISK = HavenoUtils.xmrToAtomicUnits(100);
@@ -398,7 +400,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
             KASPI = new PaymentMethod(KASPI_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(KaspiAccount.SUPPORTED_CURRENCIES)),
 
             // US
-            ZELLE = new PaymentMethod(ZELLE_ID, 4 * DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(ZelleAccount.SUPPORTED_CURRENCIES)),
+            ZELLE = new PaymentMethod(ZELLE_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(ZelleAccount.SUPPORTED_CURRENCIES)),
             POPMONEY = new PaymentMethod(POPMONEY_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(PopmoneyAccount.SUPPORTED_CURRENCIES)),
             US_POSTAL_MONEY_ORDER = new PaymentMethod(US_POSTAL_MONEY_ORDER_ID, 8 * DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(USPostalMoneyOrderAccount.SUPPORTED_CURRENCIES)),
             VENMO = new PaymentMethod(VENMO_ID, DAY, DEFAULT_TRADE_LIMIT_HIGH_RISK, getAssetCodes(VenmoAccount.SUPPORTED_CURRENCIES)),
@@ -591,8 +593,7 @@ public final class PaymentMethod implements PersistablePayload, Comparable<Payme
     @Getter
     private final String id;
 
-    // Must not change as old offers would get a new period then and that would violate the makers "contract" or
-    // expectation when he created the offer.
+    // Changing a default must preserve existing offers and trades; see the Zelle legacy period in Offer.
     @Getter
     private final long maxTradePeriod;
 

--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -2833,7 +2833,7 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
     }
 
     public long getMaxTradePeriod() {
-        return getOffer().getPaymentMethod().getMaxTradePeriod();
+        return getOffer().getMaxTradePeriod();
     }
 
     public Date getHalfTradePeriodDate() {

--- a/core/src/main/java/haveno/core/trade/TradeUtil.java
+++ b/core/src/main/java/haveno/core/trade/TradeUtil.java
@@ -121,7 +121,7 @@ public class TradeUtil {
 
     public long getMaxTradePeriod(Trade trade) {
         return trade.getOffer() != null
-                ? trade.getOffer().getPaymentMethod().getMaxTradePeriod()
+                ? trade.getMaxTradePeriod()
                 : 0;
     }
 

--- a/core/src/test/java/haveno/core/offer/ZelleTradePeriodTest.java
+++ b/core/src/test/java/haveno/core/offer/ZelleTradePeriodTest.java
@@ -1,0 +1,236 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.core.offer;
+
+import haveno.common.crypto.KeyRing;
+import haveno.common.crypto.KeyStorage;
+import haveno.common.crypto.PubKeyRingProvider;
+import haveno.core.account.witness.AccountAgeWitnessService;
+import haveno.core.api.CoreOffersService;
+import haveno.core.filter.FilterManager;
+import haveno.core.locale.Res;
+import haveno.core.monetary.Price;
+import haveno.core.payment.PaymentAccount;
+import haveno.core.payment.VenmoAccount;
+import haveno.core.payment.ZelleAccount;
+import haveno.core.payment.payload.PaymentMethod;
+import haveno.core.proto.CoreProtoResolver;
+import haveno.core.provider.price.PriceFeedService;
+import haveno.core.trade.BuyerAsMakerTrade;
+import haveno.core.trade.HavenoUtils;
+import haveno.core.trade.Trade;
+import haveno.core.trade.TradeUtil;
+import haveno.core.trade.protocol.ProcessModel;
+import haveno.core.trade.statistics.ReferralIdService;
+import haveno.core.user.Preferences;
+import haveno.core.xmr.wallet.XmrWalletService;
+import haveno.network.p2p.NodeAddress;
+import haveno.network.p2p.P2PService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+
+import static haveno.core.offer.OfferPayload.ZELLE_ONE_DAY_TRADE_PERIOD;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ZelleTradePeriodTest {
+    private static final long LEGACY_PERIOD = PaymentMethod.ZELLE_LEGACY_MAX_TRADE_PERIOD;
+    private static final long ONE_DAY = LEGACY_PERIOD / 4;
+    private static final Price PRICE = Price.valueOf("USD", 1500000L);
+
+    @TempDir
+    Path keyDirectory;
+
+    private KeyRing keyRing;
+    private XmrWalletService walletService;
+    private CreateOfferService createOfferService;
+    private CoreOffersService coreOffersService;
+    private ZelleAccount zelleAccount;
+
+    @BeforeEach
+    public void setUp() {
+        Res.setup();
+        keyRing = new KeyRing(new KeyStorage(keyDirectory.toFile()), null, true);
+        walletService = mock(XmrWalletService.class);
+        AccountAgeWitnessService witnessService = mock(AccountAgeWitnessService.class);
+        when(witnessService.getMyTradeLimit(any(), anyString(), any(), anyBoolean()))
+                .thenReturn(HavenoUtils.xmrToAtomicUnits(10).longValueExact());
+        when(witnessService.getMyWitnessHashAsHex(any())).thenReturn("witness");
+        P2PService p2PService = mock(P2PService.class);
+        when(p2PService.getAddress()).thenReturn(new NodeAddress("maker.onion", 9999));
+        OfferUtil offerUtil = new OfferUtil(witnessService, mock(FilterManager.class), mock(Preferences.class),
+                mock(PriceFeedService.class), p2PService, mock(ReferralIdService.class));
+        PubKeyRingProvider pubKeyRingProvider = mock(PubKeyRingProvider.class);
+        when(pubKeyRingProvider.get()).thenReturn(keyRing.getPubKeyRing());
+        createOfferService = new CreateOfferService(offerUtil, mock(PriceFeedService.class), p2PService,
+                pubKeyRingProvider, null, walletService, null, null);
+        coreOffersService = new CoreOffersService(null, keyRing, null, createOfferService,
+                null, null, null, offerUtil, null, mock(PriceFeedService.class), null);
+        zelleAccount = new ZelleAccount();
+        zelleAccount.init();
+        zelleAccount.setAccountName("Zelle");
+    }
+
+    @Test
+    public void testNewAndRestoredZelleAccountsCreateOneDayOffers() {
+        protobuf.PaymentAccount persisted = zelleAccount.toProtoMessage().toBuilder()
+                .setPaymentMethod(PaymentMethod.ZELLE.toProtoMessage().toBuilder().setMaxTradePeriod(LEGACY_PERIOD))
+                .build();
+        PaymentAccount restored = PaymentAccount.fromProto(persisted, new CoreProtoResolver());
+        assertNotNull(restored);
+        for (PaymentAccount account : new PaymentAccount[]{zelleAccount, restored}) {
+            assertEquals(ONE_DAY, account.getMaxTradePeriod());
+            Offer offer = createOffer(account);
+            assertEquals(ONE_DAY, offer.getOfferPayload().getMaxTradePeriod());
+            assertEquals(ONE_DAY, offer.getMaxTradePeriod());
+            assertEquals("1", offer.getExtraDataMap().get(ZELLE_ONE_DAY_TRADE_PERIOD));
+        }
+    }
+
+    @Test
+    public void testLegacyZelleKeepsFourDaysRegardlessOfStalePayloadPeriod() {
+        // Legacy edits from Venmo or postal money orders retained their old raw period, including one day.
+        for (long rawPeriod : new long[]{ONE_DAY, LEGACY_PERIOD, 8 * ONE_DAY, 0, -1, Long.MAX_VALUE}) {
+            Offer offer = offerWithPeriod(PaymentMethod.ZELLE_ID, rawPeriod, Map.of());
+            byte[] serialized = offer.toProtoMessage().toByteArray();
+            assertEquals(LEGACY_PERIOD, offer.getMaxTradePeriod());
+            assertEquals(rawPeriod, offer.getOfferPayload().getMaxTradePeriod());
+            assertArrayEquals(serialized, offer.toProtoMessage().toByteArray());
+        }
+    }
+
+    @Test
+    public void testOnlyExactMarkerEnablesOneDayAndCannotSetArbitraryDuration() {
+        for (String marker : new String[]{"", "0", "true", "2", "86400000"}) {
+            assertEquals(LEGACY_PERIOD, offerWithPeriod(PaymentMethod.ZELLE_ID, ONE_DAY,
+                    Map.of(ZELLE_ONE_DAY_TRADE_PERIOD, marker)).getMaxTradePeriod());
+        }
+        assertEquals(ONE_DAY, offerWithPeriod(PaymentMethod.ZELLE_ID, Long.MAX_VALUE,
+                Map.of(ZELLE_ONE_DAY_TRADE_PERIOD, "1")).getMaxTradePeriod());
+    }
+
+    @Test
+    public void testOtherPaymentMethodsKeepTheirEffectivePeriod() {
+        for (String methodId : new String[]{PaymentMethod.VENMO_ID, PaymentMethod.SEPA_ID}) {
+            assertEquals(PaymentMethod.getPaymentMethod(methodId).getMaxTradePeriod(),
+                    offerWithPeriod(methodId, Long.MAX_VALUE, Map.of(ZELLE_ONE_DAY_TRADE_PERIOD, "1"))
+                            .getMaxTradePeriod());
+        }
+    }
+
+    @Test
+    public void testEditingLegacyZelleRefreshesPeriodWithoutMutatingOriginalTerms() {
+        Offer original = offerWithPeriod(PaymentMethod.ZELLE_ID, ONE_DAY, Map.of("original", "metadata"));
+        byte[] serialized = original.toProtoMessage().toByteArray();
+        byte[] signatureHash = original.getOfferPayload().getSignatureHash();
+        Offer edited = coreOffersService.getEditedOffer(new OpenOffer(original), createOffer(zelleAccount).getOfferPayload());
+
+        assertEquals(ONE_DAY, edited.getMaxTradePeriod());
+        assertEquals(ONE_DAY, edited.getOfferPayload().getMaxTradePeriod());
+        assertEquals("metadata", edited.getExtraDataMap().get("original"));
+        assertEquals("1", edited.getExtraDataMap().get(ZELLE_ONE_DAY_TRADE_PERIOD));
+        assertEquals(LEGACY_PERIOD, original.getMaxTradePeriod());
+        assertArrayEquals(serialized, original.toProtoMessage().toByteArray());
+        assertArrayEquals(signatureHash, original.getOfferPayload().getSignatureHash());
+    }
+
+    @Test
+    public void testEditingPaymentMethodAddsAndRemovesMarker() {
+        Offer original = offerWithPeriod(PaymentMethod.VENMO_ID, ONE_DAY, Map.of("original", "metadata"));
+        Offer zelle = coreOffersService.getEditedOffer(new OpenOffer(original), createOffer(zelleAccount).getOfferPayload());
+        assertEquals(ONE_DAY, zelle.getMaxTradePeriod());
+        assertEquals("1", zelle.getExtraDataMap().get(ZELLE_ONE_DAY_TRADE_PERIOD));
+
+        VenmoAccount venmoAccount = new VenmoAccount();
+        venmoAccount.init();
+        Offer venmo = coreOffersService.getEditedOffer(new OpenOffer(zelle), createOffer(venmoAccount).getOfferPayload());
+        assertEquals(PaymentMethod.VENMO_ID, venmo.getPaymentMethodId());
+        assertNull(venmo.getExtraDataMap().get(ZELLE_ONE_DAY_TRADE_PERIOD));
+        assertEquals("metadata", venmo.getExtraDataMap().get("original"));
+        assertEquals("1", zelle.getExtraDataMap().get(ZELLE_ONE_DAY_TRADE_PERIOD));
+    }
+
+    @Test
+    public void testCloneOfLegacyOfferUsesOneDay() {
+        Offer original = offerWithPeriod(PaymentMethod.ZELLE_ID, LEGACY_PERIOD, Map.of());
+        Offer clone = createOfferService.createClonedOffer(original, "USD", PRICE, false, 0, zelleAccount, "");
+        assertEquals(ONE_DAY, clone.getMaxTradePeriod());
+        assertEquals(ONE_DAY, clone.getOfferPayload().getMaxTradePeriod());
+        assertEquals(LEGACY_PERIOD, original.getMaxTradePeriod());
+    }
+
+    @Test
+    public void testMarkerIsCoveredByArbitratorSignatureAndSurvivesSerialization() {
+        Offer original = offerWithPeriod(PaymentMethod.ZELLE_ID, ONE_DAY, Map.of());
+        protobuf.OfferPayload markedPayload = original.getOfferPayload().toProtoMessage().getOfferPayload().toBuilder()
+                .putExtraData(ZELLE_ONE_DAY_TRADE_PERIOD, "1").build();
+        Offer marked = new Offer(OfferPayload.fromProto(markedPayload));
+        assertFalse(Arrays.equals(original.getOfferPayload().getSignatureHash(), marked.getOfferPayload().getSignatureHash()));
+        assertEquals(ONE_DAY, Offer.fromProto(marked.toProtoMessage()).getMaxTradePeriod());
+        assertEquals(LEGACY_PERIOD, Offer.fromProto(original.toProtoMessage()).getMaxTradePeriod());
+    }
+
+    @Test
+    public void testPersistedTradesKeepDeadlineAndDurationConsistent() {
+        Offer legacy = offerWithPeriod(PaymentMethod.ZELLE_ID, ONE_DAY, Map.of());
+        Offer current = createOffer(zelleAccount);
+        for (Offer offer : new Offer[]{legacy, current}) {
+            Trade trade = new BuyerAsMakerTrade(offer, offer.getAmount(), offer.getFixedPrice(), walletService,
+                    new ProcessModel(offer.getId(), zelleAccount.getId(), keyRing.getPubKeyRing()), "trade-uid",
+                    null, null, null, null);
+            long startTime = 1_700_000_000_000L;
+            trade.setStartTime(startTime);
+            protobuf.BuyerAsMakerTrade persisted = ((protobuf.Tradable) trade.toProtoMessage()).getBuyerAsMakerTrade();
+            Trade restored = (Trade) BuyerAsMakerTrade.fromProto(persisted, walletService, new CoreProtoResolver());
+            long expectedPeriod = offer == legacy ? LEGACY_PERIOD : ONE_DAY;
+            assertEquals(expectedPeriod, restored.getMaxTradePeriod());
+            assertEquals(expectedPeriod, new TradeUtil(null, keyRing).getMaxTradePeriod(restored));
+            assertEquals(startTime + expectedPeriod / 2, restored.getHalfTradePeriodDate().getTime());
+            assertEquals(startTime + expectedPeriod, restored.getMaxTradePeriodDate().getTime());
+        }
+    }
+
+    private Offer createOffer(PaymentAccount account) {
+        return createOfferService.createAndGetOffer("offer-id", OfferDirection.BUY, "USD",
+                HavenoUtils.xmrToAtomicUnits(1), HavenoUtils.xmrToAtomicUnits(1), PRICE, false, 0,
+                0.15, account, false, false, "");
+    }
+
+    private Offer offerWithPeriod(String methodId, long rawPeriod, Map<String, String> metadata) {
+        protobuf.OfferPayload payload = createOffer(zelleAccount).getOfferPayload().toProtoMessage().getOfferPayload().toBuilder()
+                .setPaymentMethodId(methodId)
+                .setMaxTradePeriod(rawPeriod)
+                .clearExtraData()
+                .putAllExtraData(metadata)
+                .build();
+        return new Offer(OfferPayload.fromProto(payload));
+    }
+}

--- a/desktop/src/main/java/haveno/desktop/components/paymentmethods/PaymentMethodForm.java
+++ b/desktop/src/main/java/haveno/desktop/components/paymentmethods/PaymentMethodForm.java
@@ -145,7 +145,7 @@ public abstract class PaymentMethodForm {
     public static InfoTextField addOpenTradeDuration(GridPane gridPane,
                                                      int gridRow,
                                                      Offer offer) {
-        long hours = offer.getPaymentMethod().getMaxTradePeriod() / 3600_000;
+        long hours = offer.getMaxTradePeriod() / 3600_000;
         final Tuple3<Label, InfoTextField, VBox> labelInfoTextFieldVBoxTuple3 =
                 addTopLabelInfoTextField(gridPane, gridRow, Res.get("payment.maxPeriod"),
                         getTimeText(hours), -Layout.FLOATING_LABEL_DISTANCE);

--- a/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
+++ b/desktop/src/main/java/haveno/desktop/main/portfolio/pendingtrades/steps/TradeStepView.java
@@ -756,7 +756,7 @@ public abstract class TradeStepView extends VBox {
         deadlineDate.setText(started ? Res.get(expired ? "portfolio.pending.tradeView.endedDate" :
                 "portfolio.pending.tradeView.deadlineDate", model.getDateForOpenDispute()) :
                 Res.get("portfolio.pending.remainingTimeDetail.startsAfter", Trade.NUM_BLOCKS_DEPOSITS_FINALIZED));
-        String period = FormattingUtils.formatDurationAsWords(trade.getOffer().getPaymentMethod().getMaxTradePeriod(), false, false);
+        String period = FormattingUtils.formatDurationAsWords(trade.getMaxTradePeriod(), false, false);
         duration.setText(Res.get(expired ? "portfolio.pending.tradeView.periodWas" : started ?
                 "portfolio.pending.tradeView.periodRemaining" : "portfolio.pending.tradeView.maximumPeriod", period));
         timeLeftProgressBar.setProgress(expired ? 1 : started ? Math.min(1, Math.max(0, 1 - model.getRemainingTradeDurationAsPercentage())) : 0);


### PR DESCRIPTION
Fixes https://github.com/haveno-dex/haveno/issues/2538

Preserve legacy deadlines using signed offer metadata. New, cloned, and edited Zelle offers use one day; requires a coordinated update.

Supersedes https://github.com/haveno-dex/haveno/pull/2540