### PR TITLE
p2p: cool down repeatedly failing discovery peers

### DIFF
--- a/p2p/src/main/java/haveno/network/p2p/peers/PeerManager.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/PeerManager.java
@@ -19,6 +19,8 @@ package haveno.network.p2p.peers;
 
 import com.google.common.annotations.VisibleForTesting;
 import static com.google.common.base.Preconditions.checkArgument;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import haveno.common.ClockWatcher;
@@ -126,6 +128,11 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
     // Peers detected on a different P2P network; never dialed or re-added, bounded with eldest-first eviction
     private static final int MAX_WRONG_NETWORK_PEERS = 2000;
     private final Set<NodeAddress> wrongNetworkPeers = Collections.synchronizedSet(new LinkedHashSet<>());
+    // Peers evicted after repeated silent failures may be retried after the cooldown
+    private final Cache<NodeAddress, Boolean> failedPeers = CacheBuilder.newBuilder()
+            .maximumSize(2000)
+            .expireAfterWrite(1, TimeUnit.HOURS)
+            .build();
 
     private Timer checkMaxConnectionsTimer;
     private Timer recoveryGraceTimer;
@@ -259,15 +266,25 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
                 connection.getPeersNodeAddressOptional(), closeConnectionReason);
         handleConnectionFault(connection);
 
