### PR TITLE
core: recover transaction retries from failed nodes

### DIFF
--- a/core/src/main/java/haveno/core/api/XmrConnectionService.java
+++ b/core/src/main/java/haveno/core/api/XmrConnectionService.java
@@ -562,7 +562,11 @@ public final class XmrConnectionService {
     }
 
     public synchronized boolean requestConnectionSwitch(MoneroRpcConnection sourceConnection, XmrWalletBase requester) {
-        log.warn("Requesting connection switch to next best monerod, source monerod={}, proxyUri={}", sourceConnection == null ? null : sourceConnection.getUri(), sourceConnection == null ? null : sourceConnection.getProxyUri());
+        return requestConnectionSwitch(sourceConnection, requester, false);
+    }
+
+    public synchronized boolean requestConnectionSwitch(MoneroRpcConnection sourceConnection, XmrWalletBase requester, boolean skipCooldown) {
+        log.warn("Requesting connection switch to next best monerod, source monerod={}, proxyUri={}, skipCooldown={}", sourceConnection == null ? null : sourceConnection.getUri(), sourceConnection == null ? null : sourceConnection.getProxyUri(), skipCooldown);
         if (Config.baseCurrencyNetwork() == BaseCurrencyNetwork.XMR_LOCAL) {
             log.warn("Requesting connection switch on testnet", new RuntimeException("Stack trace"));
         }
@@ -601,7 +605,7 @@ public final class XmrConnectionService {
         if (HavenoUtils.isWalletInitialized()) {
 
             // skip if last switch was too recent
-            if (System.currentTimeMillis() - lastSwitchTimestamp < SKIP_SWITCH_WITHIN_MS) {
+            if (!skipCooldown && System.currentTimeMillis() - lastSwitchTimestamp < SKIP_SWITCH_WITHIN_MS) {
                 log.warn("Skipping switch to next best Monero connection because last switch was less than {} seconds ago", SKIP_SWITCH_WITHIN_MS / 1000);
                 return false;
             }

--- a/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
+++ b/core/src/main/java/haveno/core/xmr/wallet/XmrWalletService.java
@@ -2284,7 +2284,20 @@ public class XmrWalletService extends XmrWalletBase {
 
     public void handleMainWalletError(Exception e, MoneroRpcConnection sourceConnection, int numAttempts) {
         if (HavenoUtils.isUnresponsive(e)) forceCloseMainWallet(); // wallet can be stuck a while
-        if (numAttempts % TradeProtocol.REQUEST_CONNECTION_SWITCH_EVERY_NUM_ATTEMPTS == 0) requestConnectionSwitchSynchronous(sourceConnection); // request connection switch every n attempts
+        // bounded transaction retries can exhaust their attempts before the normal switch cooldown expires
+        if (numAttempts % TradeProtocol.REQUEST_CONNECTION_SWITCH_EVERY_NUM_ATTEMPTS == 0) requestConnectionSwitchSynchronous(sourceConnection, true);
+
+        // transaction retries hold walletLock, so apply even a concurrent switch whose listener is waiting on that lock
+        if (!isShutDownStarted && accountService.isAccountOpen()) {
+            MoneroRpcConnection connection = xmrConnectionService.getConnection();
+            if (connection != null) {
+                try {
+                    onConnectionChanged(connection);
+                } catch (Exception connectionError) {
+                    log.warn("Error applying connection to main wallet during transaction retry: {}", connectionError.getMessage());
+                }
+            }
+        }
         initMainWallet();
     }
 
@@ -2561,10 +2574,14 @@ public class XmrWalletService extends XmrWalletBase {
     }
 
     public boolean requestConnectionSwitchSynchronous(MoneroRpcConnection sourceConnection) {
+        return requestConnectionSwitchSynchronous(sourceConnection, false);
+    }
+
+    private boolean requestConnectionSwitchSynchronous(MoneroRpcConnection sourceConnection, boolean skipCooldown) {
         synchronized (requestConnectionSwitchSynchronousLock) {
             isProcessingRequestConnectionSwitchSynchronous = true;
             try {
-                if (xmrConnectionService.requestConnectionSwitch(sourceConnection, this)) {
+                if (xmrConnectionService.requestConnectionSwitch(sourceConnection, this, skipCooldown)) {
                     onConnectionChanged(xmrConnectionService.getConnection()); // handle connection change on same thread
                     return true;
                 }


### PR DESCRIPTION
Allow bounded main wallet transaction retries to bypass the switch cooldown and apply concurrent node changes before retrying.