### PR TITLE
core, p2p: finish shutdown after cleanup failures

### DIFF
--- a/common/src/main/java/haveno/common/setup/CommonSetup.java
+++ b/common/src/main/java/haveno/common/setup/CommonSetup.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class CommonSetup {
     private static final int SHUTDOWN_WATCHDOG_MINUTES = 4;
     private static final AtomicBoolean exitScheduled = new AtomicBoolean();
-    private static final AtomicBoolean shutdownSignalReceived = new AtomicBoolean();
+    private static final AtomicBoolean shutdownWatchdogStarted = new AtomicBoolean();
     private static final AtomicBoolean shutdownHookRunning = new AtomicBoolean();
     private static final AtomicBoolean pipelineDisposedNpeLogged = new AtomicBoolean();
     private static volatile Thread shutdownHook;
@@ -124,9 +124,9 @@ public class CommonSetup {
         Thread.currentThread().setUncaughtExceptionHandler(handler);
     }
 
-    // true once an application exit is scheduled, a termination signal was received, or the JVM shutdown hook has started
+    // true once application exit is requested or the JVM shutdown hook has started
     private static boolean isShutdownInProgress() {
-        return exitScheduled.get() || shutdownSignalReceived.get() || shutdownHookRunning.get();
+        return exitScheduled.get() || shutdownWatchdogStarted.get() || shutdownHookRunning.get();
     }
 
     private static RepeatedThrow trackThrowSite(Throwable throwable) {
@@ -206,10 +206,10 @@ public class CommonSetup {
         shutdownHook = hook;
     }
 
-    // Halts the process if a signal-initiated graceful shutdown does not complete in time,
-    // since the handled signals no longer trigger the JVM's own bounded shutdown sequence.
-    private static void startShutdownWatchdog() {
-        if (!shutdownSignalReceived.compareAndSet(false, true)) {
+    // Halts the process if graceful shutdown for application exit does not complete in time.
+    // Applies to UI requests and signals which do not trigger the JVM shutdown sequence.
+    public static void startShutdownWatchdog() {
+        if (!shutdownWatchdogStarted.compareAndSet(false, true)) {
             return;
         }
 

--- a/core/src/main/java/haveno/core/app/HavenoExecutable.java
+++ b/core/src/main/java/haveno/core/app/HavenoExecutable.java
@@ -345,6 +345,7 @@ public abstract class HavenoExecutable implements GracefulShutDownHandler, Haven
     // This might need to be overwritten in case the application is not using all modules
     @Override
     public void gracefulShutDown(ResultHandler onShutdown, boolean systemExit) {
+        if (systemExit) CommonSetup.startShutdownWatchdog();
         log.info("Starting graceful shut down of {}", getClass().getSimpleName());
 
         // consume shutdownCompletedHandler so it runs once even when repeated requests join
@@ -393,34 +394,47 @@ public abstract class HavenoExecutable implements GracefulShutDownHandler, Haven
 
             // shut down open offer manager
             log.info("Shutting down OpenOfferManager");
-            injector.getInstance(OpenOfferManager.class).shutDown(() -> {
-
-                // listen for shut down of wallets setup
-                injector.getInstance(WalletsSetup.class).shutDownComplete.addListener((ov, o, n) -> {
-
-                    // shut down p2p service
-                    log.info("Shutting down P2P service");
-                    injector.getInstance(P2PService.class).shutDown(() -> {
-
-                        // done shutting down
-                        log.info("Graceful shutdown completed. Exiting now.");
-                        module.close(injector);
-                        completeShutdown(EXIT_SUCCESS);
-                    });
-                });
-
-                // shut down trade and wallet services
-                log.info("Shutting down trade and wallet services");
-                injector.getInstance(OfferBookService.class).shutDown();
-                injector.getInstance(TradeManager.class).shutDown();
-                injector.getInstance(BtcWalletService.class).shutDown();
-                injector.getInstance(XmrWalletService.class).shutDown();
-                injector.getInstance(XmrConnectionService.class).shutDown();
-                injector.getInstance(WalletsSetup.class).shutDown();
-            });
+            injector.getInstance(OpenOfferManager.class).shutDown(this::shutDownWalletsAndP2P);
         } catch (Throwable t) {
             log.error("App shutdown failed with exception: {}\n", t.getMessage(), t);
             completeShutdown(EXIT_FAILURE);
+        }
+    }
+
+    private void shutDownWalletsAndP2P() {
+        log.info("Shutting down trade and wallet services");
+        runShutDownTask("OfferBookService", () -> injector.getInstance(OfferBookService.class).shutDown());
+        runShutDownTask("TradeManager", () -> injector.getInstance(TradeManager.class).shutDown());
+        runShutDownTask("BtcWalletService", () -> injector.getInstance(BtcWalletService.class).shutDown());
+        runShutDownTask("XmrWalletService", () -> injector.getInstance(XmrWalletService.class).shutDown());
+        runShutDownTask("XmrConnectionService", () -> injector.getInstance(XmrConnectionService.class).shutDown());
+        // wallets setup waits for termination before returning, so continue even if its cleanup fails
+        runShutDownTask("WalletsSetup", () -> injector.getInstance(WalletsSetup.class).shutDown());
+
+        log.info("Shutting down P2P service");
+        try {
+            injector.getInstance(P2PService.class).shutDown(() -> {
+                log.info("Graceful shutdown completed. Exiting now.");
+                int exitCode = EXIT_SUCCESS;
+                try {
+                    module.close(injector);
+                } catch (Throwable t) {
+                    log.error("Failed to close application module", t);
+                    exitCode = EXIT_FAILURE;
+                }
+                completeShutdown(exitCode);
+            });
+        } catch (Throwable t) {
+            log.error("Failed to shut down P2P service", t);
+            completeShutdown(EXIT_FAILURE);
+        }
+    }
+
+    private void runShutDownTask(String service, Runnable task) {
+        try {
+            task.run();
+        } catch (Throwable t) {
+            log.error("Failed to shut down {}", service, t);
         }
     }
 

--- a/p2p/src/main/java/haveno/network/p2p/P2PService.java
+++ b/p2p/src/main/java/haveno/network/p2p/P2PService.java
@@ -67,6 +67,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -98,6 +100,9 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     private final Set<DecryptedDirectMessageListener> decryptedDirectMessageListeners = new CopyOnWriteArraySet<>();
     private final Set<P2PServiceListener> p2pServiceListeners = new CopyOnWriteArraySet<>();
     private final Set<Runnable> shutDownResultHandlers = new CopyOnWriteArraySet<>();
+    private final Object shutDownLock = new Object();
+    private boolean shutDownRequested;
+    private boolean shutDownComplete;
     private final BooleanProperty hiddenServicePublished = new SimpleBooleanProperty();
     private final BooleanProperty preliminaryDataReceived = new SimpleBooleanProperty();
     private final IntegerProperty numConnectedPeers = new SimpleIntegerProperty(0);
@@ -111,7 +116,7 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     @Getter
     private static NodeAddress myNodeAddress;
     @Getter
-    private boolean isShutDownStarted = false;
+    private volatile boolean isShutDownStarted = false;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -181,50 +186,90 @@ public class P2PService implements SetupListener, MessageListener, ConnectionLis
     }
 
     public void shutDown(Runnable shutDownCompleteHandler) {
-        log.info("P2PService shutdown started");
-        shutDownResultHandlers.add(shutDownCompleteHandler);
+        boolean alreadyComplete;
+        synchronized (shutDownLock) {
+            alreadyComplete = shutDownComplete;
+            if (!alreadyComplete) {
+                shutDownResultHandlers.add(shutDownCompleteHandler);
+                if (shutDownRequested) return;
+                shutDownRequested = true;
+            }
+        }
+        if (alreadyComplete) {
+            runShutDownTask("completion handler", shutDownCompleteHandler);
+            return;
+        }
 
-        // We need to make sure queued up messages are flushed out before we continue shut down other network
-        // services
-        if (broadcaster != null) {
-            broadcaster.shutDown(this::doShutDown);
-        } else {
+        log.info("P2PService shutdown started");
+        try {
+            // We need to make sure queued up messages are flushed out before we continue shut down other network
+            // services
+            if (broadcaster != null) {
+                broadcaster.shutDown(this::doShutDown);
+            } else {
+                doShutDown();
+            }
+        } catch (Throwable t) {
+            log.error("Failed to shut down broadcaster", t);
             doShutDown();
         }
     }
 
     private void doShutDown() {
+        synchronized (shutDownLock) {
+            if (isShutDownStarted) return;
+            isShutDownStarted = true;
+        }
         log.info("P2PService doShutDown started");
-        isShutDownStarted = true;
 
-        if (p2PDataStorage != null) {
-            p2PDataStorage.shutDown();
+        // A cleanup failure must not prevent the remaining services and network from shutting down.
+        runShutDownTask("P2PDataStorage", () -> {
+            if (p2PDataStorage != null) p2PDataStorage.shutDown();
+        });
+        runShutDownTask("PeerManager", () -> {
+            if (peerManager != null) peerManager.shutDown();
+        });
+        runShutDownTask("RequestDataManager", () -> {
+            if (requestDataManager != null) requestDataManager.shutDown();
+        });
+        runShutDownTask("PeerExchangeManager", () -> {
+            if (peerExchangeManager != null) peerExchangeManager.shutDown();
+        });
+        runShutDownTask("KeepAliveManager", () -> {
+            if (keepAliveManager != null) keepAliveManager.shutDown();
+        });
+        runShutDownTask("network ready subscription", () -> {
+            if (networkReadySubscription != null) networkReadySubscription.unsubscribe();
+        });
+
+        try {
+            if (networkNode != null) {
+                networkNode.shutDown(this::onShutDownComplete);
+            } else {
+                onShutDownComplete();
+            }
+        } catch (Throwable t) {
+            log.error("Failed to shut down network node", t);
+            onShutDownComplete();
         }
+    }
 
-        if (peerManager != null) {
-            peerManager.shutDown();
+    private void onShutDownComplete() {
+        List<Runnable> handlers;
+        synchronized (shutDownLock) {
+            if (shutDownComplete) return;
+            shutDownComplete = true;
+            handlers = new ArrayList<>(shutDownResultHandlers);
+            shutDownResultHandlers.clear();
         }
+        handlers.forEach(handler -> runShutDownTask("completion handler", handler));
+    }
 
-        if (requestDataManager != null) {
-            requestDataManager.shutDown();
-        }
-
-        if (peerExchangeManager != null) {
-            peerExchangeManager.shutDown();
-        }
-
-        if (keepAliveManager != null) {
-            keepAliveManager.shutDown();
-        }
-
-        if (networkReadySubscription != null) {
-            networkReadySubscription.unsubscribe();
-        }
-
-        if (networkNode != null) {
-            networkNode.shutDown(() -> shutDownResultHandlers.forEach(Runnable::run));
-        } else {
-            shutDownResultHandlers.forEach(Runnable::run);
+    private void runShutDownTask(String service, Runnable task) {
+        try {
+            task.run();
+        } catch (Throwable t) {
+            log.error("Failed to shut down {}", service, t);
         }
     }
 

--- a/p2p/src/main/java/haveno/network/p2p/peers/BroadcastHandler.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/BroadcastHandler.java
@@ -236,9 +236,11 @@ public class BroadcastHandler implements PeerManager.Listener {
                     numOfCompletedBroadcasts,
                     numOfFailedBroadcasts);
 
-            maybeNotifyListeners(broadcastRequests);
-
-            cleanup();
+            try {
+                maybeNotifyListeners(broadcastRequests);
+            } finally {
+                cleanup();
+            }
 
         }, timeoutDelay, TimeUnit.MILLISECONDS);
     }
@@ -271,8 +273,11 @@ public class BroadcastHandler implements PeerManager.Listener {
                     return;
                 }
 
-                maybeNotifyListeners(broadcastRequestsForConnection);
-                checkForCompletion();
+                try {
+                    maybeNotifyListeners(broadcastRequestsForConnection);
+                } finally {
+                    checkForCompletion();
+                }
             }
 
             @Override
@@ -284,8 +289,11 @@ public class BroadcastHandler implements PeerManager.Listener {
                 log.warn("Broadcast to " + connection.getPeersNodeAddressOptional() + " failed. ", throwable);
                 numOfFailedBroadcasts.incrementAndGet();
 
-                maybeNotifyListeners(broadcastRequestsForConnection);
-                checkForCompletion();
+                try {
+                    maybeNotifyListeners(broadcastRequestsForConnection);
+                } finally {
+                    checkForCompletion();
+                }
             }
         }, MoreExecutors.directExecutor());
     }

