### PR TITLE
Add Ergo (ERG) cryptocurrency payments

### DIFF
--- a/assets/src/main/java/haveno/asset/ErgoAddressValidator.java
+++ b/assets/src/main/java/haveno/asset/ErgoAddressValidator.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.asset;
+
+import org.bitcoinj.core.Base58;
+import org.bouncycastle.crypto.digests.Blake2bDigest;
+import org.bouncycastle.crypto.ec.CustomNamedCurves;
+import org.bouncycastle.math.ec.ECCurve;
+import org.bouncycastle.math.ec.ECPoint;
+
+import java.util.Arrays;
+
+/**
+ * Payment admission for ordinary Ergo mainnet P2PK addresses.
+ * P2S, P2SH and testnet addresses are outside this payment policy.
+ */
+public class ErgoAddressValidator implements AddressValidator {
+
+    private static final int CHECKSUM_LENGTH = 4;
+    private static final int P2PK_LENGTH = 1 + 33 + CHECKSUM_LENGTH;
+    private static final int MAX_ENCODED_LENGTH = 52; // Base58 ceiling for a 38-byte envelope
+    private static final ECCurve CURVE = CustomNamedCurves.getByName("secp256k1").getCurve();
+
+    @Override
+    public AddressValidationResult validate(String address) {
+        if (address == null || address.isEmpty())
+            return AddressValidationResult.invalidStructure();
+        if (address.length() > MAX_ENCODED_LENGTH)
+            return unsupportedAddress();
+
+        try {
+            byte[] decoded = Base58.decode(address);
+            if (decoded.length < 1 + 1 + CHECKSUM_LENGTH || !Base58.encode(decoded).equals(address))
+                return AddressValidationResult.invalidStructure();
+
+            int contentLength = decoded.length - CHECKSUM_LENGTH;
+            Blake2bDigest digest = new Blake2bDigest(256);
+            digest.update(decoded, 0, contentLength);
+            byte[] hash = new byte[32];
+            digest.doFinal(hash, 0);
+            for (int i = 0; i < CHECKSUM_LENGTH; i++) {
+                if (decoded[contentLength + i] != hash[i])
+                    return AddressValidationResult.invalidStructure();
+            }
+
+            int prefix = Byte.toUnsignedInt(decoded[0]);
+            if (prefix == 0x02 || prefix == 0x03 || prefix == 0x11 || prefix == 0x12 || prefix == 0x13)
+                return unsupportedAddress();
+            if (prefix != 0x01 || decoded.length != P2PK_LENGTH)
+                return AddressValidationResult.invalidStructure();
+
+            byte[] publicKey = Arrays.copyOfRange(decoded, 1, contentLength);
+            // canonical identity is valid Ergo encoding, but is outside ordinary wallet payment policy
+            if (Arrays.equals(publicKey, new byte[33]))
+                return unsupportedAddress();
+            if (publicKey[0] != 0x02 && publicKey[0] != 0x03)
+                return AddressValidationResult.invalidStructure();
+
+            ECPoint point = CURVE.decodePoint(publicKey);
+            if (point.isInfinity() || !point.isValid() || !Arrays.equals(publicKey, point.getEncoded(true)))
+                return AddressValidationResult.invalidStructure();
+
+            return AddressValidationResult.validAddress();
+        } catch (IllegalArgumentException ex) {
+            return AddressValidationResult.invalidStructure();
+        }
+    }
+
+    private AddressValidationResult unsupportedAddress() {
+        return AddressValidationResult.invalidAddress("", "validation.crypto.ergo.mainnetP2pk");
+    }
+}

--- a/assets/src/main/java/haveno/asset/coins/Ergo.java
+++ b/assets/src/main/java/haveno/asset/coins/Ergo.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Haveno.
+ *
+ * Haveno is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Haveno is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Haveno. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package haveno.asset.coins;
+
+import haveno.asset.Coin;
+import haveno.asset.ErgoAddressValidator;
+
+public class Ergo extends Coin {
+
+    public Ergo() {
+        super("Ergo", "ERG", new ErgoAddressValidator());
+    }
+}

--- a/assets/src/main/resources/META-INF/services/haveno.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/haveno.asset.Asset
@@ -6,6 +6,7 @@ haveno.asset.coins.Bitcoin$Mainnet
 haveno.asset.coins.BitcoinCash
 haveno.asset.coins.Cardano
 haveno.asset.coins.Dogecoin
+haveno.asset.coins.Ergo
 haveno.asset.coins.Ether
 haveno.asset.coins.Litecoin
 haveno.asset.coins.Monero

