### PR TITLE
core: prevent canceling offers reserved for trades

### DIFF
--- a/core/src/main/java/haveno/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/haveno/core/offer/OpenOfferManager.java
@@ -73,6 +73,7 @@ import haveno.core.support.dispute.arbitration.arbitrator.ArbitratorManager;
 import haveno.core.support.dispute.mediation.mediator.MediatorManager;
 import haveno.core.trade.ClosedTradableManager;
 import haveno.core.trade.HavenoUtils;
+import haveno.core.trade.Trade;
 import haveno.core.trade.TradableList;
 import haveno.core.trade.handlers.TransactionResultHandler;
 import haveno.core.trade.protocol.TradeProtocol;
@@ -347,17 +348,15 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     }
 
     private void removeOpenOffers(List<OpenOffer> openOffers, @Nullable Runnable completeHandler) {
+        List<OpenOffer> offers;
         synchronized (openOffers) {
-            int size = openOffers.size();
-            // Copy list as we remove in the loop
-            List<OpenOffer> openOffersList = new ArrayList<>(openOffers);
-            openOffersList.forEach(openOffer -> removeOpenOffer(openOffer, () -> {
-                    }, errorMessage -> {
-                        log.warn("Error removing open offer: " + errorMessage);
-                    }));
-            if (completeHandler != null)
-                UserThread.runAfter(completeHandler, size * 200 + 500, TimeUnit.MILLISECONDS);
+            offers = new ArrayList<>(openOffers);
         }
+        // wallet replacement invalidates all offers, including those reserved for trades
+        offers.forEach(openOffer -> removeOpenOfferAux(openOffer, null, true, () -> {
+                }, errorMessage -> log.warn("Error removing open offer: " + errorMessage)));
+        if (completeHandler != null)
+            UserThread.runAfter(completeHandler, offers.size() * 200 + 500, TimeUnit.MILLISECONDS);
     }
 
 
@@ -617,29 +616,70 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
     
     // Cancel and remove from offer book
     public void removeOpenOffer(OpenOffer openOffer, ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
-        removeOffer(openOffer.getOffer(), resultHandler, errorMessageHandler);
+        removeOpenOfferAux(openOffer, null, false, resultHandler, errorMessageHandler);
     }
 
     public void removeOffer(Offer offer, ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
         Optional<OpenOffer> openOfferOptional = getOpenOffer(offer.getId());
         if (openOfferOptional.isPresent()) {
-            removeOpenOfferAux(openOfferOptional.get(), resultHandler, errorMessageHandler);
+            removeOpenOffer(openOfferOptional.get(), resultHandler, errorMessageHandler);
         } else {
             String errorMsg = "Offer was not found in our list of open offers. We still try to remove it from the offerbook.";
             log.warn(errorMsg);
-            errorMessageHandler.handleErrorMessage(errorMsg);
+            if (errorMessageHandler != null) errorMessageHandler.handleErrorMessage(errorMsg);
             offerBookService.removeOffer(offer.getOfferPayload(), () -> offer.setState(Offer.State.REMOVED), null);
         }
     }
 