--- a/p2p/src/main/java/haveno/network/p2p/peers/Broadcaster.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/Broadcaster.java
@@ -49,6 +49,7 @@ public class Broadcaster implements BroadcastHandler.ResultHandler {
     private final List<BroadcastRequest> broadcastRequests = new ArrayList<>();
     private Timer timer;
     private boolean shutDownRequested;
+    private boolean shutDownComplete;
     private Runnable shutDownResultHandler;
     private final ListeningExecutorService executor;
     private final Object lock = new Object();
@@ -75,19 +76,22 @@ public class Broadcaster implements BroadcastHandler.ResultHandler {
 
     public void shutDown(Runnable resultHandler) {
         log.info("Broadcaster shutdown started");
-        shutDownRequested = true;
-        shutDownResultHandler = resultHandler;
-        synchronized (lock) {
-            if (broadcastRequests.isEmpty()) {
-                doShutDown();
-            } else {
-                // We set delay of broadcasts and timeout to very low values,
-                // so we can expect that we get onCompleted called very fast and trigger the
-                // doShutDown from there.
-                maybeBroadcastBundle();
+        try {
+            synchronized (lock) {
+                shutDownRequested = true;
+                shutDownResultHandler = resultHandler;
+                if (broadcastRequests.isEmpty()) {
+                    doShutDown();
+                } else {
+                    // We set delay of broadcasts and timeout to very low values,
+                    // so we can expect that we get onCompleted called very fast and trigger the
+                    // doShutDown from there.
+                    maybeBroadcastBundle();
+                }
             }
+        } finally {
+            executor.shutdown();
         }
-        executor.shutdown();
     }
 
     public void flush() {
@@ -95,14 +99,27 @@ public class Broadcaster implements BroadcastHandler.ResultHandler {
     }
 
     private void doShutDown() {
-        log.info("Broadcaster doShutDown started");
         synchronized (lock) {
-            broadcastHandlers.forEach(BroadcastHandler::cancel);
-            if (timer != null) {
-                timer.stop();
+            if (shutDownComplete) return;
+            shutDownComplete = true;
+            log.info("Broadcaster doShutDown started");
+            try {
+                broadcastHandlers.forEach(handler -> {
+                    try {
+                        handler.cancel();
+                    } catch (Throwable t) {
+                        log.error("Failed to cancel broadcast handler", t);
+                    }
+                });
+                broadcastHandlers.clear();
+                if (timer != null) {
+                    timer.stop();
+                    timer = null;
+                }
+            } finally {
+                shutDownResultHandler.run();
             }
         }
-        shutDownResultHandler.run();
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -118,6 +135,7 @@ public class Broadcaster implements BroadcastHandler.ResultHandler {
             @Nullable NodeAddress sender,
             @Nullable BroadcastHandler.Listener listener) {
         synchronized (lock) {
+            if (shutDownRequested) return;
             broadcastRequests.add(new BroadcastRequest(message, sender, listener));
             if (timer == null) {
                 timer = UserThread.runAfter(this::maybeBroadcastBundle, BROADCAST_INTERVAL_MS, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Continue cleanup after errors and finish shutdown callbacks once. Apply the exit watchdog to UI shutdown and preserve persistence.