### PR TITLE
core: prevent replay of committed closed-trade writes

### DIFF
--- a/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
+++ b/common/src/main/java/haveno/common/persistence/EncryptedAppendLog.java
@@ -252,6 +252,22 @@ public class EncryptedAppendLog {
     }
 
     /**
+     * Forces the log's current contents to disk. Records that replay after a process crash may still
+     * be unsynced when the crash cut an append short of its fsync.
+     */
+    public void sync() {
+        synchronized (lock) {
+            File logFile = logFile();
+            if (!logFile.exists()) return;
+            try (FileChannel ch = FileChannel.open(logFile.toPath(), StandardOpenOption.WRITE)) {
+                ch.force(true);
+            } catch (IOException e) {
+                throw new RuntimeException("Could not sync " + fileName, e);
+            }
+        }
+    }
+
+    /**
      * Atomically replaces the log with a fresh one containing exactly {@code records} (compaction or
      * migration). Writes to a temp file, fsyncs, then renames into place; a failure leaves the
      * existing log untouched.

--- a/core/src/main/java/haveno/core/trade/ClosedTradesStore.java
+++ b/core/src/main/java/haveno/core/trade/ClosedTradesStore.java
@@ -21,6 +21,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import com.google.protobuf.InvalidProtocolBufferException;
 import haveno.common.UserThread;
 import haveno.common.config.Config;
 import haveno.common.crypto.KeyRing;
@@ -37,6 +38,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,6 +53,7 @@ import lombok.extern.slf4j.Slf4j;
  * <p>The log holds {@link protobuf.TradableLogEntry} records: an {@code upsert} adds or replaces
  * the tradable with the matching id, a {@code delete_id} tombstones one. Replaying in order
  * (latest-wins per id, first-seen position kept) reconstructs the equivalent list.
+ * A mutation ID distinguishes retries from later writes with identical contents.
  *
  * <p>Writes never throw into callers: a failed batch is kept in memory, mirrored to a pending file
  * so it survives a process kill, and retried in order before the next write. Appends must be issued
@@ -86,6 +89,11 @@ public class ClosedTradesStore {
     // Entries whose write failed (e.g. disk full); mirrored to the pending file (best effort) and
     // retried in order before the next write, on a timer, and at shutdown.
     private final List<byte[]> failedEntries = new ArrayList<>();
+    private boolean pendingEntriesLoaded = false; // guarded by failedEntries
+    private boolean pendingReceiptsChecked = false; // guarded by failedEntries
+    private boolean pendingClearRequired = false; // guarded by failedEntries
+    private boolean pendingMigrationRequired = false; // guarded by failedEntries
+    private boolean receiptsUnsynced = false; // guarded by failedEntries
     private boolean retryScheduled = false; // guarded by failedEntries
     private static final long RETRY_DELAY_SEC = 30;
 
@@ -137,51 +145,132 @@ public class ClosedTradesStore {
     /**
      * Appends the given pre-encoded {@link protobuf.TradableLogEntry} records as one batch with a
      * single fsync. Never throws (a failed batch is queued and retried) except OutOfMemoryError,
-     * so heap exhaustion is never mistaken for a write failure.
+     * so heap exhaustion is never mistaken for a write failure. New mutations must be encoded with
+     * {@link #upsertBytes} or {@link #deleteBytes}; retries retain those bytes and their identities.
      */
     public void appendEntries(List<byte[]> entries) {
         synchronized (failedEntries) {
-            boolean hadFailed = !failedEntries.isEmpty();
-            List<byte[]> batch;
-            if (failedEntries.isEmpty()) {
-                batch = entries;
-            } else {
-                batch = new ArrayList<>(failedEntries.size() + entries.size());
-                batch.addAll(failedEntries);
-                batch.addAll(entries);
-            }
-            if (batch.isEmpty()) return;
+            if (entries.isEmpty() && failedEntries.isEmpty() && !pendingClearRequired) return;
+            List<byte[]> newEntries = entries;
             try {
-                appendLog().appendAll(batch);
-                failedEntries.clear();
-                if (hadFailed) clearPendingQueue(); // the recovered records are in the log now
+                // Recover older writes before accepting new ones, even when append precedes load.
+                loadPendingEntries();
+                if (!pendingReceiptsChecked) reconcilePendingEntries(appendLog().readAllValidRecords());
+                failedEntries.addAll(newEntries);
+                newEntries = List.of();
+                // Legacy queued records need durable identities before a retry can commit them.
+                if (pendingMigrationRequired) {
+                    syncReceipts();
+                    pendingLog().rewrite(failedEntries);
+                    pendingMigrationRequired = false;
+                }
+                if (!failedEntries.isEmpty()) {
+                    appendLog().appendAll(failedEntries);
+                    failedEntries.clear();
+                    receiptsUnsynced = false; // the append fsynced the log
+                }
+                if (pendingClearRequired) clearPendingQueue();
             } catch (OutOfMemoryError e) {
                 throw e;
             } catch (Throwable t) {
+                failedEntries.addAll(newEntries);
                 log.error("Could not append {} record(s) to {}; queueing them for retry.",
-                        batch.size(), LOG_FILE_NAME, t);
-                failedEntries.clear();
-                failedEntries.addAll(batch);
-                persistPendingQueue(batch);
-                if (!retryScheduled) {
-                    retryScheduled = true;
-                    UserThread.runAfter(() -> {
-                        synchronized (failedEntries) {
-                            retryScheduled = false;
-                        }
-                        flushFailedEntries();
-                    }, RETRY_DELAY_SEC);
+                        failedEntries.size(), LOG_FILE_NAME, t);
+                // Preserve the combined queue even when main-log reads fail, but never replace an
+                // unreadable pending file. Receipts are checked once the main log can be read.
+                if (pendingEntriesLoaded) {
+                    pendingClearRequired = true;
+                    persistPendingQueue(failedEntries);
                 }
+                scheduleRetry();
             }
         }
     }
 
     /**
-     * Retries any queued failed entries now; no-op when the queue is empty. Called on a timer after
-     * a failed write and from the shutdown sequence, so queued mutations do not die with the process.
+     * Retries failed appends and outstanding queue clears. Called on a timer after failure and
+     * from the shutdown sequence, so queued mutations do not die with the process.
      */
     public void flushFailedEntries() {
         appendEntries(List.of());
+    }
+
+    // Called under the queue monitor for either a failed append or an outstanding queue clear.
+    private void scheduleRetry() {
+        if (retryScheduled) return;
+        retryScheduled = true;
+        UserThread.runAfter(() -> {
+            synchronized (failedEntries) {
+                retryScheduled = false;
+            }
+            flushFailedEntries();
+        }, RETRY_DELAY_SEC);
+    }
+
+    // Called under the queue monitor before main-log reads, so a main-log failure cannot prevent
+    // new writes from being durably queued alongside older ones.
+    private void loadPendingEntries() {
+        if (!pendingEntriesLoaded) {
+            List<byte[]> pending = pendingLog().readAllValidRecords();
+            List<byte[]> recovered = new ArrayList<>(pending.size());
+            for (byte[] record : pending) {
+                if (mutationId(record).isEmpty()) {
+                    record = withMutationId(record);
+                    pendingMigrationRequired = true;
+                }
+                recovered.add(record);
+            }
+            if (pendingMigrationRequired) {
+                log.warn("Recovering legacy pending records without mutation IDs; their pre-upgrade commit status cannot be verified.");
+            }
+            failedEntries.addAll(0, recovered);
+            pendingClearRequired = !pending.isEmpty() || new File(dir, PENDING_FILE_NAME + ".tmp").exists();
+            pendingEntriesLoaded = true;
+        }
+    }
+
+    // Main-log identities are receipts: a committed mutation must not replay after a newer update
+    // merely because queue clearing failed. Called under the queue monitor before replay or writes.
+    private void reconcilePendingEntries(List<byte[]> records) {
+        // Bound receipt lookup to the queue, rather than retaining an ID for every historical write.
+        Set<String> uncommittedIds = new HashSet<>();
+        for (byte[] record : failedEntries) {
+            String id = mutationId(record);
+            if (!id.isEmpty()) uncommittedIds.add(id);
+        }
+        if (!uncommittedIds.isEmpty()) {
+            for (byte[] record : records) uncommittedIds.remove(mutationId(record));
+            if (failedEntries.removeIf(record -> {
+                String id = mutationId(record);
+                return !id.isEmpty() && !uncommittedIds.contains(id);
+            })) receiptsUnsynced = true;
+        }
+        pendingReceiptsChecked = true;
+    }
+
+    private static String mutationId(byte[] record) {
+        try {
+            return protobuf.TradableLogEntry.parseFrom(record).getMutationId();
+        } catch (InvalidProtocolBufferException e) {
+            return ""; // Preserve undecodable records; load reports them and suppresses compaction.
+        }
+    }
+
+    private static byte[] withMutationId(byte[] record) {
+        try {
+            return protobuf.TradableLogEntry.parseFrom(record).toBuilder()
+                    .setMutationId(UUID.randomUUID().toString()).build().toByteArray();
+        } catch (InvalidProtocolBufferException e) {
+            return record;
+        }
+    }
+
+    // Receipts may have replayed from an unsynced main-log tail (a crash cut an append short of its
+    // fsync); force them to disk before any pending rewrite can drop their queued copy.
+    private void syncReceipts() {
+        if (!receiptsUnsynced) return;
+        appendLog().sync();
+        receiptsUnsynced = false;
     }
 
     // Best-effort durable copy of the failed-write queue, so a queued batch survives a process