-        // score the persisted peer once per outbound dial: received bytes prove it usable, an unintended
-        // zero-byte close accrues a failure so unusable peers purge; inbound addresses are unverified
+        // score each outbound connection once; only a silent unintended close accrues a failure
+        // partial responses are not silent, and inbound addresses are unverified
         if (connection instanceof OutboundConnection && connection.tryAccountPeerFault()) {
+            boolean receivedData = connection.getStatistic().getReceivedBytes() > 0;
+            if (receivedData && connection.getRuleViolation() == null) {
+                connection.getPeersNodeAddressOptional().ifPresent(failedPeers::invalidate);
+            }
             connection.getPeersNodeAddressOptional().flatMap(this::findPersistedPeer).ifPresent(peer -> {
-                if (connection.getStatistic().getReceivedBytes() > 0) {
+                if (receivedData) {
                     peer.onConnection();
-                } else if (!closeConnectionReason.isIntended) {
+                } else if (!closeConnectionReason.isIntended && connection.getLastReadTimestamp() == 0) {
                     peer.onDisconnect();
-                    if (peer.tooManyFailedConnectionAttempts()) removePersistedPeer(peer.getNodeAddress());
+                    if (peer.tooManyFailedConnectionAttempts()) {
+                        if (!isSeedNode(peer.getNodeAddress())) {
+                            failedPeers.put(peer.getNodeAddress(), true);
+                            log.info("Pausing peer discovery to {} for one hour after repeated silent connection failures", peer.getNodeAddress());
+                        }
+                        removePersistedPeer(peer.getNodeAddress());
+                    }
                 }
             });
         }
@@ -358,6 +375,10 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
 
     public boolean isWrongNetworkPeer(NodeAddress nodeAddress) {
         return wrongNetworkPeers.contains(nodeAddress);
+    }
+
+    public boolean isPeerUnavailable(NodeAddress nodeAddress) {
+        return isWrongNetworkPeer(nodeAddress) || failedPeers.getIfPresent(nodeAddress) != null;
     }
 
     private void blocklistWrongNetworkPeer(NodeAddress nodeAddress) {
@@ -452,7 +473,7 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
 
         Set<Peer> peers = reportedPeersToAdd.stream()
                 .filter(peer -> !isSelf(peer.getNodeAddress()))
-                .filter(peer -> !wrongNetworkPeers.contains(peer.getNodeAddress()))
+                .filter(peer -> !isPeerUnavailable(peer.getNodeAddress()))
                 .collect(Collectors.toSet());
 
         printNewReportedPeers(peers);
@@ -486,6 +507,7 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
             latestLivePeers.clear();
             Set<Peer> recentPeers = peers.stream()
                     .filter(peer -> peer.getDateAsLong() > maxAge)
+                    .filter(peer -> !isPeerUnavailable(peer.getNodeAddress()))
                     .collect(Collectors.toSet());
             latestLivePeers.addAll(recentPeers);
 
@@ -912,6 +934,8 @@ public final class PeerManager implements ConnectionListener, PersistedDataHost 
         // networkNode.getConfirmedConnections includes:
         // filter(connection -> connection.getPeersNodeAddressOptional().isPresent())
         return networkNode.getConfirmedConnections().stream()
+                // A dial target is not live until it has sent a valid message
+                .filter(connection -> !connection.isStopped() && connection.getStatistic().getLastReceivedMessageTimestamp() > 0)
                 .map((Connection connection) -> {
                     Capabilities supportedCapabilities = new Capabilities(connection.getCapabilities());
                     // If we have a new connection the supportedCapabilities is empty.

--- a/p2p/src/main/java/haveno/network/p2p/peers/getdata/RequestDataHandler.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/getdata/RequestDataHandler.java
@@ -122,6 +122,12 @@ class RequestDataHandler implements MessageListener {
     void requestData(NodeAddress nodeAddress, boolean isPreliminaryDataRequest) {
         peersNodeAddress = nodeAddress;
         if (!stopped) {
+            // Recheck candidates retained from an earlier request.
+            if (peerManager.isPeerUnavailable(nodeAddress)) {
+                cleanup();
+                listener.onFault("Peer is unavailable for data requests: " + nodeAddress, null);
+                return;
+            }
             GetDataRequest getDataRequest;
 
             if (isPreliminaryDataRequest)

--- a/p2p/src/main/java/haveno/network/p2p/peers/getdata/RequestDataManager.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/getdata/RequestDataManager.java
@@ -417,6 +417,7 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
                                 peerManager.handleConnectionFault(nodeAddress);
                                 handlerMap.remove(nodeAddress);
 
+                                remainingNodeAddresses.removeIf(peerManager::isPeerUnavailable);
                                 if (!remainingNodeAddresses.isEmpty()) {
                                     log.debug("There are remaining nodes available for requesting data. " +
                                             "We will try requestDataFromPeers again.");
@@ -569,7 +570,7 @@ public class RequestDataManager implements MessageListener, ConnectionListener, 
         return collection.stream()
                 .filter(e -> !list.contains(e) &&
                         !peerManager.isSelf(e) &&
-                        !peerManager.isWrongNetworkPeer(e))
+                        !peerManager.isPeerUnavailable(e))
                 .collect(Collectors.toList());
     }
 

--- a/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/PeerExchangeHandler.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/PeerExchangeHandler.java
@@ -117,6 +117,16 @@ class PeerExchangeHandler implements MessageListener {
     private void sendGetPeersRequest(NodeAddress nodeAddress) {
         log.debug("sendGetPeersRequest to nodeAddress={}", nodeAddress);
         if (!stopped) {
+            // recheck after the delay, as another connection may have rejected this peer
+            if (peerManager.isPeerUnavailable(nodeAddress)) {
+                UserThread.execute(() -> {
+                    if (!stopped) {
+                        cleanup();
+                        listener.onFault("Peer is unavailable for peer exchange: " + nodeAddress, null);
+                    }
+                });
+                return;
+            }
             if (networkNode.getNodeAddress() != null) {
                 GetPeersRequest getPeersRequest = new GetPeersRequest(networkNode.getNodeAddress(),
                         nonce,

--- a/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/PeerExchangeManager.java
+++ b/p2p/src/main/java/haveno/network/p2p/peers/peerexchange/PeerExchangeManager.java
@@ -232,6 +232,7 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
 
                                 peerManager.handleConnectionFault(nodeAddress);
                                 handlerMap.remove(nodeAddress);
+                                remainingNodeAddresses.removeIf(peerManager::isPeerUnavailable);
                                 if (!remainingNodeAddresses.isEmpty()) {
                                     if (!peerManager.hasSufficientConnections()) {
                                         log.debug("There are remaining nodes available for requesting peers. " +
@@ -357,7 +358,7 @@ public class PeerExchangeManager implements MessageListener, ConnectionListener,
                 .filter(e -> !list.contains(e) &&
                         !peerManager.isSelf(e) &&
                         !peerManager.isConfirmed(e) &&
-                        !peerManager.isWrongNetworkPeer(e))
+                        !peerManager.isPeerUnavailable(e))
                 .collect(Collectors.toList());
     }
 

--- a/p2p/src/test/java/haveno/network/p2p/peers/PeerManagerTest.java
+++ b/p2p/src/test/java/haveno/network/p2p/peers/PeerManagerTest.java
@@ -17,11 +17,14 @@
 
 package haveno.network.p2p.peers;
 
+import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.SettableFuture;
 import haveno.common.ThreadUtils;
 import haveno.common.Timer;
 import haveno.common.UserThread;
+import haveno.common.app.Capabilities;
 import haveno.network.p2p.MockNode;
+import haveno.network.p2p.NodeAddress;
 import haveno.network.p2p.network.CloseConnectionReason;
 import haveno.network.p2p.network.Connection;
 import haveno.network.p2p.network.InboundConnection;
@@ -29,17 +32,26 @@ import haveno.network.p2p.network.MessageListener;
 import haveno.network.p2p.network.NetworkNode;
 import haveno.network.p2p.network.OutboundConnection;
 import haveno.network.p2p.network.PeerType;
+import haveno.network.p2p.network.RuleViolation;
 import haveno.network.p2p.network.Statistic;
+import haveno.network.p2p.peers.getdata.RequestDataManager;
 import haveno.network.p2p.peers.keepalive.KeepAliveManager;
 import haveno.network.p2p.peers.keepalive.messages.Ping;
 import haveno.network.p2p.peers.keepalive.messages.Pong;
+import haveno.network.p2p.peers.peerexchange.Peer;
+import haveno.network.p2p.peers.peerexchange.PeerExchangeManager;
+import haveno.network.p2p.seed.SeedNodeRepository;
+import haveno.network.p2p.storage.P2PDataStorage;
 import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
@@ -52,6 +64,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -68,6 +81,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -87,6 +101,220 @@ public class PeerManagerTest {
     @AfterEach
     public void tearDown() {
         node.getPersistenceManager().shutdown();
+    }
+
+    @Test
+    public void testFailedPeerIsNotReintroducedByReports() {
+        NodeAddress address = new NodeAddress("failed.onion:9999");
+        PeerManager manager = node.getPeerManager();
+        for (int i = 0; i < 8; i++) {
+            manager.addToReportedPeers(Set.of(new Peer(address, null)), mock(Connection.class), new Capabilities());
+            assertEquals(i, manager.getPersistedPeers().iterator().next().getFailedConnectionAttempts());
+            OutboundConnection connection = outboundConnection(address, 0);
+            manager.onDisconnect(CloseConnectionReason.NO_PROTO_BUFFER_ENV, connection);
+            manager.onDisconnect(CloseConnectionReason.NO_PROTO_BUFFER_ENV, connection);
+            assertEquals(i == 7, manager.isPeerUnavailable(address));
+        }
+        assertTrue(manager.getPersistedPeers().isEmpty());
+        manager.addToReportedPeers(Set.of(new Peer(address, null)), mock(Connection.class), new Capabilities());
+
+        assertTrue(manager.getPersistedPeers().isEmpty());
+        assertTrue(manager.getReportedPeers().isEmpty());
+        assertFalse(manager.isWrongNetworkPeer(address));
+    }
+
+    @Test
+    public void testFailedPeerCooldownExpires() throws IOException {
+        AtomicLong now = new AtomicLong();
+        Ticker ticker = mock(Ticker.class);
+        when(ticker.read()).thenAnswer(invocation -> now.get());
+        try (MockedStatic<Ticker> tickerClass = mockStatic(Ticker.class)) {
+            tickerClass.when(Ticker::systemTicker).thenReturn(ticker);
+            node.getPeerManager().shutDown();
+            node.getPersistenceManager().shutdown();
+            node = new MockNode(2);
+            PeerManager manager = node.getPeerManager();
+            NodeAddress address = new NodeAddress("failed.onion:9999");
+            reportFailingPeer(manager, address);
+            OutboundConnection connection = outboundConnection(address, 0);
+            manager.onDisconnect(CloseConnectionReason.RESET, connection);
+            now.set(TimeUnit.MINUTES.toNanos(59));
+            manager.onDisconnect(CloseConnectionReason.RESET, connection);
+            assertTrue(manager.isPeerUnavailable(address));
+            now.set(TimeUnit.HOURS.toNanos(1));
+            assertFalse(manager.isPeerUnavailable(address));
+            manager.addToReportedPeers(Set.of(new Peer(address, null)), mock(Connection.class), new Capabilities());
+            assertEquals(1, manager.getPersistedPeers().size());
+        }
+    }
+
+    @Test
+    public void testInboundTrafficCannotClearCooldownButOutboundTrafficCan() {
+        PeerManager manager = node.getPeerManager();
+        NodeAddress address = new NodeAddress("failed.onion:9999");
+        reportFailingPeer(manager, address);
+        manager.onDisconnect(CloseConnectionReason.RESET, outboundConnection(address, 0));
+        InboundConnection inbound = mock(InboundConnection.class);
+        when(inbound.getPeersNodeAddressOptional()).thenReturn(Optional.of(address));
+        manager.onDisconnect(CloseConnectionReason.RESET, inbound);
+        assertTrue(manager.isPeerUnavailable(address));
+
+        manager.onDisconnect(CloseConnectionReason.RESET, outboundConnection(address, 1));
+        assertFalse(manager.isPeerUnavailable(address));
+    }
+
+    @Test
+    public void testIntendedClosesAndInboundFaultsDoNotSuppressPeers() {
+        PeerManager manager = node.getPeerManager();
+        NodeAddress address = new NodeAddress("peer.onion:9999");
+        reportFailingPeer(manager, address);
+        manager.onDisconnect(CloseConnectionReason.APP_SHUT_DOWN, outboundConnection(address, 0));
+        InboundConnection inbound = mock(InboundConnection.class);
+        when(inbound.getPeersNodeAddressOptional()).thenReturn(Optional.of(address));
+        when(inbound.getRuleViolation()).thenReturn(RuleViolation.WRONG_NETWORK_ID);
+        manager.onDisconnect(CloseConnectionReason.RULE_VIOLATION, inbound);
+
+        assertFalse(manager.isPeerUnavailable(address));
+        assertEquals(7, manager.getPersistedPeers().iterator().next().getFailedConnectionAttempts());
+    }
+
+    @Test
+    public void testSilentFailuresDoNotSuppressSeedNodes() {
+        PeerManager manager = spy(node.getPeerManager());
+        NodeAddress address = new NodeAddress("seed.onion:9999");
+        when(manager.isSeedNode(address)).thenReturn(true);
+        reportFailingPeer(manager, address);
+        manager.onDisconnect(CloseConnectionReason.RESET, outboundConnection(address, 0));
+
+        assertFalse(manager.isPeerUnavailable(address));
+        assertTrue(manager.getPersistedPeers().isEmpty());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = CloseConnectionReason.class, names = {"NO_PROTO_BUFFER_ENV", "SOCKET_TIMEOUT", "RESET"})
+    public void testPartialResponseDoesNotCountAsSilentFailure(CloseConnectionReason reason) {
+        PeerManager manager = node.getPeerManager();
+        NodeAddress address = new NodeAddress("peer.onion:9999");
+        reportFailingPeer(manager, address);
+        OutboundConnection connection = outboundConnection(address, 0);
+        when(connection.getLastReadTimestamp()).thenReturn(1L);
+
+        manager.onDisconnect(reason, connection);
+
+        assertFalse(manager.isPeerUnavailable(address));
+        assertEquals(7, manager.getPersistedPeers().iterator().next().getFailedConnectionAttempts());
+    }
+
+    @Test
+    public void testOfflineDialFailuresPreservePeerCandidates() {
+        PeerManager manager = node.getPeerManager();
+        NodeAddress address = new NodeAddress("peer.onion:9999");
+        reportFailingPeer(manager, address);
+        for (int i = 0; i < 20; i++) manager.handleConnectionFault(address);
+
+        assertFalse(manager.isPeerUnavailable(address));
+        assertEquals(7, manager.getPersistedPeers().iterator().next().getFailedConnectionAttempts());
+        assertEquals(1, manager.getReportedPeers().size());
+    }
+
+    @Test
+    public void testWrongNetworkPeerStaysBlockedAfterOutboundTraffic() {
+        PeerManager manager = node.getPeerManager();
+        NodeAddress address = new NodeAddress("wrong.onion:9999");
+        OutboundConnection connection = outboundConnection(address, 1);
+        when(connection.getRuleViolation()).thenReturn(RuleViolation.WRONG_NETWORK_ID);
+        manager.onDisconnect(CloseConnectionReason.RULE_VIOLATION, connection);
+        manager.onDisconnect(CloseConnectionReason.RESET, outboundConnection(address, 1));
+
+        assertTrue(manager.isPeerUnavailable(address));
+        assertTrue(manager.isWrongNetworkPeer(address));
+    }
+
+    @Test
+    public void testLivePeersRequireValidatedMessagesAndExcludeSuppressedPeers() {
+        PeerManager manager = node.getPeerManager();
+        NodeAddress address = new NodeAddress("peer.onion:9999");
+        OutboundConnection connection = outboundConnection(address, 0);
+        when(connection.getCapabilities()).thenReturn(new Capabilities());
+        when(node.getNetworkNode().getConfirmedConnections()).thenReturn(Set.of(connection));
+        assertTrue(manager.getLivePeers(null).isEmpty());
+
+        when(connection.getStatistic().getReceivedBytes()).thenReturn(1L);
+        assertTrue(manager.getLivePeers(null).isEmpty());
+        when(connection.getStatistic().getLastReceivedMessageTimestamp()).thenReturn(1L);
+        assertEquals(1, manager.getLivePeers(null).size());
+        reportFailingPeer(manager, address);
+        manager.onDisconnect(CloseConnectionReason.RESET, outboundConnection(address, 0));
+        assertTrue(manager.getLivePeers(null).isEmpty());
+    }
+
+    @Test
+    public void testDelayedPeerExchangeRechecksPeerEligibility() {
+        try (MockedStatic<ThreadUtils> threadUtils = mockStatic(ThreadUtils.class);
+             MockedStatic<UserThread> userThread = mockStatic(UserThread.class)) {
+            userThread.when(() -> UserThread.execute(any(Runnable.class))).thenAnswer(invocation -> {
+                invocation.getArgument(0, Runnable.class).run();
+                return null;
+            });
+            NodeAddress address = new NodeAddress("peer.onion:9999");
+            when(node.getNetworkNode().getNodeAddress()).thenReturn(new NodeAddress("self.onion:9999"));
+            PeerExchangeManager exchange = new PeerExchangeManager(node.getNetworkNode(), mock(SeedNodeRepository.class), node.getPeerManager());
+            try {
+                exchange.requestReportedPeersFromSeedNodes(address);
+                ArgumentCaptor<Runnable> delayedSend = ArgumentCaptor.forClass(Runnable.class);
+                threadUtils.verify(() -> ThreadUtils.runAfterRandomDelay(delayedSend.capture(), anyLong(), anyLong(), any(TimeUnit.class)));
+                reportFailingPeer(node.getPeerManager(), address);
+                node.getPeerManager().onDisconnect(CloseConnectionReason.RESET, outboundConnection(address, 0));
+                delayedSend.getValue().run();
+
+                userThread.verify(() -> UserThread.execute(any(Runnable.class)));
+                verify(node.getNetworkNode(), never()).sendMessage(eq(address), any());
+            } finally {
+                exchange.shutDown();
+            }
+        }
+    }
+
+    @Test
+    public void testDelayedDataRequestRechecksPeerEligibility() {
+        try (MockedStatic<UserThread> userThread = mockStatic(UserThread.class)) {
+            NodeAddress address = new NodeAddress("peer.onion:9999");
+            when(node.getNetworkNode().nodeAddressProperty()).thenReturn(new SimpleObjectProperty<>());
+            SeedNodeRepository seeds = mock(SeedNodeRepository.class);
+            when(seeds.getSeedNodeAddresses()).thenReturn(List.of(address));
+            P2PDataStorage storage = mock(P2PDataStorage.class);
+            RequestDataManager requests = new RequestDataManager(node.getNetworkNode(), seeds, storage, node.getPeerManager());
+            requests.setListener(mock(RequestDataManager.Listener.class));
+            try {
+                requests.requestPreliminaryData();
+                ArgumentCaptor<Runnable> delayedSend = ArgumentCaptor.forClass(Runnable.class);
+                userThread.verify(() -> UserThread.runAfter(delayedSend.capture(), anyLong(), eq(TimeUnit.MILLISECONDS)));
+                reportFailingPeer(node.getPeerManager(), address);
+                node.getPeerManager().onDisconnect(CloseConnectionReason.RESET, outboundConnection(address, 0));
+                delayedSend.getValue().run();
+
+                verify(storage, never()).buildPreliminaryGetDataRequest(anyInt());
+                verify(node.getNetworkNode(), never()).sendMessage(eq(address), any());
+            } finally {
+                requests.shutDown();
+            }
+        }
+    }
+
+    private static void reportFailingPeer(PeerManager manager, NodeAddress address) {
+        Peer peer = new Peer(address, null);
+        peer.setFailedConnectionAttempts(7);
+        manager.addToReportedPeers(Set.of(peer), mock(Connection.class), new Capabilities());
+    }
+
+    private static OutboundConnection outboundConnection(NodeAddress address, long receivedBytes) {
+        OutboundConnection connection = mock(OutboundConnection.class);
+        when(connection.getPeersNodeAddressOptional()).thenReturn(Optional.of(address));
+        Statistic statistic = mock(Statistic.class);
+        when(statistic.getReceivedBytes()).thenReturn(receivedBytes);
+        when(connection.getStatistic()).thenReturn(statistic);
+        when(connection.tryAccountPeerFault()).thenReturn(true, false);
+        return connection;
     }
 
     @Test


### PR DESCRIPTION
Bound silent-failure retries and preserve partially responsive peers. Advertise validated peers and recheck queued discovery requests.