--- a/build.gradle
+++ b/build.gradle
@@ -411,6 +411,7 @@ configure(project(':proto')) {
 
 configure(project(':assets')) {
     dependencies {
+        implementation libs.bcprov.jdk18on
         implementation(libs.bitcoinj) {
             exclude(module: 'bcprov-jdk15on')
             exclude(module: 'guava')

--- a/core/src/main/java/haveno/core/api/CoreOffersService.java
+++ b/core/src/main/java/haveno/core/api/CoreOffersService.java
@@ -64,6 +64,7 @@ import haveno.core.trade.HavenoUtils;
 
 import static haveno.core.payment.PaymentAccountUtil.isPaymentAccountValidForNewOffer;
 import haveno.core.user.User;
+import haveno.core.util.ParsingUtils;
 import haveno.core.util.PriceUtil;
 import static java.lang.String.format;
 import java.math.BigDecimal;
@@ -291,7 +292,16 @@ public class CoreOffersService {
         String upperCaseCurrencyCode = currencyCode.toUpperCase();
 
         // get price (default to source price)
-        Price price = useMarketBasedPrice ? null : priceAsString.isEmpty() ? sourceOffer.isUseMarketBasedPrice() ? null : sourceOffer.getPrice() : Price.parse(upperCaseCurrencyCode, priceAsString);
+        Price price = null;
+        if (!useMarketBasedPrice) {
+            if (priceAsString.isEmpty())
+                price = sourceOffer.isUseMarketBasedPrice() ? null : sourceOffer.getPrice();
+            else if (CurrencyUtil.isTraditionalCurrency(upperCaseCurrencyCode))
+                price = Price.parse(upperCaseCurrencyCode, priceAsString);
+            else
+                price = Price.valueOf(upperCaseCurrencyCode,
+                        priceStringToLong(ParsingUtils.convertCharsForNumber(priceAsString), upperCaseCurrencyCode));
+        }
         if (price == null) useMarketBasedPrice = true;
 
         // get extra info
@@ -529,7 +539,20 @@ public class CoreOffersService {
     }
 
     private long priceStringToLong(String priceAsString, String currencyCode) {
-        int precision = CurrencyUtil.isTraditionalCurrency(currencyCode) ? TraditionalMoney.SMALLEST_UNIT_EXPONENT : CryptoMoney.SMALLEST_UNIT_EXPONENT;
+        if (!CurrencyUtil.isTraditionalCurrency(currencyCode)) {
+            try {
+                BigDecimal price = new BigDecimal(priceAsString);
+                int precision = CryptoMoney.SMALLEST_UNIT_EXPONENT;
+                if (price.compareTo(BigDecimal.valueOf(Long.MIN_VALUE, precision)) < 0 ||
+                        price.compareTo(BigDecimal.valueOf(Long.MAX_VALUE, precision)) > 0)
+                    throw new IllegalArgumentException("Crypto price has too many decimals or is out of range");
+                return price.movePointRight(precision).longValueExact();
+            } catch (ArithmeticException e) {
+                throw new IllegalArgumentException("Crypto price has too many decimals or is out of range", e);
+            }
+        }
+
+        int precision = TraditionalMoney.SMALLEST_UNIT_EXPONENT;
         double priceAsDouble = new BigDecimal(priceAsString).doubleValue();
         double scaled = scaleUpByPowerOf10(priceAsDouble, precision);
         return roundDoubleToLong(scaled);

--- a/core/src/main/java/haveno/core/util/PriceUtil.java
+++ b/core/src/main/java/haveno/core/util/PriceUtil.java
@@ -54,9 +54,10 @@ public class PriceUtil {
     }
 
     public static MonetaryValidator getPriceValidator(String currencyCode) {
+        // Trigger and alert values keep the existing downstream rounding
         return CurrencyUtil.isPricePrecise(currencyCode) ?
                 new AmountValidator4Decimals() :
-                new AmountValidator8Decimals();
+                new AmountValidator8Decimals(false);
     }
 
     public static InputValidator.ValidationResult isTriggerPriceValid(String triggerPriceAsString,

--- a/core/src/main/java/haveno/core/util/validation/AmountValidator8Decimals.java
+++ b/core/src/main/java/haveno/core/util/validation/AmountValidator8Decimals.java
@@ -18,8 +18,34 @@
 package haveno.core.util.validation;
 
 import com.google.inject.Inject;
+import haveno.core.locale.Res;
+import haveno.core.monetary.CryptoMoney;
+
+import java.math.BigDecimal;
 
 public class AmountValidator8Decimals extends MonetaryValidator {
+    private final boolean requireExactAmount;
+
+    @Override
+    public ValidationResult validate(String input) {
+        ValidationResult result = super.validate(input);
+        if (!result.isValid || !requireExactAmount)
+            return result;
+
+        try {
+            BigDecimal amount = new BigDecimal(cleanInput(input));
+            if (amount.compareTo(BigDecimal.valueOf(getMinValue())) < 0)
+                return new ValidationResult(false, Res.get("validation.traditional.tooSmall"));
+            if (amount.compareTo(BigDecimal.valueOf(getMaxValue())) > 0)
+                return new ValidationResult(false, Res.get("validation.traditional.tooLarge"));
+            if (amount.stripTrailingZeros().scale() > CryptoMoney.SMALLEST_UNIT_EXPONENT)
+                return new ValidationResult(false, Res.get("validation.crypto.tooManyDecimals"));
+            return result;
+        } catch (NumberFormatException ex) {
+            return new ValidationResult(false, Res.get("validation.NaN"));
+        }
+    }
+
     @Override
     public double getMinValue() {
         return 0.00000001;
@@ -33,5 +59,10 @@ public class AmountValidator8Decimals extends MonetaryValidator {
 
     @Inject
     public AmountValidator8Decimals() {
+        this(true);
+    }
+
+    public AmountValidator8Decimals(boolean requireExactAmount) {
+        this.requireExactAmount = requireExactAmount;
     }
 }

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3757,6 +3757,8 @@ validation.invalidInput=Invalid input: {0}
 validation.accountNrFormat=Account number must be of format: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Address validation failed because it does not match the structure of a {0} address.
+validation.crypto.ergo.mainnetP2pk=Use a standard Ergo mainnet wallet address (P2PK). P2S/P2SH script addresses and testnet addresses are not supported.
+validation.crypto.tooManyDecimals=Enter a value with at most 8 decimal places.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_cs.properties
+++ b/core/src/main/resources/i18n/displayStrings_cs.properties
@@ -2353,7 +2353,7 @@ guiUtil.accountExport.tradingAccount=Obchodní účet s ID {0}\n
 guiUtil.accountImport.noImport=Neobchodovali jsme obchodní účet s ID {0}, protože již existuje.\n
 guiUtil.accountExport.exportFailed=Export do CSV selhal kvůli chybě.\nChyba = {0}
 guiUtil.accountExport.selectExportPath=Vyberte složku pro export
-guiUtil.accountImport.imported=Obchodní účet importovaný z:\n{0}\n\nImportované účty:\n{1}
+guiUtil.accountImport.imported=Obchodní účet importovaný z cesty:\n{0}\n\nImportované účty:\n{1}
 guiUtil.accountImport.noAccountsFound=Nebyly nalezeny žádné exportované obchodní účty na: {0}.\nNázev souboru je {1}."
 guiUtil.openWebBrowser.warning=Chystáte se otevřít webovou stránku \
 ve webovém prohlížeči.\n\
@@ -3362,6 +3362,8 @@ validation.invalidInput=Neplatný vstup: {0}
 validation.accountNrFormat=Číslo účtu musí být ve formátu: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Ověření adresy se nezdařilo, protože neodpovídá struktuře adresy {0}.
+validation.crypto.ergo.mainnetP2pk=Použijte standardní adresu peněženky P2PK hlavní sítě Ergo. Skriptové adresy P2S/P2SH ani adresy testovací sítě nejsou podporovány.
+validation.crypto.tooManyDecimals=Zadejte hodnotu s nejvýše 8 desetinnými místy.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=Adresa LTZ musí začínat na "L". Adresy začínající na "z" nejsou podporovány.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_de.properties
+++ b/core/src/main/resources/i18n/displayStrings_de.properties
@@ -2235,6 +2235,8 @@ validation.invalidInput=Ungültige Eingabe: {0}
 validation.accountNrFormat=Die Kontonummer muss folgendes Format haben: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Die Adressvalidierung ist fehlgeschlagen, da diese nicht mit der Struktur einer {0}-Adresse übereinstimmt.
+validation.crypto.ergo.mainnetP2pk=Verwenden Sie eine normale Wallet-Adresse im Ergo-Mainnet (P2PK). P2S/P2SH-Skriptadressen und Testnet-Adressen werden nicht unterstützt.
+validation.crypto.tooManyDecimals=Geben Sie einen Wert mit höchstens 8 Nachkommastellen ein.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=Die LTZ Adresse muss mit L beginnen. Adressen die mit z beginnen werden nicht unterstützt.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_es.properties
+++ b/core/src/main/resources/i18n/displayStrings_es.properties
@@ -2236,6 +2236,8 @@ validation.invalidInput=Entrada inválida: {0}
 validation.accountNrFormat=El número de cuenta debe ser del formato: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=La validación de dirección falló porque no se corresponde con la estructura de una dirección {0}.
+validation.crypto.ergo.mainnetP2pk=Utiliza una dirección estándar de monedero de la red principal de Ergo (P2PK). No se admiten direcciones de script P2S/P2SH ni direcciones de la red de pruebas.
+validation.crypto.tooManyDecimals=Introduce un valor con un máximo de 8 decimales.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=Las drecciones LTZ deben empezar con L. Las direcciones que empiecen por z no están soportadas.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fa.properties
+++ b/core/src/main/resources/i18n/displayStrings_fa.properties
@@ -2208,6 +2208,8 @@ validation.invalidInput=ورودی نامعتبر: {0}
 validation.accountNrFormat=شماره حساب باید از فرمت {0} باشد
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=تأیید آدرس ناموفق بود زیرا آن با ساختار یک آدرس {0} مطابقت ندارد.
+validation.crypto.ergo.mainnetP2pk=از یک آدرس استاندارد کیف پول P2PK در شبکهٔ اصلی Ergo استفاده کنید. آدرس‌های اسکریپت P2S/P2SH و آدرس‌های شبکهٔ آزمایشی پشتیبانی نمی‌شوند.
+validation.crypto.tooManyDecimals=مقداری با حداکثر 8 رقم اعشار وارد کنید.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_fr.properties
+++ b/core/src/main/resources/i18n/displayStrings_fr.properties
@@ -2240,6 +2240,8 @@ validation.invalidInput=La valeur saisie est invalide: {0}
 validation.accountNrFormat=Le numéro du compte doit être au format: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=La validation de l'adresse a échoué car elle ne concorde pas avec la structure d'une adresse {0}.
+validation.crypto.ergo.mainnetP2pk=Utilisez une adresse de portefeuille standard P2PK du réseau principal Ergo. Les adresses de script P2S/P2SH et les adresses du réseau de test ne sont pas prises en charge.
+validation.crypto.tooManyDecimals=Saisissez une valeur comportant au maximum 8 décimales.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=L'adresse LTZ doit commencer par L. Les adresses commençant par z ne sont pas supportées.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_it.properties
+++ b/core/src/main/resources/i18n/displayStrings_it.properties
@@ -2211,6 +2211,8 @@ validation.invalidInput=Input non valido: {0}
 validation.accountNrFormat=Il numero di conto deve essere nel formato: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Convalida dell'indirizzo non riuscita perché non corrisponde alla struttura di un indirizzo {0}.
+validation.crypto.ergo.mainnetP2pk=Usa un indirizzo standard di portafoglio della rete principale di Ergo (P2PK). Gli indirizzi script P2S/P2SH e gli indirizzi della rete di test non sono supportati.
+validation.crypto.tooManyDecimals=Inserisci un valore con al massimo 8 cifre decimali.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_ja.properties
+++ b/core/src/main/resources/i18n/displayStrings_ja.properties
@@ -2235,6 +2235,8 @@ validation.invalidInput=不正な入力: {0}
 validation.accountNrFormat=アカウント番号は次の形式である必要があります: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure={0}アドレスの構造と一致しないためアドレス検証に失敗しました。
+validation.crypto.ergo.mainnetP2pk=Ergoメインネットの標準的なウォレットアドレス（P2PK）を使用してください。P2S/P2SHスクリプトアドレスとテストネットのアドレスはサポートされていません。
+validation.crypto.tooManyDecimals=小数点以下8桁以内の値を入力してください。
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZアドレスは必ずLで始まる必要があります。zで始まるアドレスはサポートされていません。
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt-br.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt-br.properties
@@ -2218,6 +2218,8 @@ validation.invalidInput=Entrada inválida: {0}
 validation.accountNrFormat=O número da conta deve estar no formato: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Validação do endereço falhou pois este não é compatível com a estrutura de um endereço {0}.
+validation.crypto.ergo.mainnetP2pk=Use um endereço padrão de carteira da rede principal da Ergo (P2PK). Endereços de script P2S/P2SH e endereços da rede de testes não são suportados.
+validation.crypto.tooManyDecimals=Insira um valor com no máximo 8 casas decimais.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_pt.properties
+++ b/core/src/main/resources/i18n/displayStrings_pt.properties
@@ -2208,6 +2208,8 @@ validation.invalidInput=Input inválido: {0}
 validation.accountNrFormat=O número da conta deve estar no formato: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Validação do endereço falhou pois este não é compatível com a estrutura de um endereço {0}.
+validation.crypto.ergo.mainnetP2pk=Utilize um endereço padrão de carteira da rede principal da Ergo (P2PK). Os endereços de script P2S/P2SH e os endereços da rede de testes não são suportados.
+validation.crypto.tooManyDecimals=Introduza um valor com no máximo 8 casas decimais.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_ru.properties
+++ b/core/src/main/resources/i18n/displayStrings_ru.properties
@@ -2210,6 +2210,8 @@ validation.invalidInput=Недействительное значение: {0}
 validation.accountNrFormat=Допустимый формат номера счёта: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Сбой проверки адреса. Адрес не соответствует структуре адреса {0}.
+validation.crypto.ergo.mainnetP2pk=Используйте стандартный адрес кошелька основной сети Ergo (P2PK). Скриптовые адреса P2S/P2SH и адреса тестовой сети не поддерживаются.
+validation.crypto.tooManyDecimals=Введите значение не более чем с 8 знаками после запятой.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_th.properties
+++ b/core/src/main/resources/i18n/displayStrings_th.properties
@@ -2209,6 +2209,8 @@ validation.invalidInput=ใส่ข้อมูลไม่ถูกต้อ�
 validation.accountNrFormat=หมายเลขบัญชีต้องเป็นรูปแบบ: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=การตรวจสอบความถูกต้องของที่อยู่ล้มเหลวเนื่องจากไม่ตรงกับโครงสร้างของที่อยู่ {0}
+validation.crypto.ergo.mainnetP2pk=ใช้ที่อยู่กระเป๋าเงินมาตรฐานบนเครือข่ายหลักของ Ergo (P2PK) ไม่รองรับที่อยู่สคริปต์ P2S/P2SH และที่อยู่บนเครือข่ายทดสอบ
+validation.crypto.tooManyDecimals=ป้อนค่าที่มีทศนิยมไม่เกิน 8 ตำแหน่ง
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_tr.properties
+++ b/core/src/main/resources/i18n/displayStrings_tr.properties
@@ -3300,6 +3300,8 @@ validation.invalidInput=Geçersiz giriş: {0}
 validation.accountNrFormat=Hesap numarası şu formatta olmalıdır: {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Adres doğrulaması, {0} adres yapısına uymadığı için başarısız oldu.
+validation.crypto.ergo.mainnetP2pk=Ergo ana ağına ait standart bir cüzdan adresi (P2PK) kullanın. P2S/P2SH betik adresleri ve test ağı adresleri desteklenmez.
+validation.crypto.tooManyDecimals=En fazla 8 ondalık basamak içeren bir değer girin.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ adresi L ile başlamalıdır. z ile başlayan adresler desteklenmez.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_vi.properties
+++ b/core/src/main/resources/i18n/displayStrings_vi.properties
@@ -2210,6 +2210,8 @@ validation.invalidInput=Giá trị nhập không hợp lệ: {0}
 validation.accountNrFormat=Số tài khoản phải có định dạng : {0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=Xác nhận địa chỉ không thành công vì không khớp với cấu trúc của {0} địa chỉ.
+validation.crypto.ergo.mainnetP2pk=Hãy sử dụng địa chỉ ví tiêu chuẩn trên mạng chính Ergo (P2PK). Địa chỉ script P2S/P2SH và địa chỉ mạng thử nghiệm không được hỗ trợ.
+validation.crypto.tooManyDecimals=Nhập một giá trị có tối đa 8 chữ số thập phân.
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ address must start with L. Addresses starting with z are not supported.
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hans.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hans.properties
@@ -2221,6 +2221,8 @@ validation.invalidInput=输入无效：{0}
 validation.accountNrFormat=帐号必须是格式：{0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=地址验证失败，因为它与 {0} 地址的结构不匹配。
+validation.crypto.ergo.mainnetP2pk=请使用 Ergo 主网标准钱包地址（P2PK）。不支持 P2S/P2SH 脚本地址和测试网地址。
+validation.crypto.tooManyDecimals=请输入最多包含 8 位小数的数值。
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ 地址需要以 L 开头。 不支持以 Z 开头的地址。
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings_zh-hant.properties
+++ b/core/src/main/resources/i18n/displayStrings_zh-hant.properties
@@ -2215,6 +2215,8 @@ validation.invalidInput=輸入無效：{0}
 validation.accountNrFormat=帳號必須是格式：{0}
 # suppress inspection "UnusedProperty"
 validation.crypto.wrongStructure=地址驗證失敗，因為它與 {0} 地址的結構不匹配。
+validation.crypto.ergo.mainnetP2pk=請使用 Ergo 主網標準錢包位址（P2PK）。不支援 P2S/P2SH 腳本位址和測試網位址。
+validation.crypto.tooManyDecimals=請輸入最多包含 8 位小數的數值。
 # suppress inspection "UnusedProperty"
 validation.crypto.ltz.zAddressesNotSupported=LTZ 地址需要以 L 開頭。 不支持以 Z 開頭的地址。
 # suppress inspection "UnusedProperty"

--- a/core/src/test/java/haveno/core/locale/CurrencyUtilTest.java
+++ b/core/src/test/java/haveno/core/locale/CurrencyUtilTest.java
@@ -59,6 +59,17 @@ public class CurrencyUtilTest {
     }
 
     @Test
+    public void testErgoIsDiscoveredThroughAssetRegistry() {
+        AssetRegistry registry = new AssetRegistry();
+        assertEquals(1, registry.stream().filter(asset -> asset.getTickerSymbol().equals("ERG")).count());
+        Asset ergo = CurrencyUtil.findAsset(registry, "ERG", BaseCurrencyNetwork.XMR_MAINNET).orElseThrow();
+        assertEquals("Ergo", ergo.getName());
+        assertEquals("ERG", ergo.getTickerSymbol());
+        assertEquals("Ergo", CurrencyUtil.getTradeCurrency("ERG").orElseThrow().getName());
+        assertTrue(CurrencyUtil.getAllSortedCryptoCurrencies().stream().anyMatch(currency -> currency.getCode().equals("ERG")));
+    }
+
+    @Test
     public void testFindAsset() {
         MockAssetRegistry assetRegistry = new MockAssetRegistry();
 

--- a/core/src/test/java/haveno/core/monetary/PriceTest.java
+++ b/core/src/test/java/haveno/core/monetary/PriceTest.java
@@ -17,14 +17,219 @@
 
 package haveno.core.monetary;
 
+import haveno.common.handlers.ErrorMessageHandler;
+import haveno.core.api.CoreOffersService;
+import haveno.core.locale.Res;
+import haveno.core.offer.CreateOfferService;
+import haveno.core.offer.Offer;
+import haveno.core.offer.OpenOffer;
+import haveno.core.offer.OpenOfferManager;
+import haveno.core.payment.PaymentAccount;
+import haveno.core.user.User;
+import haveno.core.util.PriceUtil;
+import haveno.core.util.VolumeUtil;
+import haveno.core.util.validation.AmountValidator8Decimals;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static haveno.core.monetary.Price.parse;
 import static haveno.core.monetary.Price.valueOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PriceTest {
+
+    @Test
+    public void testTraditionalTriggerAndAlertPricesKeepRounding() {
+        Res.setup();
+        for (String input : new String[]{"1.123456789", "1,123456789", "1123456789e-9"}) {
+            assertTrue(PriceUtil.getPriceValidator("USD").validate(input).isValid, input);
+            assertTrue(PriceUtil.isTriggerPriceValid(input, null, false, "USD").isValid, input);
+            assertEquals(112345679L, PriceUtil.getMarketPriceAsLong(input, "USD"), input);
+        }
+        assertFalse(PriceUtil.getPriceValidator("USD").validate("0").isValid);
+        assertFalse(PriceUtil.getPriceValidator("USD").validate("100000001").isValid);
+        assertFalse(new AmountValidator8Decimals().validate("1.123456789").isValid);
+    }
+
+    @Test
+    public void testApiCloneCryptoPricePreservesExactValuesAndNormalizedSyntax() throws Throwable {
+        assertEquals(112345678L, apiClonePriceValue(" 1,123456780 ", "ERG"));
+        assertEquals(9007199254740993L, apiClonePriceValue("90071992.54740993", "ERG"));
+        assertEquals(Long.MAX_VALUE, apiClonePriceValue("92233720368.54775807", "ERG"));
+    }
+
+    @Test
+    public void testApiCloneCryptoPriceRejectsUnrepresentableOverrides() {
+        for (String input : new String[]{"1.123456789", "92233720368.54775808", "-92233720368.54775809", "1e20"}) {
+            assertThrows(IllegalArgumentException.class, () -> apiClonePriceValue(input, "ERG"), input);
+        }
+    }
+
+    @Test
+    public void testApiCloneTraditionalPriceKeepsExistingParser() throws Throwable {
+        assertEquals(112345678L, apiClonePriceValue(" 1,123456780 ", "USD"));
+        assertThrows(IllegalArgumentException.class, () -> apiClonePriceValue("1.123456789", "USD"));
+    }
+
+    private long apiClonePriceValue(String input, String currencyCode) throws Throwable {
+        CreateOfferService createOfferService = mock(CreateOfferService.class);
+        OpenOfferManager manager = mock(OpenOfferManager.class);
+        OpenOffer sourceOpenOffer = mock(OpenOffer.class);
+        Offer sourceOffer = mock(Offer.class);
+        User user = mock(User.class);
+        PaymentAccount account = mock(PaymentAccount.class);
+        when(manager.getOpenOffer("source")).thenReturn(Optional.of(sourceOpenOffer));
+        when(sourceOpenOffer.getOffer()).thenReturn(sourceOffer);
+        when(sourceOffer.isMyOffer(null)).thenReturn(true);
+        when(user.getPaymentAccount("payment")).thenReturn(account);
+
+        // capture the price at the real clone producer and stop before offer placement
+        AtomicReference<Price> constructedPrice = new AtomicReference<>();
+        RuntimeException stopBeforePlacement = new RuntimeException("price captured");
+        when(createOfferService.createClonedOffer(eq(sourceOffer), eq(currencyCode), any(Price.class),
+                eq(false), eq(0d), eq(account), eq("info"))).thenAnswer(invocation -> {
+                    constructedPrice.set(invocation.getArgument(2));
+                    throw stopBeforePlacement;
+                });
+
+        CoreOffersService service = new CoreOffersService(null, null, null, createOfferService, null, null,
+                manager, null, user, null, null);
+        Method clone = CoreOffersService.class.getDeclaredMethod("cloneOffer", String.class, String.class,
+                String.class, boolean.class, double.class, String.class, String.class, String.class,
+                Consumer.class, ErrorMessageHandler.class);
+        clone.setAccessible(true);
+        try {
+            clone.invoke(service, "source", currencyCode, input, false, 0d, "", "payment", "info", null, null);
+            throw new AssertionError("Clone did not construct an offer price");
+        } catch (InvocationTargetException exception) {
+            if (exception.getCause() == stopBeforePlacement)
+                return constructedPrice.get().getValue();
+            throw exception.getCause();
+        }
+    }
+
+    @Test
+    public void testApiCryptoPricePreservesEightDecimalsAndTrailingZeros() throws Throwable {
+        assertEquals(112345678L, apiPriceValue("1.12345678", "ERG"));
+        assertEquals(112345678L, apiPriceValue("1.123456780", "ERG"));
+        assertEquals(1L, apiPriceValue("1e-8", "ERG"));
+    }
+
+    @Test
+    public void testApiCryptoPriceRejectsNonzeroNinthDecimal() {
+        for (String input : new String[]{"1.123456789", "0.000000001", "123456789e-9"}) {
+            assertThrows(IllegalArgumentException.class, () -> apiPriceValue(input, "ERG"), input);
+        }
+    }
+
+    @Test
+    public void testApiCryptoPricePreservesLargeExactValues() throws Throwable {
+        assertEquals(9007199254740993L, apiPriceValue("90071992.54740993", "ERG"));
+        assertEquals(Long.MAX_VALUE, apiPriceValue("92233720368.54775807", "ERG"));
+        assertEquals(Long.MIN_VALUE, apiPriceValue("-92233720368.54775808", "ERG"));
+    }
+
+    @Test
+    public void testApiCryptoPriceRejectsOverflow() {
+        for (String input : new String[]{"92233720368.54775808", "-92233720368.54775809", "1e20"}) {
+            assertThrows(IllegalArgumentException.class, () -> apiPriceValue(input, "ERG"), input);
+        }
+    }
+
+    @Test
+    public void testApiTraditionalPriceKeepsRounding() throws Throwable {
+        assertEquals(112345679L, apiPriceValue("1.123456789", "USD"));
+        assertEquals(-112345679L, apiPriceValue("-1.123456789", "USD"));
+    }
+
+    @Test
+    public void testApiPriceKeepsBigDecimalInputSyntax() {
+        for (String currencyCode : new String[]{"ERG", "USD"}) {
+            assertThrows(IllegalArgumentException.class, () -> apiPriceValue("1,23", currencyCode));
+            assertThrows(IllegalArgumentException.class, () -> apiPriceValue(" 1.23", currencyCode));
+        }
+    }
+
+    private long apiPriceValue(String input, String currencyCode) throws Throwable {
+        // exercise the converter shared by API offer creation and editing
+        CoreOffersService service = new CoreOffersService(null, null, null, null, null, null,
+                null, null, null, null, null);
+        Method converter = CoreOffersService.class.getDeclaredMethod("priceStringToLong", String.class, String.class);
+        converter.setAccessible(true);
+        try {
+            return (long) converter.invoke(service, input, currencyCode);
+        } catch (InvocationTargetException exception) {
+            throw exception.getCause();
+        }
+    }
+
+    @Test
+    public void testCryptoEntryValidationRejectsExcessTradingPrecision() {
+        Res.setup();
+        AmountValidator8Decimals validator = new AmountValidator8Decimals();
+        for (String input : new String[]{"1.123456789", "1,123456789", "123456789e-9"}) {
+            assertFalse(validator.validate(input).isValid, input);
+            assertEquals(Res.get("validation.crypto.tooManyDecimals"), validator.validate(input).errorMessage);
+            assertThrows(IllegalArgumentException.class, () -> parse("ERG", input));
+        }
+    }
+
+    @Test
+    public void testCryptoEntryValidationMatchesExactNumericBoundsAndFormats() {
+        Res.setup();
+        AmountValidator8Decimals validator = new AmountValidator8Decimals();
+        for (String input : new String[]{"1.12345678", "1,12345678", "1.123456780", "1e-8", "100000000"}) {
+            assertTrue(validator.validate(input).isValid, input);
+            assertTrue(parse("ERG", input).isPositive(), input);
+        }
+        for (String input : new String[]{"0", "-1", "0.000000001", "100000001", "100000000.00000001", "NaN", "Infinity"}) {
+            assertFalse(validator.validate(input).isValid, input);
+        }
+    }
+
+    @Test
+    public void testErgoPaymentAmountPreservesTradingPrecision() {
+        Price price = parse("ERG", "123.12345678");
+        BigInteger oneXmr = new BigInteger("1000000000000");
+        Volume volume = price.getVolumeByAmount(oneXmr);
+
+        assertEquals(12312345678L, price.getValue());
+        assertEquals("123.12345678", price.toPlainString());
+        assertEquals("ERG", volume.getCurrencyCode());
+        assertEquals(12312345678L, volume.getValue());
+        assertEquals("123.12345678", VolumeUtil.formatVolume(volume));
+        assertEquals("123.12345678 ERG", VolumeUtil.formatVolumeWithCode(volume));
+        assertEquals(volume.getValue(), Volume.parse(VolumeUtil.formatVolume(volume), "ERG").getValue());
+        assertEquals(oneXmr, price.getAmountByVolume(volume));
+
+        Volume halfVolume = price.getVolumeByAmount(oneXmr.divide(BigInteger.TWO));
+        assertEquals("61.56172839", halfVolume.toPlainString());
+        assertEquals(oneXmr.divide(BigInteger.TWO), price.getAmountByVolume(halfVolume));
+    }
+
+    @Test
+    public void testErgoTradingQuantumRejectsUnrepresentableNanoErg() {
+        assertEquals(1L, parse("ERG", "0.00000001").getValue());
+        assertEquals(1L, Volume.parse("0.00000001", "ERG").getValue());
+        assertEquals("0.00000001 ERG", VolumeUtil.formatVolumeWithCode(Volume.parse("0.00000001", "ERG")));
+        assertThrows(IllegalArgumentException.class, () -> parse("ERG", "0.000000001"));
+        assertThrows(IllegalArgumentException.class, () -> Volume.parse("0.000000001", "ERG"));
+        assertThrows(IllegalArgumentException.class, () -> Volume.parse("1.123456789", "ERG"));
+    }
 
     @Test
     public void testParse() {

--- a/core/src/test/java/haveno/core/offer/OfferTest.java
+++ b/core/src/test/java/haveno/core/offer/OfferTest.java
@@ -17,14 +17,114 @@
 
 package haveno.core.offer;
 
+import haveno.common.crypto.Encryption;
+import haveno.common.crypto.PubKeyRing;
+import haveno.common.crypto.Sig;
+import haveno.core.payment.payload.PaymentMethod;
+import haveno.core.provider.price.MarketPrice;
+import haveno.core.provider.price.PriceFeedService;
+import haveno.core.util.VolumeUtil;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class OfferTest {
+
+    @Test
+    public void testErgoFixedPriceWorksWithoutMarketFeed() throws Exception {
+        OfferPayload payload = ergoPayload(false);
+        when(payload.getPrice()).thenReturn(12312345678L);
+        Offer offer = new Offer(payload);
+
+        assertEquals("XMR", offer.getBaseCurrencyCode());
+        assertEquals("ERG", offer.getCounterCurrencyCode());
+        assertEquals(12312345678L, offer.getPrice().getValue());
+        offer.verifyTradePrice(12312345678L);
+        assertThrows(IllegalArgumentException.class, () -> offer.verifyTradePrice(12312345677L));
+    }
+
+    @Test
+    public void testErgoIndexedPriceRequiresRecentExternalQuote() {
+        Offer offer = new Offer(ergoPayload(true));
+        PriceFeedService feed = mock(PriceFeedService.class);
+        offer.setPriceFeedService(feed);
+
+        assertNull(offer.getPrice());
+        assertThrows(MarketPriceNotAvailableException.class, () -> offer.verifyTradePrice(100000000L));
+
+        long now = Instant.now().toEpochMilli();
+        when(feed.getMarketPrice("ERG")).thenReturn(new MarketPrice("ERG", 123.12345678,
+                now - MarketPrice.MARKET_PRICE_MAX_AGE_MS - 1000, true));
+        assertNull(offer.getPrice());
+        assertThrows(MarketPriceNotAvailableException.class, () -> offer.verifyTradePrice(12312345678L));
+
+        when(feed.getMarketPrice("ERG")).thenReturn(new MarketPrice("ERG", 123.12345678, now, false));
+        assertNull(offer.getPrice());
+        assertThrows(MarketPriceNotAvailableException.class, () -> offer.verifyTradePrice(12312345678L));
+
+        when(feed.getMarketPrice("ERG")).thenReturn(new MarketPrice("ERG", 0, now, true));
+        assertNull(offer.getPrice());
+    }
+
+    @Test
+    public void testErgoIndexedPriceAppliesDirectionAndMargin() throws Exception {
+        OfferPayload payload = ergoPayload(true);
+        when(payload.getMarketPriceMarginPct()).thenReturn(0.05);
+        Offer offer = new Offer(payload);
+        PriceFeedService feed = mock(PriceFeedService.class);
+        when(feed.getMarketPrice("ERG")).thenReturn(new MarketPrice("ERG", 200, Instant.now().toEpochMilli(), true));
+        offer.setPriceFeedService(feed);
+
+        assertEquals(19000000000L, offer.getPrice().getValue());
+        offer.verifyTradePrice(19000000000L);
+        when(payload.getDirection()).thenReturn(OfferDirection.SELL);
+        assertEquals(21000000000L, offer.getPrice().getValue());
+        offer.verifyTradePrice(21000000000L);
+    }
+
+    @Test
+    public void testErgoOfferSerializationPreservesPaymentAmount() throws Exception {
+        PubKeyRing pubKeyRing = new PubKeyRing(Sig.generateKeyPair().getPublic(), Encryption.generateKeyPair().getPublic());
+        protobuf.OfferPayload payload = protobuf.OfferPayload.newBuilder()
+                .setId("erg-fixed-offer")
+                .setPubKeyRing(pubKeyRing.toProtoMessage())
+                .setBaseCurrencyCode("XMR")
+                .setCounterCurrencyCode("ERG")
+                .setDirection(protobuf.OfferDirection.BUY)
+                .setPaymentMethodId(PaymentMethod.BLOCK_CHAINS_ID)
+                .setPrice(12312345678L)
+                .setAmount(1000000000000L)
+                .setMinAmount(1000000000000L)
+                .build();
+        Offer original = new Offer(OfferPayload.fromProto(payload));
+        Offer restored = Offer.fromProto(protobuf.Offer.parseFrom(original.toProtoMessage().toByteArray()));
+
+        assertEquals(original.toProtoMessage(), restored.toProtoMessage());
+        assertEquals("XMR", restored.getBaseCurrencyCode());
+        assertEquals("ERG", restored.getCounterCurrencyCode());
+        assertEquals(PaymentMethod.BLOCK_CHAINS_ID, restored.getPaymentMethodId());
+        assertEquals(12312345678L, restored.getPrice().getValue());
+        assertEquals("123.12345678 ERG", VolumeUtil.formatVolumeWithCode(restored.getVolume()));
+        assertEquals(original.getAmount(), restored.getAmount());
+    }
+
+    private OfferPayload ergoPayload(boolean marketBased) {
+        OfferPayload payload = mock(OfferPayload.class);
+        when(payload.getId()).thenReturn("erg-price-test");
+        when(payload.getBaseCurrencyCode()).thenReturn("XMR");
+        when(payload.getCounterCurrencyCode()).thenReturn("ERG");
+        when(payload.isUseMarketBasedPrice()).thenReturn(marketBased);
+        when(payload.getDirection()).thenReturn(OfferDirection.BUY);
+        return payload;
+    }
 
     @Test
     public void testHasNoRange() {

--- a/core/src/test/java/haveno/core/payment/PaymentAccountsTest.java
+++ b/core/src/test/java/haveno/core/payment/PaymentAccountsTest.java
@@ -19,19 +19,74 @@ package haveno.core.payment;
 
 import haveno.core.account.witness.AccountAgeWitness;
 import haveno.core.account.witness.AccountAgeWitnessService;
+import haveno.core.locale.CurrencyUtil;
+import haveno.core.locale.Res;
+import haveno.core.locale.TradeCurrency;
 import haveno.core.offer.Offer;
 import haveno.core.payment.payload.PaymentAccountPayload;
+import haveno.core.payment.payload.PaymentMethod;
+import haveno.core.proto.CoreProtoResolver;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PaymentAccountsTest {
+    @BeforeEach
+    public void setUp() {
+        Res.setup();
+    }
+
+    @Test
+    public void testErgoAccountRequiresMatchingOfferCurrencyAndMethod() {
+        CryptoCurrencyAccount account = new CryptoCurrencyAccount();
+        account.init();
+        account.setSingleTradeCurrency(CurrencyUtil.getTradeCurrency("ERG").orElseThrow());
+        Offer offer = mock(Offer.class);
+        when(offer.getCounterCurrencyCode()).thenReturn("ERG");
+        when(offer.getPaymentMethod()).thenReturn(PaymentMethod.BLOCK_CHAINS);
+
+        assertTrue(PaymentAccountUtil.isPaymentAccountValidForOffer(offer, account));
+        when(offer.getCounterCurrencyCode()).thenReturn("BTC");
+        assertFalse(PaymentAccountUtil.isPaymentAccountValidForOffer(offer, account));
+        when(offer.getCounterCurrencyCode()).thenReturn("ERG");
+        when(offer.getPaymentMethod()).thenReturn(PaymentMethod.BLOCK_CHAINS_INSTANT);
+        assertFalse(PaymentAccountUtil.isPaymentAccountValidForOffer(offer, account));
+    }
+
+    @Test
+    public void testErgoAccountRoundTripUsesRegisteredCurrency() throws Exception {
+        TradeCurrency ergo = CurrencyUtil.getTradeCurrency("ERG").orElseThrow();
+        CryptoCurrencyAccount account = new CryptoCurrencyAccount();
+        assertTrue(account.getSupportedCurrencies().contains(ergo));
+        account.init();
+        account.setAccountName("Ergo wallet");
+        account.setSingleTradeCurrency(ergo);
+        account.setAddress("9iJd9drp1KR3R7HLi7YmQbB5sJ5HFKZoPb5MxGepamggJs5vDHm");
+
+        protobuf.PaymentAccount encoded = protobuf.PaymentAccount.parseFrom(account.toProtoMessage().toByteArray());
+        CryptoCurrencyAccount restored = assertInstanceOf(CryptoCurrencyAccount.class,
+                PaymentAccount.fromProto(encoded, new CoreProtoResolver()));
+
+        assertEquals(account.toProtoMessage(), restored.toProtoMessage());
+        assertEquals(account.getId(), restored.getId());
+        assertEquals(account.getAddress(), restored.getAddress());
+        assertEquals(PaymentMethod.BLOCK_CHAINS_ID, restored.getPaymentMethod().getId());
+        assertEquals("ERG", restored.getSingleTradeCurrency().getCode());
+        assertEquals("Ergo", restored.getSingleTradeCurrency().getName());
+        assertTrue(restored.isCryptoCurrency());
+    }
+
     @Test
     public void testGetOldestPaymentAccountForOfferWhenNoValidAccounts() {
         PaymentAccounts accounts = new PaymentAccounts(Collections.emptySet(), mock(AccountAgeWitnessService.class));

--- a/core/src/test/java/haveno/core/payment/validation/CryptoAddressValidatorTest.java
+++ b/core/src/test/java/haveno/core/payment/validation/CryptoAddressValidatorTest.java
@@ -17,17 +17,98 @@
 
 package haveno.core.payment.validation;
 
+import haveno.asset.AddressValidationResult;
+import haveno.asset.Asset;
 import haveno.asset.AssetRegistry;
 import haveno.common.config.BaseCurrencyNetwork;
 import haveno.common.config.Config;
 import haveno.core.locale.CurrencyUtil;
 import haveno.core.locale.Res;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CryptoAddressValidatorTest {
+
+    @Test
+    public void acceptsErgoMainnetP2pkThroughAssetRegistry() {
+        CryptoAddressValidator validator = new CryptoAddressValidator(new AssetRegistry());
+        validator.setCurrencyCode("ERG");
+
+        // sigmastate ErgoAddressSpecification public P2PK vector
+        assertTrue(validator.validate("9iJd9drp1KR3R7HLi7YmQbB5sJ5HFKZoPb5MxGepamggJs5vDHm").isValid);
+        assertTrue(validator.validate("9fRAWhdxEsTcdb8PhGNrZfwqa65zfkuYHAMmkQLcic1gdLSV5vA").isValid);
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> rejectsMalformedErgoAddresses() {
+        // point, network, type and payload-length fixtures have independently recomputed checksums
+        return Stream.of(
+            "checksum, 9iJd9drp1KR3R7HLi7YmQbB5sJ5HFKZoPb5MxGepamggJs5vDHn",
+            "invalid alphabet, 0iJd9drp1KR3R7HLi7YmQbB5sJ5HFKZoPb5MxGepamggJs5vDHm",
+            "unknown network, 5tGUvKAeQvdpDyXs38k8Eycm3miwzdzq1XXFGVMgXttTguHv8Y49",
+            "unknown type, bTCLdiZLU4pxy9azwJE9vsdqAu2nW8kHiTU3KJwJ22pXJU9mkFS",
+            "short payload, 2yV1VEniv65YMsMvQMy8o8HnWX9g2S3uCTkakLQXGMYeWmuhYo",
+            "long payload, fTJnZ7grUQH7fQj7zTuD17qWUzMtiCwmkhQFUx5w24E8VefRQtUj",
+            "noncanonical zero-prefixed point, 9adaAMuB9v8yX1mZ5PtoB6VFSCeqRGjASd8ZTM6VUkiHLQNBguB",
+            "invalid point tag, 9kFNKsJqrk6GYvs3chAmMumrnQgzu2QgBE9UCRLiaRh4oSgXpD8",
+            "x outside field, 9gToh4FGiCAevUWfo8ko34HaBYVzNPFnoYLtBoAAiuDDMC3Aduv",
+            "point outside curve, 9eX4WpoErmVRnevxtZ8o5jgoGRtGigQv1uGmweUHU4j4KYh8tBA",
+            "leading zero byte, 19iJd9drp1KR3R7HLi7YmQbB5sJ5HFKZoPb5MxGepamggJs5vDHm",
+            "trailing byte, fTJnZ7grUQH7fQj7zTuD17qWUzMtiCwmkhQFUx5w24E8Vr4hsEyE"
+        ).map(fixture -> {
+            String[] fields = fixture.split(", ", 2);
+            return DynamicTest.dynamicTest(fields[0], () -> {
+                AddressValidationResult result = ergoAsset().validateAddress(fields[1]);
+                assertFalse(result.isValid());
+                assertEquals("validation.crypto.wrongStructure", result.getI18nKey());
+                CryptoAddressValidator validator = new CryptoAddressValidator(new AssetRegistry());
+                validator.setCurrencyCode("ERG");
+                assertFalse(validator.validate(fields[1]).isValid);
+            });
+        });
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> reportsUnsupportedErgoAddressPolicy() {
+        return Stream.of(
+            "canonical identity, 9adaAMuB9v8yX1mZ5PtoB6VFSCeqRGjASd8ZTM6VUkiHLDgh2Rp",
+            "mainnet P2SH, 8UApt8czfFVuTgQmMwtsRBZ4nfWquNiSwCWUjMg",
+            "mainnet P2S, 4MQyML64GnzMxZgm",
+            "testnet P2PK, 3WvsT2Gm4EpsM9Pg18PdY6XyhNNMqXDsvJTbbf6ihLvAmSb7u5RN"
+        ).map(fixture -> {
+            String[] fields = fixture.split(", ", 2);
+            return DynamicTest.dynamicTest(fields[0], () -> {
+                AddressValidationResult result = ergoAsset().validateAddress(fields[1]);
+                assertFalse(result.isValid());
+                assertEquals("validation.crypto.ergo.mainnetP2pk", result.getI18nKey());
+            });
+        });
+    }
+
+    @Test
+    public void rejectsEmptyWhitespaceAndOversizedErgoInput() {
+        Asset asset = ergoAsset();
+        String address = "9iJd9drp1KR3R7HLi7YmQbB5sJ5HFKZoPb5MxGepamggJs5vDHm";
+        for (String input : new String[]{null, "", " ", " " + address, address + " ", address + "\n", "9".repeat(10000)}) {
+            assertFalse(asset.validateAddress(input).isValid());
+        }
+    }
+
+    private Asset ergoAsset() {
+        Asset asset = new AssetRegistry().stream()
+                .filter(candidate -> candidate.getTickerSymbol().equals("ERG"))
+                .findFirst().orElse(null);
+        assertNotNull(asset, "ERG must be available through the payment asset registry");
+        return asset;
+    }
 
     @Test
     public void test() {

--- a/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferDataModelTest.java
+++ b/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferDataModelTest.java
@@ -1,6 +1,7 @@
 package haveno.desktop.main.offer.createoffer;
 
 import haveno.core.locale.CryptoCurrency;
+import haveno.core.locale.CurrencyUtil;
 import haveno.core.locale.TraditionalCurrency;
 import haveno.core.locale.GlobalSettings;
 import haveno.core.locale.Res;
@@ -9,6 +10,7 @@ import haveno.core.offer.OfferDirection;
 import haveno.core.offer.OfferUtil;
 import haveno.core.offer.OpenOfferManager;
 import haveno.core.payment.ZelleAccount;
+import haveno.core.payment.CryptoCurrencyAccount;
 import haveno.core.payment.PaymentAccount;
 import haveno.core.payment.RevolutAccount;
 import haveno.core.provider.price.PriceFeedService;
@@ -17,14 +19,19 @@ import haveno.core.user.Preferences;
 import haveno.core.user.User;
 import haveno.core.xmr.model.XmrAddressEntry;
 import haveno.core.xmr.wallet.XmrWalletService;
+import haveno.desktop.main.offer.MutableOfferDataModel;
 import javafx.collections.FXCollections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
+import java.lang.reflect.Method;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -92,6 +99,27 @@ public class CreateOfferDataModelTest {
 
         model.initWithData(OfferDirection.BUY, new TraditionalCurrency("USD"), true);
         assertEquals("USD", model.getTradeCurrencyCode().get());
+    }
+
+    @Test
+    public void testErgoAccountSelectedOverPreferredBitcoinAccount() throws Exception {
+        CryptoCurrencyAccount ergo = new CryptoCurrencyAccount();
+        ergo.init();
+        ergo.setAccountName("Ergo wallet");
+        ergo.setSingleTradeCurrency(CurrencyUtil.getTradeCurrency("ERG").orElseThrow());
+        CryptoCurrencyAccount bitcoin = new CryptoCurrencyAccount();
+        bitcoin.init();
+        bitcoin.setAccountName("Bitcoin wallet");
+        bitcoin.setSingleTradeCurrency(CurrencyUtil.getTradeCurrency("BTC").orElseThrow());
+        when(user.getPaymentAccounts()).thenReturn(new HashSet<>(Set.of(bitcoin, ergo)));
+        when(preferences.getSelectedPaymentAccountForCreateOffer()).thenReturn(bitcoin);
+        when(user.findFirstPaymentAccountWithCurrency(ergo.getSingleTradeCurrency())).thenReturn(ergo);
+
+        assertTrue(model.initWithData(OfferDirection.BUY, ergo.getSingleTradeCurrency(), true));
+        assertEquals("ERG", model.getTradeCurrencyCode().get());
+        Method getAccount = MutableOfferDataModel.class.getDeclaredMethod("getPaymentAccount");
+        getAccount.setAccessible(true);
+        assertSame(ergo, getAccount.invoke(model));
     }
 
     @Test

--- a/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
+++ b/desktop/src/test/java/haveno/desktop/main/offer/createoffer/CreateOfferViewModelTest.java
@@ -21,8 +21,10 @@ import haveno.common.config.Config;
 import haveno.core.account.witness.AccountAgeWitnessService;
 import haveno.core.locale.Country;
 import haveno.core.locale.CryptoCurrency;
+import haveno.core.locale.CurrencyUtil;
 import haveno.core.locale.GlobalSettings;
 import haveno.core.locale.Res;
+import haveno.core.monetary.Volume;
 import haveno.core.offer.CreateOfferService;
 import haveno.core.offer.OfferDirection;
 import haveno.core.offer.OfferUtil;
@@ -45,12 +47,17 @@ import haveno.core.util.validation.InputValidator;
 import haveno.core.xmr.model.XmrAddressEntry;
 import haveno.core.xmr.wallet.Restrictions;
 import haveno.core.xmr.wallet.XmrWalletService;
+import haveno.desktop.main.offer.MutableOfferViewModel;
+import haveno.desktop.main.offer.MutableOfferDataModel;
+import javafx.beans.value.ObservableValue;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.collections.FXCollections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -69,6 +76,7 @@ import static org.mockito.Mockito.when;
 public class CreateOfferViewModelTest {
 
     private CreateOfferViewModel model;
+    private CreateOfferDataModel dataModel;
     private final CoinFormatter coinFormatter = new ImmutableCoinFormatter(
             Config.baseCurrencyNetworkParameters().getMonetaryFormat());
 
@@ -114,7 +122,7 @@ public class CreateOfferViewModelTest {
         when(createOfferService.getRandomOfferId()).thenReturn(UUID.randomUUID().toString());
         when(tradeStats.getObservableTradeStatisticsList()).thenReturn(FXCollections.observableArrayList());
 
-        CreateOfferDataModel dataModel = new CreateOfferDataModel(createOfferService,
+        dataModel = new CreateOfferDataModel(createOfferService,
             openOfferManager,
             offerUtil,
             xmrWalletService,
@@ -142,6 +150,71 @@ public class CreateOfferViewModelTest {
                 coinFormatter,
                 offerUtil);
         model.activate();
+    }
+
+    @Test
+    public void testErgoPricePrecisionErrorDoesNotRestoreAnOldPrice() throws Exception {
+        assertTrue(dataModel.initWithData(OfferDirection.BUY, CurrencyUtil.getTradeCurrency("ERG").orElseThrow(), false));
+        assertEquals("ERG", model.getTradeCurrency().getCode());
+        model.amount.set("0.1");
+        model.price.set("123.12345678");
+        long previousPrice = dataModel.getPrice().get().getValue();
+        assertFalse(model.isNextButtonDisabled.get());
+
+        model.price.set("123.123456789");
+        focusOut("Price");
+
+        assertEquals("123.123456789", model.price.get());
+        assertEquals(previousPrice, dataModel.getPrice().get().getValue());
+        assertFalse(validationResult("priceValidationResult").isValid);
+        assertEquals(Res.get("validation.crypto.tooManyDecimals"), validationResult("priceValidationResult").errorMessage);
+        assertTrue(model.isNextButtonDisabled.get());
+
+        model.price.set("124.12345678");
+        focusOut("Price");
+
+        assertEquals("124.12345678", model.price.get());
+        assertEquals(12412345678L, dataModel.getPrice().get().getValue());
+        assertTrue(validationResult("priceValidationResult").isValid);
+        assertFalse(model.isNextButtonDisabled.get());
+    }
+
+    @Test
+    public void testErgoVolumePrecisionErrorDoesNotRestoreAnOldAmount() throws Exception {
+        assertTrue(dataModel.initWithData(OfferDirection.BUY, CurrencyUtil.getTradeCurrency("ERG").orElseThrow(), false));
+        model.amount.set("0.1");
+        model.price.set("123.12345678");
+        assertFalse(model.isNextButtonDisabled.get());
+
+        model.volume.set("12.312345679");
+        focusOut("Volume");
+
+        assertEquals("12.312345679", model.volume.get());
+        assertFalse(validationResult("volumeValidationResult").isValid);
+        assertEquals(Res.get("validation.crypto.tooManyDecimals"), validationResult("volumeValidationResult").errorMessage);
+        assertTrue(model.isNextButtonDisabled.get());
+
+        model.volume.set("24.62469135");
+        focusOut("Volume");
+
+        assertEquals("24.62469135", model.volume.get());
+        Method getVolume = MutableOfferDataModel.class.getDeclaredMethod("getVolume");
+        getVolume.setAccessible(true);
+        assertEquals(2462469135L, ((Volume) ((ObservableValue<?>) getVolume.invoke(dataModel)).getValue()).getValue());
+        assertTrue(validationResult("volumeValidationResult").isValid);
+        assertFalse(model.isNextButtonDisabled.get());
+    }
+
+    private void focusOut(String fieldName) throws Exception {
+        Method method = MutableOfferViewModel.class.getDeclaredMethod("onFocusOut" + fieldName + "TextField", boolean.class, boolean.class);
+        method.setAccessible(true);
+        method.invoke(model, true, false);
+    }
+
+    private InputValidator.ValidationResult validationResult(String fieldName) throws Exception {
+        Field field = MutableOfferViewModel.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (InputValidator.ValidationResult) ((ObservableValue<?>) field.get(model)).getValue();
     }
 
     @Test

--- a/docs/ergo.md
+++ b/docs/ergo.md
@@ -1,0 +1,57 @@
+# Ergo (ERG) payments
+
+ERG is a payment currency for exchanging Ergo against XMR. ERG is sent from an
+external Ergo wallet. Haveno continues to use its existing Monero escrow and
+arbitration protocol.
+
+## Payment accounts
+
+Create a cryptocurrency payment account, select **Ergo (ERG)**, and enter the
+receiving address from your Ergo wallet. Saving the account also adds ERG to
+the preferred currencies used by the offer book.
+
+This integration supports ordinary mainnet **P2PK** wallet addresses. It does
+not accept testnet addresses or P2S/P2SH script addresses. Those are other Ergo
+address formats; the restriction is a payment-account policy. The form explains
+the supported format when an unsupported address is entered.
+
+## Prices and payment amounts
+
+Haveno represents cryptocurrency prices and volumes with eight decimal places.
+For ERG, its smallest trading increment is **0.00000001 ERG**, equivalent to
+**10 nanoERG**. Ergo itself has nine decimal places. An entered price or volume
+with a nonzero ninth decimal is rejected rather than silently rounded.
+
+Calculated volumes follow Haveno's existing integer conversion to the trading
+increment. Send the exact ERG amount displayed in the trade's payment details;
+the amount displayed and copied uses all eight trading decimal places. Wallet
+transaction fees are separate from the amount sent to the other trader.
+
+Fixed-price offers work without an external ERG market quote. Market-based
+offers require a recent external ERG quote from the configured Haveno price
+provider. Missing or stale quotes do not produce a usable market-based price.
+Adding the asset does not add an ERG quote to a network's price providers.
+
+To sell ERG, use an offer to buy XMR with ERG. Follow Haveno's payment steps,
+send ERG from your external wallet, and use the existing payment confirmation
+and dispute process. There is no embedded Ergo wallet or ERG payment QR code.
+
+Availability to traders depends on a Haveno network distributing the integration
+and enabling the asset. It also requires counterparties offering XMR for ERG.
+
+## Validation
+
+The address validator checks raw Base58 encoding, the network/type prefix, the
+four-byte Blake2b-256 checksum, the exact P2PK envelope length, and the compressed
+secp256k1 public key. It rejects malformed input before a payment account can be
+accepted.
+
+Relevant existing test classes cover the asset registry and address validation,
+account and offer serialization, payment-account matching, exact payment
+formatting, and fixed or market-based prices:
+
+```sh
+./gradlew :core:test --tests haveno.core.payment.validation.CryptoAddressValidatorTest --tests haveno.core.locale.CurrencyUtilTest --tests haveno.core.payment.PaymentAccountsTest --tests haveno.core.monetary.PriceTest --tests haveno.core.offer.OfferTest :assets:test :assets:checkstyleMain :core:checkstyleTest
+```
+
+On Windows, use `gradlew.bat` with the same arguments.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ haveno-desktop = "1.8.0-SNAPSHOT"
 
 [libraries]
 bcpg-jdk18on = { module = "org.bouncycastle:bcpg-jdk18on", version.ref = "bc" }
+bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bc" }
 bitcoinj = { module = "com.github.bisq-network:bitcoinj", version.ref = "bitcoinj" }
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "codec" }
 commons-csv = { module = "org.apache.commons:commons-csv", version.ref = "commons-csv" }


### PR DESCRIPTION
This contribution adds ERG payment accounts and ERG/XMR offers using an external Ergo wallet and Haveno's existing Monero escrow protocol. It supports ordinary mainnet P2PK wallet addresses, validates their encoding, checksum, network and key, and explains unsupported address formats.

Trading precision remains eight decimal places, or ten nanoERG. Exact offer inputs reject nonzero precision beyond eight decimal places. Crypto API creation, editing and clone overrides preserve exact prices and reject out-of-range values before scaling. Existing fiat trigger/alert rounding and fiat API behavior remain intact. User messages cover all sixteen maintained locales.

Validation: 414 tests passed, 10 existing tests disabled, zero failures; applicable style checks and independent source reviews passed. UI regressions verify valid input enables continuation, invalid precision disables it, and corrected input restores the stored amount and continuation.

Two earlier local Haveno/Monero scenarios exercised both maker directions through deposits, payment details, confirmations, payout, closure and restart persistence. External ERG transfers were simulated. Those scenarios have not been rerun against the final candidate, which includes subsequent validation-order and fiat-alert corrections covered by current unit tests, style checks and source review. Public CI results are tracked in this PR's checks.

Fixed-price trading was exercised with an empty local quote provider. Indexed prices still require a recent external ERG quote; this contribution does not add a provider, liquidity or network distribution.

The shared-file changes in #690, #1059, #2127, #2573, #2576 and #2577 address separate behavior; this contribution does not depend on those PRs.

Base: `522a895332dbe3ac32e937e040538b5458948e9e`. Proposed initial scope: native ERG against XMR, ordinary mainnet P2PK payment accounts and external-wallet payment.