@@ -189,7 +278,9 @@ public class ClosedTradesStore {
     // retry succeeds.
     private void persistPendingQueue(List<byte[]> records) {
         try {
+            syncReceipts();
             pendingLog().rewrite(records);
+            pendingMigrationRequired = false;
         } catch (OutOfMemoryError e) {
             throw e;
         } catch (Throwable t) {
@@ -199,17 +290,22 @@ public class ClosedTradesStore {
 
     private void clearPendingQueue() {
         try {
-            if (pendingLog().exists()) pendingLog().rewrite(List.of());
+            // Also replaces a leftover rewrite temp when no live pending file was created.
+            syncReceipts();
+            pendingLog().rewrite(List.of());
+            pendingClearRequired = false;
         } catch (OutOfMemoryError e) {
             throw e;
         } catch (Throwable t) {
             log.warn("Could not clear the failed-write queue {}", PENDING_FILE_NAME, t);
+            scheduleRetry();
         }
     }
 
     static byte[] upsertBytes(Tradable tradable) {
         return protobuf.TradableLogEntry.newBuilder()
                 .setUpsert((protobuf.Tradable) tradable.toProtoMessage())
+                .setMutationId(UUID.randomUUID().toString())
                 .build()
                 .toByteArray();
     }
@@ -217,6 +313,7 @@ public class ClosedTradesStore {
     static byte[] deleteBytes(String id) {
         return protobuf.TradableLogEntry.newBuilder()
                 .setDeleteId(id)
+                .setMutationId(UUID.randomUUID().toString())
                 .build()
                 .toByteArray();
     }
@@ -233,11 +330,19 @@ public class ClosedTradesStore {
      * compaction suppressed so a fixed build can recover them.
      */
     public List<Tradable> load() {
+        synchronized (failedEntries) {
+            return loadLocked();
+        }
+    }
+
+    private List<Tradable> loadLocked() {
+        loadPendingEntries();
         List<byte[]> records = appendLog().readAllValidRecords();
+        reconcilePendingEntries(records);
 
         // Merge in records whose append failed in a previous session; they replay after the log
         // and are re-appended to it below.
-        List<byte[]> pendingRecords = pendingLog().readAllValidRecords();
+        List<byte[]> pendingRecords = new ArrayList<>(failedEntries);
         if (!pendingRecords.isEmpty()) {
             log.warn("Recovering {} record(s) from {} after a failed write in a previous session.",
                     pendingRecords.size(), PENDING_FILE_NAME);
@@ -290,19 +395,16 @@ public class ClosedTradesStore {
 
         // Re-append the recovered pending records to the log (clears the pending file on success),
         // so the on-disk log replays to this same state.
-        if (!pendingRecords.isEmpty()) {
-            synchronized (failedEntries) {
-                failedEntries.addAll(0, pendingRecords);
-            }
-            flushFailedEntries();
-        }
+        flushFailedEntries();
 
         maybeMergeLegacy(byId, seenIds);
 
         List<Tradable> result = new ArrayList<>(byId.values());
-        // Never compact while undecodable records exist - a rewrite from the decoded trades would
-        // permanently drop them.
-        if (skipped == 0) maybeCompact(records.size(), result, deletedIds);
+        // Compaction discards mutation identities. Keep them until the pending queue is cleared,
+        // and never rewrite from undecodable records or an uncommitted in-memory queue.
+        if (skipped == 0 && !pendingClearRequired && failedEntries.isEmpty()) {
+            maybeCompact(records.size(), result, deletedIds);
+        }
         return result;
     }
 

--- a/core/src/test/java/haveno/core/trade/ClosedTradesStoreTest.java
+++ b/core/src/test/java/haveno/core/trade/ClosedTradesStoreTest.java
@@ -18,6 +18,7 @@
 package haveno.core.trade;
 
 import com.google.inject.Provider;
+import haveno.common.UserThread;
 import haveno.common.crypto.Encryption;
 import haveno.common.crypto.KeyRing;
 import haveno.common.crypto.KeyStorage;
@@ -40,10 +41,26 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class ClosedTradesStoreTest {
 
@@ -264,6 +281,380 @@ public class ClosedTradesStoreTest {
         EncryptedAppendLog clearedPending = new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME, keyRing.getSymmetricKey(), 1);
         assertTrue(clearedPending.readAllValidRecords().isEmpty(), "pending queue must be cleared after recovery");
         assertEquals(List.of("b"), ids(newStore().load()));
+    }
+
+    @Test
+    public void testCommittedPendingUpdateCannotOverwriteNewerUpdateOnRestart() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore store = newStore();
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            setLog(store, "appendLog", main);
+            setLog(store, "pendingLog", pending);
+            doThrow(new IllegalStateException("Simulated append failure"))
+                    .doCallRealMethod().when(main).appendAll(anyList());
+            doThrow(new IllegalStateException("Simulated queue clear failure"))
+                    .when(pending).rewrite(List.of());
+
+            store.appendUpsert(openOffer("same", 1));
+            assertEquals(1, pending.readAllValidRecords().size());
+            store.appendUpsert(openOffer("same", 2));
+
+            List<Tradable> loaded = newStore().load();
+            assertEquals(List.of("same"), ids(loaded));
+            assertEquals(2, ((OpenOffer) loaded.get(0)).getTriggerPrice());
+            assertTrue(pending.readAllValidRecords().isEmpty());
+        }
+    }
+
+    @Test
+    public void testCommittedPendingDeleteCannotRemoveReaddedTradeOnRestart() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore store = newStore();
+            store.appendUpsert(openOffer("same", 1));
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            setLog(store, "appendLog", main);
+            setLog(store, "pendingLog", pending);
+            doThrow(new IllegalStateException("Simulated append failure"))
+                    .doCallRealMethod().when(main).appendAll(anyList());
+            doThrow(new IllegalStateException("Simulated queue clear failure"))
+                    .when(pending).rewrite(List.of());
+
+            store.appendDelete("same");
+            store.flushFailedEntries();
+            store.appendUpsert(openOffer("same", 2));
+
+            List<Tradable> loaded = newStore().load();
+            assertEquals(List.of("same"), ids(loaded));
+            assertEquals(2, ((OpenOffer) loaded.get(0)).getTriggerPrice());
+        }
+    }
+
+    @Test
+    public void testCommittedReceiptsAreSyncedBeforeQueueIsCleared() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            newStore().appendUpsert(openOffer("same", 1));
+            byte[] committed = new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3).readAllValidRecords().get(0);
+            new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME, keyRing.getSymmetricKey(), 1)
+                    .rewrite(List.of(committed));
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            ClosedTradesStore store = newStore();
+            setLog(store, "appendLog", main);
+            setLog(store, "pendingLog", pending);
+
+            assertEquals(List.of("same"), ids(store.load()));
+
+            InOrder inOrder = inOrder(main, pending);
+            inOrder.verify(main).sync();
+            inOrder.verify(pending).rewrite(List.of());
+            verify(main, never()).appendAll(anyList());
+            assertTrue(pending.readAllValidRecords().isEmpty());
+        }
+    }
+
+    @Test
+    public void testCommittedReceiptsAreSyncedBeforePendingSnapshotIsReplaced() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            newStore().appendUpsert(openOffer("a", 1));
+            byte[] committed = new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3).readAllValidRecords().get(0);
+            new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME, keyRing.getSymmetricKey(), 1)
+                    .rewrite(List.of(committed, ClosedTradesStore.upsertBytes(openOffer("b", 1))));
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            doThrow(new IllegalStateException("Simulated append failure")).when(main).appendAll(anyList());
+            ClosedTradesStore store = newStore();
+            setLog(store, "appendLog", main);
+            setLog(store, "pendingLog", pending);
+
+            assertEquals(List.of("a", "b"), ids(store.load()));
+
+            InOrder inOrder = inOrder(main, pending);
+            inOrder.verify(main).sync();
+            inOrder.verify(pending).rewrite(anyList());
+            assertEquals(1, pending.readAllValidRecords().size());
+        }
+    }
+
+    private static void setLog(ClosedTradesStore store, String name, EncryptedAppendLog log) throws Exception {
+        var field = ClosedTradesStore.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(store, log);
+    }
+
+    @Test
+    public void testLaterIdenticalDeleteIsStillRecovered() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore store = newStore();
+            store.appendUpsert(openOffer("same", 1));
+            store.appendDelete("same");
+            store.appendUpsert(openOffer("same", 2));
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            setLog(store, "appendLog", main);
+            doThrow(new IllegalStateException("Simulated append failure")).when(main).appendAll(anyList());
+
+            store.appendDelete("same");
+
+            assertTrue(newStore().load().isEmpty(), "equal payloads can represent separate mutations");
+        }
+    }
+
+    @Test
+    public void testPartialBatchRestartPreservesReaddedTradeOrder() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore store = newStore();
+            store.appendUpsert(openOffer("a", 0));
+            store.appendUpsert(openOffer("b", 0));
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            setLog(store, "appendLog", main);
+            doThrow(new IllegalStateException("Simulated append failure")).when(main).appendAll(anyList());
+            store.appendEntries(List.of(ClosedTradesStore.deleteBytes("a"),
+                    ClosedTradesStore.upsertBytes(openOffer("a", 1)),
+                    ClosedTradesStore.upsertBytes(openOffer("c", 0))));
+            doAnswer(invocation -> {
+                List<byte[]> batch = invocation.getArgument(0);
+                new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME, keyRing.getSymmetricKey(), 3)
+                        .appendAll(batch.subList(0, 2));
+                throw new OutOfMemoryError("Simulated process termination during batch append");
+            }).when(main).appendAll(anyList());
+            assertThrows(OutOfMemoryError.class, store::flushFailedEntries);
+
+            assertEquals(List.of("b", "a", "c"), ids(newStore().load()));
+            assertEquals(List.of("b", "a", "c"), ids(newStore().load()));
+            assertEquals(5, new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3).readAllValidRecords().size());
+        }
+    }
+
+    @Test
+    public void testFailedPendingClearDefersCompactionUntilRestartRecovery() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore store = newStore();
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            setLog(store, "appendLog", main);
+            setLog(store, "pendingLog", pending);
+            doThrow(new IllegalStateException("Simulated append failure"))
+                    .doCallRealMethod().when(main).appendAll(anyList());
+            doThrow(new IllegalStateException("Simulated queue clear failure"))
+                    .when(pending).rewrite(List.of());
+            store.appendUpsert(openOffer("same", 0));
+            for (int i = 1; i <= 600; i++) store.appendUpsert(openOffer("same", i));
+
+            ClosedTradesStore reader = newStore();
+            setLog(reader, "appendLog", main);
+            setLog(reader, "pendingLog", pending);
+            List<Tradable> loaded = reader.load();
+            assertEquals(600, ((OpenOffer) loaded.get(0)).getTriggerPrice());
+            verify(main, never()).rewrite(anyList());
+
+            assertEquals(600, ((OpenOffer) newStore().load().get(0)).getTriggerPrice());
+            assertEquals(1, new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3).readAllValidRecords().size());
+            assertEquals(600, ((OpenOffer) newStore().load().get(0)).getTriggerPrice());
+        }
+    }
+
+    @Test
+    public void testLegacyPendingIdentitiesAreDurableBeforeAppend() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            pending.rewrite(List.of(protobuf.TradableLogEntry.newBuilder()
+                    .setUpsert((protobuf.Tradable) openOffer("same", 1).toProtoMessage()).build().toByteArray()));
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            doAnswer(invocation -> {
+                List<byte[]> batch = invocation.getArgument(0);
+                String durableId = protobuf.TradableLogEntry.parseFrom(pending.readAllValidRecords().get(0)).getMutationId();
+                assertFalse(durableId.isEmpty());
+                assertEquals(durableId, protobuf.TradableLogEntry.parseFrom(batch.get(0)).getMutationId());
+                return invocation.callRealMethod();
+            }).when(main).appendAll(anyList());
+            doThrow(new OutOfMemoryError("Simulated process termination before queue clear"))
+                    .when(pending).rewrite(List.of());
+            ClosedTradesStore store = newStore();
+            setLog(store, "appendLog", main);
+            setLog(store, "pendingLog", pending);
+
+            assertThrows(OutOfMemoryError.class, store::load);
+
+            ClosedTradesStore restarted = newStore();
+            restarted.appendUpsert(openOffer("same", 2));
+            assertEquals(2, ((OpenOffer) newStore().load().get(0)).getTriggerPrice());
+        }
+    }
+
+    @Test
+    public void testFailedLegacyPendingMigrationDefersAppendWithoutHidingHistory() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            newStore().appendUpsert(openOffer("main", 0));
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            pending.rewrite(List.of(protobuf.TradableLogEntry.newBuilder()
+                    .setUpsert((protobuf.Tradable) openOffer("queued", 1).toProtoMessage()).build().toByteArray()));
+            byte[] originalPending = Files.readAllBytes(new File(dir, ClosedTradesStore.PENDING_FILE_NAME).toPath());
+            doThrow(new IllegalStateException("Simulated legacy queue rewrite failure"))
+                    .when(pending).rewrite(anyList());
+            ClosedTradesStore store = newStore();
+            setLog(store, "pendingLog", pending);
+
+            assertEquals(List.of("main", "queued"), ids(store.load()));
+            assertEquals(1, new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3).readAllValidRecords().size());
+            assertArrayEquals(originalPending,
+                    Files.readAllBytes(new File(dir, ClosedTradesStore.PENDING_FILE_NAME).toPath()));
+            doCallRealMethod().when(pending).rewrite(anyList());
+            store.appendUpsert(openOffer("queued", 2));
+
+            assertEquals(2, ((OpenOffer) newStore().load().get(1)).getTriggerPrice());
+        }
+    }
+
+    @Test
+    public void testAppendBeforeLoadRecoversOlderPendingFirst() throws Exception {
+        new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME, keyRing.getSymmetricKey(), 1)
+                .rewrite(List.of(ClosedTradesStore.upsertBytes(openOffer("same", 1))));
+
+        newStore().appendUpsert(openOffer("same", 2));
+
+        assertEquals(2, ((OpenOffer) newStore().load().get(0)).getTriggerPrice());
+    }
+
+    @Test
+    public void testFailedClearIsRetriedWithEmptyMemoryQueue() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            pending.rewrite(List.of(ClosedTradesStore.upsertBytes(openOffer("queued", 1))));
+            doThrow(new IllegalStateException("Simulated queue clear failure"))
+                    .doCallRealMethod().when(pending).rewrite(List.of());
+            ClosedTradesStore store = newStore();
+            setLog(store, "pendingLog", pending);
+            store.load();
+            assertEquals(1, pending.readAllValidRecords().size());
+            ArgumentCaptor<Runnable> retry = ArgumentCaptor.forClass(Runnable.class);
+            userThread.verify(() -> UserThread.runAfter(retry.capture(), eq(30L)));
+
+            retry.getValue().run();
+
+            assertTrue(pending.readAllValidRecords().isEmpty());
+            assertEquals(List.of("queued"), ids(newStore().load()));
+        }
+    }
+
+    @Test
+    public void testOlderPendingSnapshotCannotOverwriteNewerBatchOnRestart() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore store = newStore();
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            setLog(store, "appendLog", main);
+            setLog(store, "pendingLog", pending);
+            doThrow(new IllegalStateException("Simulated append failure"))
+                    .doThrow(new IllegalStateException("Simulated repeated append failure"))
+                    .doCallRealMethod().when(main).appendAll(anyList());
+            store.appendUpsert(openOffer("same", 1));
+            doThrow(new IllegalStateException("Simulated pending rewrite failure")).when(pending).rewrite(anyList());
+            store.appendUpsert(openOffer("same", 2));
+            store.appendUpsert(openOffer("same", 3));
+
+            assertEquals(3, ((OpenOffer) newStore().load().get(0)).getTriggerPrice());
+        }
+    }
+
+    @Test
+    public void testMainReadFailureStillDurablyQueuesNewWritesAlongsideOldPending() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore writer = newStore();
+            writer.appendUpsert(openOffer("committed", 1));
+            EncryptedAppendLog main = spy(new EncryptedAppendLog(dir, ClosedTradesStore.LOG_FILE_NAME,
+                    keyRing.getSymmetricKey(), 3));
+            byte[] committed = main.readAllValidRecords().get(0);
+            writer.appendUpsert(openOffer("committed", 2));
+            EncryptedAppendLog pending = new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1);
+            pending.rewrite(List.of(committed, protobuf.TradableLogEntry.newBuilder()
+                    .setUpsert((protobuf.Tradable) openOffer("queued", 1).toProtoMessage()).build().toByteArray()));
+            doThrow(new IllegalStateException("Simulated main-log read failure")).when(main).readAllValidRecords();
+            ClosedTradesStore store = newStore();
+            setLog(store, "appendLog", main);
+
+            store.appendUpsert(openOffer("new", 3));
+
+            assertEquals(3, pending.readAllValidRecords().size());
+            assertFalse(protobuf.TradableLogEntry.parseFrom(pending.readAllValidRecords().get(1)).getMutationId().isEmpty());
+            doCallRealMethod().when(main).readAllValidRecords();
+            store.appendUpsert(openOffer("next", 4));
+            List<Tradable> loaded = newStore().load();
+            assertEquals(List.of("committed", "queued", "new", "next"), ids(loaded));
+            assertEquals(2, ((OpenOffer) loaded.get(0)).getTriggerPrice());
+            assertEquals(3, ((OpenOffer) loaded.get(2)).getTriggerPrice());
+        }
+    }
+
+    @Test
+    public void testMainReadFailureCanCreateFirstDurableQueue() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore store = newStore();
+            EncryptedAppendLog main = mock(EncryptedAppendLog.class);
+            doThrow(new IllegalStateException("Simulated main-log read failure")).when(main).readAllValidRecords();
+            setLog(store, "appendLog", main);
+
+            store.appendUpsert(openOffer("new", 3));
+
+            assertEquals(List.of("new"), ids(newStore().load()));
+        }
+    }
+
+    @Test
+    public void testEmptyPendingFileDoesNotNeedClearingOnStartup() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            EncryptedAppendLog pending = spy(new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME,
+                    keyRing.getSymmetricKey(), 1));
+            new EncryptedAppendLog(dir, ClosedTradesStore.PENDING_FILE_NAME, keyRing.getSymmetricKey(), 1).rewrite(List.of());
+            ClosedTradesStore store = newStore();
+            setLog(store, "pendingLog", pending);
+
+            assertTrue(store.load().isEmpty());
+
+            verify(pending, never()).rewrite(anyList());
+            userThread.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    public void testIdleShutdownFlushDoesNotInitializeLockedStore() throws Exception {
+        try (var userThread = mockStatic(UserThread.class)) {
+            ClosedTradesStore store = newStore();
+            EncryptedAppendLog main = mock(EncryptedAppendLog.class);
+            EncryptedAppendLog pending = mock(EncryptedAppendLog.class);
+            setLog(store, "appendLog", main);
+            setLog(store, "pendingLog", pending);
+            keyRing.lockKeys();
+
+            store.flushFailedEntries();
+
+            verifyNoInteractions(main, pending);
+            userThread.verifyNoInteractions();
+        }
     }
 
     @Test

--- a/proto/src/main/proto/pb.proto
+++ b/proto/src/main/proto/pb.proto
@@ -1534,6 +1534,8 @@ message TradableLogEntry {
         Tradable upsert = 1;
         string delete_id = 2;
     }
+    // Local persistence identity, retained when a failed mutation is retried.
+    string mutation_id = 3;
 }
 
 message Offer {


### PR DESCRIPTION
Give queued mutations stable identities and retain them until the queue is cleared, including across restart, migration, and compaction.