-    private void removeOpenOfferAux(OpenOffer openOffer,
-                                ResultHandler resultHandler,
-                                ErrorMessageHandler errorMessageHandler) {
-        log.info("Canceling and removing open offer: {}", openOffer.getId());
+    public boolean removeOpenOfferOnTradeError(Trade trade) {
+        Optional<OpenOffer> openOffer = getOpenOffer(trade.getId());
+        return openOffer.isPresent() && removeOpenOfferAux(openOffer.get(), trade, false, null, null);
+    }
+
+    private boolean removeOpenOfferAux(OpenOffer openOffer,
+                                      @Nullable Trade failingTrade,
+                                      boolean force,
+                                      ResultHandler resultHandler,
+                                      ErrorMessageHandler errorMessageHandler) {
         try {
+            // query before taking the offers lock; persisted trades can own offers reset to AVAILABLE
+            Trade owner = force || HavenoUtils.tradeManager == null ? null : HavenoUtils.tradeManager.getOpenTrade(openOffer.getId()).orElse(null);
+            String errorMessage = null;
+            boolean wasOnOfferBook = false;
+            synchronized (openOffers.getList()) {
+                if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.getState() == OpenOffer.State.CLOSED) {
+                    errorMessage = "The offer with ID " + openOffer.getId() + " was removed or replaced, so it cannot be canceled.";
+                } else if (failingTrade != null && (owner != failingTrade || !failingTrade.isMaker() || failingTrade.isSuperseded() || failingTrade.isShutDownStarted() || !failingTrade.isInPreparation())) {
+                    errorMessage = "The offer with ID " + openOffer.getId() + " cannot be canceled by an inactive or advanced trade.";
+                } else if (!force && failingTrade == null && (openOffer.isReserved() || (owner != null && owner.isMaker() && !owner.isSuperseded() && !owner.isShutDownStarted()))) {
+                    errorMessage = "The offer with ID " + openOffer.getId() + " is reserved for a trade in progress, so it cannot be canceled.";
+                } else {
+                    wasOnOfferBook = isOnOfferBook(openOffer);
+                    openOffer.setState(OpenOffer.State.CANCELED); // claim cancellation atomically with reservation
+                }
+            }
+            if (errorMessage != null) {
+                log.warn(errorMessage);
+                if (errorMessageHandler != null) errorMessageHandler.handleErrorMessage(errorMessage);
+                return false;
+            }
+
+            return removeCanceledOpenOffer(openOffer, wasOnOfferBook, resultHandler, errorMessageHandler);
+        } catch (Throwable t) {
+            log.warn("Error canceling open offer " + openOffer.getId() + ": " + t.getMessage(), t);
+            if (errorMessageHandler != null) errorMessageHandler.handleErrorMessage("Error canceling open offer " + openOffer.getId() + ": " + t.getMessage());
+            return false;
+        }
+    }
+
+    private boolean removeCanceledOpenOffer(OpenOffer openOffer,
+                                           boolean wasOnOfferBook,
+                                           ResultHandler resultHandler,
+                                           ErrorMessageHandler errorMessageHandler) {
+        try {
+            log.info("Canceling and removing open offer: {}", openOffer.getId());
             if (!offersToBeEdited.containsKey(openOffer.getId())) {
-                if (isOnOfferBook(openOffer)) {
-                    openOffer.setState(OpenOffer.State.CANCELED);
+                if (wasOnOfferBook) {
                     offerBookService.removeOffer(openOffer.getOffer().getOfferPayload(),
                             () -> {
                                 ThreadUtils.submitToPool(() -> { // TODO: this runs off thread and then shows popup when done. should show overlay spinner until done
@@ -649,7 +689,6 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                             },
                             errorMessageHandler);
                 } else {
-                    openOffer.setState(OpenOffer.State.CANCELED);
                     ThreadUtils.submitToPool(() -> {
                         doCancelOffer(openOffer);
                         if (resultHandler != null) resultHandler.handleResult();
@@ -661,21 +700,43 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 doCancelOffer(openOffer);
                 if (resultHandler != null) resultHandler.handleResult();
             }
+            return true;
         } catch (Throwable t) {
             log.warn("Error canceling open offer " + openOffer.getId() + ": " + t.getMessage(), t);
             if (errorMessageHandler != null) errorMessageHandler.handleErrorMessage("Error canceling open offer " + openOffer.getId() + ": " + t.getMessage());
+            return false;
         }
     }
 
     private void removeOpenOffersOnSpent(String keyImage) {
+        List<OpenOffer> offers = new ArrayList<>();
+        // check reservation under the offers lock so unreserve cannot miss a spent notification
         synchronized (openOffers.getList()) {
-            for (OpenOffer openOffer : new ArrayList<>(openOffers.getList())) {
+            for (OpenOffer openOffer : openOffers.getList()) {
                 if (openOffer.getState() != OpenOffer.State.CANCELED && openOffer.getState() != OpenOffer.State.RESERVED && openOffer.getOffer().getOfferPayload().getReserveTxKeyImages() != null && openOffer.getOffer().getOfferPayload().getReserveTxKeyImages().contains(keyImage)) {
-                    log.warn("Canceling open offer because reserved funds have been spent unexpectedly, offerId={}, state={}", openOffer.getId(), openOffer.getState());
-                    removeOpenOfferAux(openOffer, null, null);
+                    offers.add(openOffer);
                 }
             }
         }
+        for (OpenOffer openOffer : offers) {
+            log.warn("Canceling open offer because reserved funds have been spent unexpectedly, offerId={}, state={}", openOffer.getId(), openOffer.getState());
+            removeOpenOffer(openOffer, null, null);
+        }
+    }
+
+    public void removeOpenOfferIfSpent(OpenOffer openOffer) {
+        boolean spent;
+        synchronized (openOffers.getList()) {
+            if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || openOffer.isCanceled() || openOffer.isReserved()) return;
+            spent = hasSpentReserveOutputs(openOffer);
+        }
+        if (spent) removeOpenOffer(openOffer, null, null);
+    }
+
+    private boolean hasSpentReserveOutputs(OpenOffer openOffer) {
+        List<String> keyImages = openOffer.getOffer().getOfferPayload().getReserveTxKeyImages();
+        return keyImages != null && keyImages.stream().anyMatch(keyImage ->
+                Boolean.TRUE.equals(xmrConnectionService.getKeyImagePoller().isSpent(keyImage)));
     }
 
     public void activateOpenOffer(OpenOffer openOffer,
@@ -915,18 +976,30 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         requestPersistence();
     }
 
-    public void reserveOpenOffer(OpenOffer openOffer) {
-        openOffer.setState(OpenOffer.State.RESERVED);
+    public boolean reserveOpenOffer(OpenOffer openOffer) {
+        synchronized (openOffers.getList()) {
+            if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || !openOffer.isAvailable()) return false;
+            openOffer.setState(OpenOffer.State.RESERVED);
+        }
         requestPersistence();
+        return true;
     }
 
     public void unreserveOpenOffer(OpenOffer openOffer) {
-        if (!openOffer.isReserved()) { // TODO: this avoids a race condition with cancelOpenOffer (e.g. on 2nd arbitrator NACK) and onProtocolInitializationError after trade initialization fails, leaving a historical tradable in state AVAILABLE
-            log.warn("Not unreserving open offer {} because it is not reserved, state={}", openOffer.getId(), openOffer.getState());
-            return;
+        boolean spent;
+        boolean wasOnOfferBook;
+        synchronized (openOffers.getList()) {
+            if (getOpenOffer(openOffer.getId()).orElse(null) != openOffer || (!openOffer.isReserved() && !openOffer.isAvailable())) return;
+            spent = hasSpentReserveOutputs(openOffer);
+            wasOnOfferBook = spent && isOnOfferBook(openOffer);
+            // claim cancellation before releasing the lock so spent offers cannot be reserved again
+            openOffer.setState(spent ? OpenOffer.State.CANCELED : OpenOffer.State.AVAILABLE);
         }
-        openOffer.setState(OpenOffer.State.AVAILABLE);
         requestPersistence();
+        if (spent) {
+            log.warn("Canceling open offer after trade error because reserved funds have been spent, offerId={}", openOffer.getId());
+            removeCanceledOpenOffer(openOffer, wasOnOfferBook, null, null);
+        }
     }
 
     public boolean hasConflictingClone(OpenOffer openOffer) {

--- a/core/src/main/java/haveno/core/trade/Trade.java
+++ b/core/src/main/java/haveno/core/trade/Trade.java
@@ -2367,6 +2367,11 @@ public abstract class Trade extends XmrWalletBase implements Tradable, Model, Xm
 
             // unregister trade
             processModel.getTradeManager().unregisterTrade(this);
+
+            // retry spent-input cleanup after releasing ownership, preserving any new trade reservation
+            if (this instanceof MakerTrade && openOffer.isPresent()) {
+                processModel.getOpenOfferManager().removeOpenOfferIfSpent(openOffer.get());
+            }
         }
     }
 

--- a/core/src/main/java/haveno/core/trade/TradeManager.java
+++ b/core/src/main/java/haveno/core/trade/TradeManager.java
@@ -773,17 +773,27 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
             trade.getSelf().setReserveTxHex(openOffer.getReserveTxHex());
             trade.getSelf().setReserveTxKey(openOffer.getReserveTxKey());
             trade.getSelf().setReserveTxKeyImages(offer.getOfferPayload().getReserveTxKeyImages());
-            try {
-                addMakerTrade(trade);
-            } catch (IllegalArgumentException e) {
-                sendAckMessage(sender, request.getTakerPubKeyRing(), request, false, e.getMessage(), null);
+
+            // claim the offer atomically with cancellation
+            if (!openOfferManager.reserveOpenOffer(openOffer)) {
+                sendAckMessage(sender, request.getTakerPubKeyRing(), request, false, "The offer with ID " + request.getOfferId() + " is already taken or unavailable", null);
                 return;
             }
 
-            // reserve and initialize only after the payment amount has been claimed
-            openOfferManager.reserveOpenOffer(openOffer);
-            shutDownPriorFailedTrades(request.getOfferId());
+            boolean tradeAdded = false;
             try {
+                addMakerTrade(trade);
+                tradeAdded = true;
+            } catch (IllegalArgumentException e) {
+                sendAckMessage(sender, request.getTakerPubKeyRing(), request, false, e.getMessage(), null);
+                return;
+            } finally {
+                if (!tradeAdded) openOfferManager.unreserveOpenOffer(openOffer);
+            }
+
+            // initialize only after the offer and payment amount have been claimed
+            try {
+                shutDownPriorFailedTrades(request.getOfferId());
                 initTradeAndProtocol(trade, createTradeProtocol(trade));
             } catch (Exception e) {
                 log.warn("Maker error initializing trade protocol, tradeId={}", trade.getId(), e);

--- a/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/haveno/core/trade/protocol/TradeProtocol.java
@@ -43,7 +43,6 @@ import haveno.common.handlers.ErrorMessageHandler;
 import haveno.common.proto.network.NetworkEnvelope;
 import haveno.common.taskrunner.Task;
 import haveno.core.offer.Offer;
-import haveno.core.offer.OpenOffer;
 import haveno.core.support.messages.ChatMessage;
 import haveno.core.trade.ArbitratorTrade;
 import haveno.core.trade.BuyerTrade;
@@ -1157,12 +1156,10 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
 
         // remove offer on unacceptable 2nd nack
         String warningMessage = "Your offer (" + trade.getOffer().getShortId() + ") has been removed because there was a problem taking the trade.\n\nError message: " + ackMessage.getErrorMessage();
-        OpenOffer openOffer = HavenoUtils.openOfferManager.getOpenOffer(trade.getId()).orElse(null);
-        if (openOffer != null) {
-            HavenoUtils.openOfferManager.removeOpenOffer(openOffer, null, null);
+        if (HavenoUtils.openOfferManager.removeOpenOfferOnTradeError(trade)) {
             HavenoUtils.setTopError(warningMessage);
+            log.warn(warningMessage);
         }
-        log.warn(warningMessage);
     }
 
     private static boolean isAcceptableInitTradeRequestNack(AckMessage ackMessage) {

--- a/core/src/test/java/haveno/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/haveno/core/offer/OpenOfferManagerTest.java
@@ -8,7 +8,11 @@ import haveno.common.handlers.ResultHandler;
 import haveno.common.persistence.PersistenceManager;
 import haveno.core.api.CoreContext;
 import haveno.core.api.XmrConnectionService;
+import haveno.core.api.XmrKeyImagePoller;
+import haveno.core.trade.HavenoUtils;
 import haveno.core.trade.TradableList;
+import haveno.core.trade.Trade;
+import haveno.core.trade.TradeManager;
 import haveno.network.p2p.NetworkNotReadyException;
 import haveno.network.p2p.P2PService;
 import haveno.network.p2p.peers.PeerManager;
@@ -17,15 +21,26 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.natpryce.makeiteasy.MakeItEasy.make;
 import static haveno.core.offer.OfferMaker.btcUsdOffer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -235,6 +250,279 @@ public class OpenOfferManagerTest {
         manager.editOpenOfferStart(openOffer, () -> secondEditSuccessful.set(true), null);
         assertTrue(secondEditSuccessful.get());
         verify(offerBookService, times(2)).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+    }
+
+    @Test
+    public void testRemoveAllOpenOffersCancelsReservedOffer() {
+        assertRemoveAllOpenOffersCancelsTradeOwnedOffer(OpenOffer.State.RESERVED);
+    }
+
+    @Test
+    public void testRemoveAllOpenOffersCancelsRestoredTradeOwnedOffer() {
+        assertRemoveAllOpenOffersCancelsTradeOwnedOffer(OpenOffer.State.AVAILABLE);
+    }
+
+    private void assertRemoveAllOpenOffersCancelsTradeOwnedOffer(OpenOffer.State initialState) {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+        TradeManager tradeManager = mock(TradeManager.class);
+        Trade trade = mock(Trade.class);
+        TradeManager originalTradeManager = HavenoUtils.tradeManager;
+        OpenOfferManager originalOpenOfferManager = HavenoUtils.openOfferManager;
+
+        when(p2PService.isBootstrapped()).thenReturn(true);
+        when(trade.isMaker()).thenReturn(true);
+        doAnswer(invocation -> {
+            ((ErrorMessageHandler) invocation.getArgument(2)).handleErrorMessage("Network unavailable");
+            return null;
+        }).when(offerBookService).removeOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        try {
+            HavenoUtils.tradeManager = tradeManager;
+            OpenOfferManager manager = new OpenOfferManager(coreContext,
+                    null,
+                    null,
+                    p2PService,
+                    xmrConnectionService,
+                    null,
+                    null,
+                    null,
+                    offerBookService,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    persistenceManager,
+                    signedOfferPersistenceManager,
+                    null);
+            OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+            openOffer.setState(initialState);
+            manager.getObservableList().add(openOffer);
+            when(tradeManager.getOpenTrade(openOffer.getId())).thenReturn(Optional.of(trade));
+
+            AtomicBoolean cancelRejected = new AtomicBoolean(false);
+            manager.removeOpenOffer(openOffer, null, errorMessage -> cancelRejected.set(true));
+            assertTrue(cancelRejected.get());
+            assertEquals(initialState, openOffer.getState());
+
+            manager.removeAllOpenOffers(null);
+            assertEquals(OpenOffer.State.CANCELED, openOffer.getState());
+            verify(offerBookService).removeOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+            manager.unreserveOpenOffer(openOffer);
+            assertEquals(OpenOffer.State.CANCELED, openOffer.getState());
+            assertFalse(manager.reserveOpenOffer(openOffer));
+        } finally {
+            HavenoUtils.tradeManager = originalTradeManager;
+            HavenoUtils.openOfferManager = originalOpenOfferManager;
+        }
+    }
+
+    @Test
+    public void testUnreserveCancelsOfferWithSpentInputs() {
+        assertUnreserveOpenOfferState(OpenOffer.State.RESERVED, true, OpenOffer.State.CANCELED);
+    }
+
+    @Test
+    public void testUnreserveCancelsRestoredOfferWithSpentInputs() {
+        assertUnreserveOpenOfferState(OpenOffer.State.AVAILABLE, true, OpenOffer.State.CANCELED);
+    }
+
+    @Test
+    public void testUnreserveMakesUnspentOfferAvailable() {
+        assertUnreserveOpenOfferState(OpenOffer.State.RESERVED, false, OpenOffer.State.AVAILABLE);
+    }
+
+    @Test
+    public void testUnreserveMakesOfferWithUnknownSpentStatusAvailable() {
+        assertUnreserveOpenOfferState(OpenOffer.State.RESERVED, null, OpenOffer.State.AVAILABLE);
+    }
+
+    private void assertUnreserveOpenOfferState(OpenOffer.State initialState, Boolean spent, OpenOffer.State expectedState) {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+        XmrKeyImagePoller keyImagePoller = mock(XmrKeyImagePoller.class);
+        TradeManager originalTradeManager = HavenoUtils.tradeManager;
+        OpenOfferManager originalOpenOfferManager = HavenoUtils.openOfferManager;
+
+        when(p2PService.isBootstrapped()).thenReturn(true);
+        when(xmrConnectionService.getKeyImagePoller()).thenReturn(keyImagePoller);
+        when(keyImagePoller.isSpent("unspent")).thenReturn(false);
+        when(keyImagePoller.isSpent("reserve")).thenReturn(spent);
+        doAnswer(invocation -> {
+            ErrorMessageHandler errorMessageHandler = invocation.getArgument(2);
+            if (errorMessageHandler != null) errorMessageHandler.handleErrorMessage("Network unavailable");
+            return null;
+        }).when(offerBookService).removeOffer(any(OfferPayload.class), any(), any());
+
+        try {
+            HavenoUtils.tradeManager = null;
+            OpenOfferManager manager = createOfferManager(p2PService, offerBookService, xmrConnectionService);
+            OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+            openOffer.getOffer().getOfferPayload().setReserveTxKeyImages(List.of("unspent", "reserve"));
+            openOffer.setState(initialState);
+            manager.getObservableList().add(openOffer);
+
+            manager.unreserveOpenOffer(openOffer);
+
+            assertEquals(expectedState, openOffer.getState());
+            if (expectedState == OpenOffer.State.CANCELED) {
+                verify(offerBookService).removeOffer(any(OfferPayload.class), any(), any());
+                assertFalse(manager.reserveOpenOffer(openOffer));
+                manager.unreserveOpenOffer(openOffer);
+                assertEquals(OpenOffer.State.CANCELED, openOffer.getState());
+            }
+        } finally {
+            HavenoUtils.tradeManager = originalTradeManager;
+            HavenoUtils.openOfferManager = originalOpenOfferManager;
+        }
+    }
+
+    @Test
+    public void testSpentRecheckCancelsOfferAfterTradeUnregistered() {
+        assertSpentRecheckAfterOwnershipRelease(false);
+    }
+
+    @Test
+    public void testSpentRecheckPreservesNewTradeReservation() {
+        assertSpentRecheckAfterOwnershipRelease(true);
+    }
+
+    private void assertSpentRecheckAfterOwnershipRelease(boolean reserveAgain) {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+        XmrKeyImagePoller keyImagePoller = mock(XmrKeyImagePoller.class);
+        TradeManager tradeManager = mock(TradeManager.class);
+        Trade trade = mock(Trade.class);
+        TradeManager originalTradeManager = HavenoUtils.tradeManager;
+        OpenOfferManager originalOpenOfferManager = HavenoUtils.openOfferManager;
+
+        when(p2PService.isBootstrapped()).thenReturn(true);
+        when(xmrConnectionService.getKeyImagePoller()).thenReturn(keyImagePoller);
+        when(keyImagePoller.isSpent("reserve")).thenReturn(false);
+        when(trade.isMaker()).thenReturn(true);
+
+        try {
+            HavenoUtils.tradeManager = tradeManager;
+            OpenOfferManager manager = createOfferManager(p2PService, offerBookService, xmrConnectionService);
+            OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+            openOffer.getOffer().getOfferPayload().setReserveTxKeyImages(List.of("reserve"));
+            openOffer.setState(OpenOffer.State.RESERVED);
+            manager.getObservableList().add(openOffer);
+            when(tradeManager.getOpenTrade(openOffer.getId())).thenReturn(Optional.of(trade));
+
+            manager.unreserveOpenOffer(openOffer);
+            assertEquals(OpenOffer.State.AVAILABLE, openOffer.getState());
+
+            when(keyImagePoller.isSpent("reserve")).thenReturn(true);
+            manager.removeOpenOfferIfSpent(openOffer);
+            assertEquals(OpenOffer.State.AVAILABLE, openOffer.getState());
+            verify(offerBookService, never()).removeOffer(any(), any(), any());
+
+            when(tradeManager.getOpenTrade(openOffer.getId())).thenReturn(Optional.empty());
+            if (reserveAgain) assertTrue(manager.reserveOpenOffer(openOffer));
+            manager.removeOpenOfferIfSpent(openOffer);
+            if (reserveAgain) {
+                assertEquals(OpenOffer.State.RESERVED, openOffer.getState());
+                verify(offerBookService, never()).removeOffer(any(), any(), any());
+            } else {
+                assertEquals(OpenOffer.State.CANCELED, openOffer.getState());
+                verify(offerBookService).removeOffer(any(), any(), any());
+            }
+        } finally {
+            HavenoUtils.tradeManager = originalTradeManager;
+            HavenoUtils.openOfferManager = originalOpenOfferManager;
+        }
+    }
+
+    @Test
+    public void testSpentNotificationDuringUnreserveIsNotLost() throws Exception {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        XmrConnectionService xmrConnectionService = mock(XmrConnectionService.class);
+        XmrKeyImagePoller keyImagePoller = mock(XmrKeyImagePoller.class);
+        TradeManager originalTradeManager = HavenoUtils.tradeManager;
+        OpenOfferManager originalOpenOfferManager = HavenoUtils.openOfferManager;
+        CountDownLatch statusRead = new CountDownLatch(1);
+        CountDownLatch finishStatusRead = new CountDownLatch(1);
+        CountDownLatch notificationStarted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        when(p2PService.isBootstrapped()).thenReturn(true);
+        when(xmrConnectionService.getKeyImagePoller()).thenReturn(keyImagePoller);
+        when(keyImagePoller.isSpent("reserve")).thenAnswer(invocation -> {
+            statusRead.countDown();
+            assertTrue(finishStatusRead.await(5, TimeUnit.SECONDS));
+            return false;
+        });
+
+        try {
+            HavenoUtils.tradeManager = null;
+            OpenOfferManager manager = createOfferManager(p2PService, offerBookService, xmrConnectionService);
+            OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+            openOffer.getOffer().getOfferPayload().setReserveTxKeyImages(List.of("reserve"));
+            openOffer.setState(OpenOffer.State.RESERVED);
+            manager.getObservableList().add(openOffer);
+            var removeOnSpent = OpenOfferManager.class.getDeclaredMethod("removeOpenOffersOnSpent", String.class);
+            removeOnSpent.setAccessible(true);
+
+            var unreserve = executor.submit(() -> manager.unreserveOpenOffer(openOffer));
+            assertTrue(statusRead.await(5, TimeUnit.SECONDS));
+            var notification = executor.submit(() -> {
+                notificationStarted.countDown();
+                removeOnSpent.invoke(manager, "reserve");
+                return null;
+            });
+            assertTrue(notificationStarted.await(5, TimeUnit.SECONDS));
+            assertThrows(TimeoutException.class, () -> notification.get(100, TimeUnit.MILLISECONDS));
+            finishStatusRead.countDown();
+
+            unreserve.get(5, TimeUnit.SECONDS);
+            notification.get(5, TimeUnit.SECONDS);
+            assertEquals(OpenOffer.State.CANCELED, openOffer.getState());
+            verify(offerBookService).removeOffer(any(), any(), any());
+        } finally {
+            finishStatusRead.countDown();
+            executor.shutdownNow();
+            try {
+                assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            } finally {
+                HavenoUtils.tradeManager = originalTradeManager;
+                HavenoUtils.openOfferManager = originalOpenOfferManager;
+            }
+        }
+    }
+
+    private OpenOfferManager createOfferManager(P2PService p2PService,
+                                                OfferBookService offerBookService,
+                                                XmrConnectionService xmrConnectionService) {
+        return new OpenOfferManager(coreContext,
+                null,
+                null,
+                p2PService,
+                xmrConnectionService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                signedOfferPersistenceManager,
+                null);
     }
 
 }


### PR DESCRIPTION
Claim cancellation and reservation atomically using the offers lock. Allow initialization-error cleanup only for the current maker trade.